### PR TITLE
FW-4119 Add base model class

### DIFF
--- a/fv_be/app/models.py
+++ b/fv_be/app/models.py
@@ -1,3 +1,0 @@
-# from django.db import models
-
-# Create your models here.

--- a/fv_be/app/models/__init__.py
+++ b/fv_be/app/models/__init__.py
@@ -1,0 +1,1 @@
+from .base import BaseModel  # noqa F401

--- a/fv_be/app/models/base.py
+++ b/fv_be/app/models/base.py
@@ -30,11 +30,11 @@ class BaseModel(RulesModel):
     created_by = models.ForeignKey(
         User, on_delete=models.SET_NULL, null=True, default=None
     )
-    created_by_date = models.DateTimeField(auto_now_add=True)
+    created = models.DateTimeField(auto_now_add=True)
     last_modified_by = models.ForeignKey(
         User, on_delete=models.SET_NULL, null=True, default=None
     )
-    last_modified_date = models.DateTimeField(auto_now=True)
+    last_modified = models.DateTimeField(auto_now=True)
 
     @property
     def created_by(self):

--- a/fv_be/app/models/base.py
+++ b/fv_be/app/models/base.py
@@ -1,0 +1,45 @@
+import uuid
+
+# this will be replaced by our custom User class when we create the site models
+from django.contrib.auth.models import User
+from django.db import models
+from rules.contrib.models import RulesModel
+
+
+class BaseModel(RulesModel):
+    """
+    Base model for all FirstVoices Backend models, with standard fields and support for rules-based permissions.
+
+    Date fields values are generated automatically, but user fields (created_by and last_modified_by) are required when
+    creating new data.
+
+    Access rules can be configured using a declaration in the Meta class, like this example:
+    class Meta:
+        rules_permissions = {
+            "add": rules.is_staff,
+            "view": rules.is_authenticated,
+        }
+    See the django-rules docs [https://github.com/dfunckt/django-rules#permissions-in-models] for more details.
+    """
+
+    class Meta:
+        abstract = True
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    is_trashed = models.BooleanField(default=False)
+    created_by = models.ForeignKey(
+        User, on_delete=models.SET_NULL, null=True, default=None
+    )
+    created_by_date = models.DateTimeField(auto_now_add=True)
+    last_modified_by = models.ForeignKey(
+        User, on_delete=models.SET_NULL, null=True, default=None
+    )
+    last_modified_date = models.DateTimeField(auto_now=True)
+
+    @property
+    def created_by(self):
+        return self.created_by.get_full_name()
+
+    @property
+    def last_modified_by(self):
+        return self.last_modified_by.get_full_name()

--- a/fv_be/app/models/base.py
+++ b/fv_be/app/models/base.py
@@ -1,7 +1,6 @@
 import uuid
 
-# this will be replaced by our custom User class when we create the site models
-from django.contrib.auth.models import User
+from django.conf import settings
 from django.db import models
 from rules.contrib.models import RulesModel
 
@@ -28,18 +27,18 @@ class BaseModel(RulesModel):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     is_trashed = models.BooleanField(default=False)
     created_by = models.ForeignKey(
-        User, on_delete=models.SET_NULL, null=True, default=None
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        default=None,
+        related_name="created_%(app_label)s_%(class)s",
     )
     created = models.DateTimeField(auto_now_add=True)
     last_modified_by = models.ForeignKey(
-        User, on_delete=models.SET_NULL, null=True, default=None
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        default=None,
+        related_name="modified_%(app_label)s_%(class)s",
     )
     last_modified = models.DateTimeField(auto_now=True)
-
-    @property
-    def created_by(self):
-        return self.created_by.get_full_name()
-
-    @property
-    def last_modified_by(self):
-        return self.last_modified_by.get_full_name()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,3 +20,5 @@ django-cors-headers==3.14.0  # https://github.com/adamchainz/django-cors-headers
 # DRF-spectacular for api documentation
 drf-spectacular==0.26.0  # https://github.com/tfranzel/drf-spectacular
 django-webpack-loader==1.8.1  # https://github.com/django-webpack/django-webpack-loader
+# Django-rules
+rules>=3.3 # https://github.com/dfunckt/django-rules


### PR DESCRIPTION
This change adds the base model class which can be inherited by other models. 
The base class contains the following fields:

- id - a UUID
- is_trashed - a field to indicate if the model has been deleted
- created_by - a foreign key to a user
- created - date and time which is automatically updated on creation using the auto_now_add option
- last_modified_by - a foreign key to a user
- last_modified - date and time which is automatically updated when the model is modified using the auto_now option

The date fields are automatically handled and updated but the user fields must be updated when the documents are created or modified.