### PR TITLE
FW-4229 Default categories on new site creation

### DIFF
--- a/src/firstvoices/backend/admin/dictionary_admin.py
+++ b/src/firstvoices/backend/admin/dictionary_admin.py
@@ -54,6 +54,8 @@ class DictionaryEntryInline(BaseDictionaryInlineAdmin):
 class CategoryInline(BaseDictionaryInlineAdmin):
     model = Category
     fields = ("title", "parent") + BaseInlineAdmin.fields
+    readonly_fields = ("parent",) + BaseDictionaryInlineAdmin.readonly_fields
+    ordering = ["title"]
 
 
 class DictionaryEntryHiddenBaseAdmin(HiddenBaseAdmin):

--- a/src/firstvoices/backend/models/base.py
+++ b/src/firstvoices/backend/models/base.py
@@ -7,6 +7,7 @@ from django.dispatch import receiver
 from django.utils import timezone
 from rules.contrib.models import RulesModel
 
+from .constants import Visibility
 from .managers import PermissionsManager
 
 
@@ -63,6 +64,34 @@ class BaseModel(RulesModel):
 
     # from dc:lastContributor
     last_modified = models.DateTimeField(auto_now=True, db_index=True)
+
+
+class BaseSiteContentModel(BaseModel):
+    """
+    Base model for non-access-controlled site content data such as categories, that do not have their own
+    visibility levels. Can also be used as a base for more specific types of site content base models.
+    """
+
+    class Meta:
+        abstract = True
+
+    site = models.ForeignKey(
+        to="backend.Site", on_delete=models.CASCADE, related_name="%(class)s"
+    )
+
+
+class BaseControlledSiteContentModel(BaseSiteContentModel):
+    """
+    Base model for access-controlled site content models such as words, phrases, songs, and stories, that have their own
+    visibility level setting.
+    """
+
+    class Meta:
+        abstract = True
+
+    visibility = models.IntegerField(
+        choices=Visibility.choices, default=Visibility.TEAM
+    )
 
 
 # method to add last_modified and created fields if missing in the data, helpful for fixtures

--- a/src/firstvoices/backend/models/category.py
+++ b/src/firstvoices/backend/models/category.py
@@ -3,7 +3,7 @@ from django.db import models
 from django.utils.translation import gettext as _
 
 # FirstVoices
-from .sites import BaseSiteContentModel
+from .base import BaseSiteContentModel
 
 
 class Category(BaseSiteContentModel):
@@ -11,7 +11,7 @@ class Category(BaseSiteContentModel):
 
     # Fields
     title = models.CharField(max_length=200)
-    description = models.TextField()
+    description = models.TextField(blank=True)
     # i.e. A category may have a parent, but the parent category cannot have a parent itself. (i.e. no grandparents).
     # This is enforced in the clean method.
     parent = models.ForeignKey(

--- a/src/firstvoices/backend/models/characters.py
+++ b/src/firstvoices/backend/models/characters.py
@@ -1,10 +1,9 @@
 from django.db import models
 from django.utils.translation import gettext as _
 
-# FirstVoices
+from .base import BaseSiteContentModel
 from .constants import MAX_CHARACTER_LENGTH
 from .dictionary import DictionaryEntry
-from .sites import BaseSiteContentModel
 
 
 class Character(BaseSiteContentModel):

--- a/src/firstvoices/backend/models/dictionary.py
+++ b/src/firstvoices/backend/models/dictionary.py
@@ -1,10 +1,9 @@
 from django.db import models
 from django.utils.translation import gettext as _
 
-from .base import BaseModel
+from .base import BaseControlledSiteContentModel, BaseModel
 from .category import Category
 from .part_of_speech import PartOfSpeech
-from .sites import BaseControlledSiteContentModel
 
 
 class BaseDictionaryContentModel(BaseModel):

--- a/src/firstvoices/backend/models/utils/__init__.py
+++ b/src/firstvoices/backend/models/utils/__init__.py
@@ -1,0 +1,1 @@
+from .utils import load_data, load_default_categories  # noqa F401

--- a/src/firstvoices/backend/models/utils/default_categories.json
+++ b/src/firstvoices/backend/models/utils/default_categories.json
@@ -1,0 +1,268 @@
+[
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Animals",
+            "parent": ""
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Birds",
+            "parent": "Animals"
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Body",
+            "parent": ""
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Body Parts",
+            "parent": "Body"
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Buildings",
+            "parent": "Human Things / Activities"
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Colours",
+            "parent": ""
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Cultural Objects & Practices",
+            "parent": "Human Things / Activities"
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Essential Phrases",
+            "parent": ""
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Family",
+            "parent": "Human Relations"
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Fish",
+            "parent": "Animals"
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Fishing & Hunting",
+            "parent": "Human Things / Activities"
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Flowers",
+            "parent": "Plants"
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Food",
+            "parent": ""
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Fungi & Lichens",
+            "parent": "Plants"
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Greetings",
+            "parent": "Essential Phrases"
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Health",
+            "parent": "Body"
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Household",
+            "parent": "Human Things / Activities"
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Human Relations",
+            "parent": ""
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Human Things / Activities",
+            "parent": ""
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Insects",
+            "parent": "Animals"
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Language / Communication",
+            "parent": ""
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Mammals",
+            "parent": "Animals"
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Medicine Plants",
+            "parent": "Plants"
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Movement",
+            "parent": ""
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Natural Resources",
+            "parent": "Nature / Environment"
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Nature / Environment",
+            "parent": ""
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Numbers",
+            "parent": ""
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Place Names",
+            "parent": "Nature / Environment"
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Plants",
+            "parent": ""
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Seasons",
+            "parent": "Nature / Environment"
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Senses",
+            "parent": "Body"
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Spiritual Beliefs",
+            "parent": ""
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Sports & Play",
+            "parent": "Human Things / Activities"
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Thinking / Feeling",
+            "parent": ""
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Time",
+            "parent": ""
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Trees",
+            "parent": "Plants"
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Weather",
+            "parent": "Nature / Environment"
+        }
+    },
+    {
+        "model": "backend.category",
+        "fields": {
+            "title": "Work & Trade",
+            "parent": "Human Things / Activities"
+        }
+    }
+]

