### PR TITLE
FW-4123 Add character models

### DIFF
--- a/fv_be/app/admin/admin.py
+++ b/fv_be/app/admin/admin.py
@@ -5,6 +5,12 @@ from django.contrib.auth.models import Group
 from django.contrib.sites.models import Site as Sites
 from rest_framework.authtoken.models import TokenProxy
 
+from fv_be.app.models.characters import (
+    AlphabetMapper,
+    Character,
+    CharacterVariant,
+    IgnoredCharacter,
+)
 from fv_be.app.models.sites import Site
 
 from .base_admin import BaseAdmin
@@ -33,3 +39,9 @@ admin.site.unregister(Group)
 admin.site.unregister(SocialAccount)
 admin.site.unregister(SocialApp)
 admin.site.unregister(SocialToken)
+
+# Character Models
+admin.site.register(Character)
+admin.site.register(CharacterVariant)
+admin.site.register(IgnoredCharacter)
+admin.site.register(AlphabetMapper)

--- a/fv_be/app/models/__init__.py
+++ b/fv_be/app/models/__init__.py
@@ -1,2 +1,8 @@
 from .base import BaseModel  # noqa F401
+from .characters import (  # noqa F401
+    AlphabetMapper,
+    Character,
+    CharacterVariant,
+    IgnoredCharacter,
+)
 from .sites import Membership, Site  # noqa F401

--- a/fv_be/app/models/characters.py
+++ b/fv_be/app/models/characters.py
@@ -1,0 +1,90 @@
+from django.db import models
+from django.utils.translation import gettext as _
+
+# FirstVoices
+from .sites import BaseSiteContentModel
+
+
+class Character(BaseSiteContentModel):
+    """
+    Represents a character in a site.
+    """
+
+    # from FVCharacter type
+
+    class Meta:
+        verbose_name = _("character")
+        verbose_name_plural = _("characters")
+
+    # from dc:title
+    title = models.CharField(max_length=15)
+
+    # from fvcharacter:alphabet_order
+    sort_order = models.IntegerField()
+
+    # from fv:custom_order
+    sort_character = models.CharField(max_length=1, blank=True)
+
+    # from fvcharacter:fuzzy_latin_match
+    approximate_form = models.CharField(max_length=15, blank=True)
+
+    # from fv:notes
+    notes = models.TextField(blank=True)
+
+    # from fvcharacter:related_words
+    # TODO: add this as a foreign key to the dictionary entry model once it's created
+    # related_dictionary_entries = models.ForeignKey(DictionaryEntry, on_delete=models.SET_NULL, blank=True, null=True)
+
+    def __str__(self):
+        return self.title
+
+
+class CharacterVariant(BaseSiteContentModel):
+    """
+    Represents a canonical variant of a character in a site.
+    """
+
+    class Meta:
+        verbose_name = _("character variant")
+        verbose_name_plural = _("character variants")
+
+    title = models.CharField(max_length=15)
+
+    base_key = models.ForeignKey(Character, on_delete=models.CASCADE)
+
+    def __str__(self):
+        return self.title
+
+
+class IgnoredCharacter(BaseSiteContentModel):
+    """
+    Represents a character that is ignored during sort in a site.
+    """
+
+    class Meta:
+        verbose_name = _("ignored character")
+        verbose_name_plural = _("ignored characters")
+
+    title = models.CharField(max_length=15)
+
+    def __str__(self):
+        return self.title
+
+
+class AlphabetMapper(BaseSiteContentModel):
+    """
+    Represents a private table holding the g2p mappings and configuration for a site.
+    """
+
+    class Meta:
+        verbose_name = _("alphabet mapper")
+        verbose_name_plural = _("alphabet mappers")
+
+    # TODO: Once file storage is configured, enable these FileFields / change to proper paths
+    # alphabet_mapper is a placeholder for now.
+    # input_to_canonical = models.FileField(upload_to="alphabet_mapper")
+    # canonical_to_base = models.FileField(upload_to="alphabet_mapper")
+    # g2p_config = models.FileField(upload_to="alphabet_mapper")
+
+    def __str__(self):
+        return self.id


### PR DESCRIPTION
Adds the initial models for character management in fv-be. Fields dependant on models yet to be merged and file upload have been commented out and labelled with TODOs. 

Note: running the migration again to set up the admin site added a new file: `0002_character_ignoredcharacter_charactervariant_and_more.py` I'm not sure if the file should be part of this commit, if so I can add it.