### PR TITLE
FW-4192 Add custom model manager for view permissions

### DIFF
--- a/src/firstvoices/backend/models/base.py
+++ b/src/firstvoices/backend/models/base.py
@@ -4,6 +4,8 @@ from django.conf import settings
 from django.db import models
 from rules.contrib.models import RulesModel
 
+from .managers import PermissionsManager
+
 
 class BaseModel(RulesModel):
     """
@@ -23,6 +25,9 @@ class BaseModel(RulesModel):
 
     class Meta:
         abstract = True
+
+    # The permissions manager adds functionality to filter a queryset based on user permissions.
+    objects = PermissionsManager()
 
     # from uid (and seemingly not uid:uid)
     id = models.UUIDField(

--- a/src/firstvoices/backend/models/managers.py
+++ b/src/firstvoices/backend/models/managers.py
@@ -1,0 +1,20 @@
+from django.db import models
+
+
+class PermissionsManager(models.Manager):
+    """
+    This custom manager adds additional functionality to filter models based on user permissions. For example the
+    get_viewable_for_user function allows the filtering of model objects by the view permissions a user has.
+    """
+
+    def get_viewable_for_user(self, user):
+        """This function returns a queryset containing model objects that a user has view permissions on."""
+
+        # Get the list of model UUIDs that the user has view permissions for
+        models_uuid_list = [
+            model.id
+            for model in self.get_queryset()
+            if user.has_perm(f"backend.view_{model.__class__.__name__.lower()}", model)
+        ]
+        # Return a queryset filtered by the UUID list
+        return self.get_queryset().filter(id__in=models_uuid_list)

--- a/src/firstvoices/backend/views/base_views.py
+++ b/src/firstvoices/backend/views/base_views.py
@@ -9,16 +9,9 @@ class FVPermissionViewSetMixin(AutoPermissionViewSetMixin):
     """
 
     def list(self, request, *args, **kwargs):
-        # Get the list of model UUIDs that the user has view permissions for
-        models_uuid_list = [
-            model.id
-            for model in self.get_queryset()
-            if self.request.user.has_perm(
-                f"app.view_{model.__class__.__name__.lower()}", model
-            )
-        ]
-        # Create a queryset filtered by the UUID list
-        queryset = self.queryset.model.objects.filter(id__in=models_uuid_list)
+        # Get the model objects a user has view permissions on.
+        queryset = self.queryset.model.objects.get_viewable_for_user(request.user)
+
         # Serialize and return the data
         serializer = self.serializer_class(queryset, many=True)
         return Response(serializer.data)


### PR DESCRIPTION
This changes adds a custom model manager `PermissionsManager` which is an extension of the built-in model manager. The new custom manager has a function `get_viewable_for_user` which takes in a user and will filter models based on that user's view permissions. Additional functionality can be added to this manager in the future, such as filtering based on other permissions.

Ex: `Site.objects.get_viewable_for_user(request.user)` will return a queryset containing all Site models that the requesting user has permission to view.

The `BaseModel` objects field has been set to use this manager, extending it's built in objects functionality. Any models which inherit from BaseModel can use this functionality.