--- a/src/firstvoices/backend/models/utils/utils.py
+++ b/src/firstvoices/backend/models/utils/utils.py
@@ -1,0 +1,60 @@
+import json
+from os import path
+
+from firstvoices.backend.models.category import Category
+
+
+def load_data(json_file):
+    """Helper function to load data from a json file."""
+
+    with open(path.dirname(__file__) + "/" + json_file, encoding="utf-8") as data_file:
+        json_data = json.loads(data_file.read())
+        return json_data
+
+
+def load_default_categories(site):
+    """
+    Function to load default categories on the creation of a new site. Used in the save function of the site
+    model.
+    """
+
+    # Load the default categories from file.
+    default_categories = load_data("default_categories.json")
+
+    # Get a list of parent categories
+    parent_categories = [
+        category
+        for category in default_categories
+        if category["fields"]["parent"] == ""
+    ]
+
+    # Get a list of child categories
+    child_categories = [
+        category
+        for category in default_categories
+        if category["fields"]["parent"] != ""
+    ]
+
+    # Create the categories for the new model
+    # Adds the parent categories first since the children depend on them
+    for category in parent_categories + child_categories:
+        fields = category["fields"]
+
+        # If the current category getting added has a parent, grab it from the existing categories.
+        if fields["parent"] != "":
+            parent_category = Category.objects.filter(
+                site_id=site.id, title=fields["parent"]
+            )[0]
+        else:
+            parent_category = None
+
+        # Create and save the category
+        c = Category(
+            title=fields["title"],
+            site=site,
+            parent=parent_category,
+            created_by=site.created_by,
+            last_modified_by=site.last_modified_by,
+        )
+        c.is_cleaned = False
+        c.save()


### PR DESCRIPTION
### Description of Changes
These changes add functionality to the site model save function to auto-add a set of default categories to any newly created sites. The category model "description" field is now also optional and the default categories have empty descriptions.

Additionally, these changes needed the use of the "Category" model in the "Site" model. This was causing a circular import issue so I moved the "BaseSiteContentModel" and "BaseControlledSiteContentModel" files to the base.py file and updated the "site" foreign key on "BaseSiteContentModel" to use `to="backend.Site"` instead of importing "Site" and using it directly:  https://github.com/First-Peoples-Cultural-Council/fv-be/blob/fb8d95f3c8e81c4d6c13eb229bc11e40f6359732/src/firstvoices/backend/models/base.py#L78-L80

### Checklist
- [X] README / documentation has been updated if needed
- [X] PR title / commit messages contain Jira ticket number if applicable
- [X] Tests have been updated / created if applicable
- [X] Admin Panel has been updated if models have been added or modified
- [X] Migrations have been updated and committed if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [x] Pull the branch and test locally

### Additional Notes
N/A