### PR TITLE
fw-4363, add related entries to character api

### DIFF
--- a/firstvoices/backend/serializers/character_serializers.py
+++ b/firstvoices/backend/serializers/character_serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from backend.models.characters import Character, CharacterVariant, IgnoredCharacter
+from backend.serializers.dictionary_serializers import DictionaryEntrySummarySerializer
 from backend.serializers.fields import SiteHyperlinkedIdentityField
 
 
@@ -21,6 +22,9 @@ class CharacterVariantSerializer(serializers.ModelSerializer):
 class CharacterDetailSerializer(serializers.ModelSerializer):
     url = SiteHyperlinkedIdentityField(view_name="api:character-detail")
     variants = CharacterVariantSerializer(many=True)
+    related_entries = DictionaryEntrySummarySerializer(
+        source="related_dictionary_entries", many=True
+    )
 
     class Meta:
         model = Character
@@ -32,6 +36,5 @@ class CharacterDetailSerializer(serializers.ModelSerializer):
             "approximate_form",
             "notes",
             "variants",
-            # related dictionary entries will be added in a future PR
-            # "related_dictionary_entries",
+            "related_entries",
         ]

--- a/firstvoices/backend/serializers/dictionary_serializers.py
+++ b/firstvoices/backend/serializers/dictionary_serializers.py
@@ -65,6 +65,9 @@ class DictionaryEntryDetailSerializer(serializers.HyperlinkedModelSerializer):
     )
     categories = CategorySerializer(many=True)
     site = SiteSummarySerializer()
+    related_entries = DictionaryEntrySummarySerializer(
+        source="related_dictionary_entries", many=True
+    )
     split_chars = serializers.SerializerMethodField()
     split_chars_base = serializers.SerializerMethodField()
     split_words = serializers.SerializerMethodField()
@@ -111,10 +114,6 @@ class DictionaryEntryDetailSerializer(serializers.HyperlinkedModelSerializer):
         word_list = base_title.split(" ")
 
         return word_list
-
-    related_entries = DictionaryEntrySummarySerializer(
-        source="related_dictionary_entries", many=True
-    )
 
     class Meta:
         model = dictionary.DictionaryEntry

--- a/firstvoices/backend/tests/test_apis/test_characters_api.py
+++ b/firstvoices/backend/tests/test_apis/test_characters_api.py
@@ -50,58 +50,7 @@ class TestCharactersEndpoints(BaseSiteControlledContentApiTest):
             "approximateForm": "Ch0",
             "notes": self.CHARACTER_NOTE,
             "variants": [],
-        }
-
-    @pytest.mark.django_db
-    def test_list_with_characters_and_variants(self):
-        user = factories.get_non_member_user()
-        self.client.force_authenticate(user=user)
-        site = factories.SiteFactory(visibility=Visibility.PUBLIC)
-
-        character0 = factories.CharacterFactory.create(
-            title="Ch0",
-            site=site,
-            sort_order=1,
-            approximate_form="Ch0",
-            notes=self.CHARACTER_NOTE,
-        )
-        factories.CharacterFactory.create(
-            title="Ch1", site=site, sort_order=2, approximate_form="Ch1", notes=""
-        )
-
-        factories.CharacterVariantFactory.create(
-            title="Ch0v0", base_character=character0
-        )
-        factories.CharacterVariantFactory.create(
-            title="Ch0v1", base_character=character0
-        )
-
-        response = self.client.get(self.get_list_endpoint(site.slug))
-
-        assert response.status_code == 200
-
-        response_data = json.loads(response.content)
-        assert len(response_data["results"]) == 2
-        assert response_data["count"] == 2
-
-        character_json = response_data["results"][0]
-        variant_json0 = character_json["variants"][0]
-        variant_json1 = character_json["variants"][1]
-
-        assert character_json == {
-            "url": f"http://testserver{self.get_detail_endpoint(site_slug=site.slug, key=str(character0.id))}",
-            "id": str(character0.id),
-            "title": "Ch0",
-            "sortOrder": 1,
-            "approximateForm": "Ch0",
-            "notes": self.CHARACTER_NOTE,
-            "variants": [variant_json0, variant_json1],
-        }
-        assert variant_json0 == {
-            "title": "Ch0v0",
-        }
-        assert variant_json1 == {
-            "title": "Ch0v1",
+            "relatedEntries": [],
         }
 
     # Test that users can only access characters if they have the correct role in a site
@@ -165,7 +114,91 @@ class TestCharactersEndpoints(BaseSiteControlledContentApiTest):
             "approximateForm": "Ch0",
             "notes": self.CHARACTER_NOTE,
             "variants": [variant_json],
+            "relatedEntries": [],
         }
+
+    @pytest.mark.django_db
+    def test_detail_variants(self):
+        user = factories.get_non_member_user()
+        self.client.force_authenticate(user=user)
+
+        site = factories.SiteFactory(visibility=Visibility.PUBLIC)
+        character0 = factories.CharacterFactory.create(
+            title="Ch0",
+            site=site,
+            sort_order=1,
+            approximate_form="Ch0",
+            notes=self.CHARACTER_NOTE,
+        )
+
+        character1 = factories.CharacterFactory.create(
+            title="Ch1", site=site, sort_order=2, approximate_form="Ch1", notes=""
+        )
+
+        variant = factories.CharacterVariantFactory.create(
+            title="Ch0v0", base_character=character0
+        )
+        factories.CharacterVariantFactory.create(
+            title="Ch0v1", base_character=character1
+        )
+
+        response = self.client.get(
+            self.get_detail_endpoint(site_slug=site.slug, key=str(character0.id))
+        )
+
+        assert response.status_code == 200
+
+        response_data = json.loads(response.content)
+        assert response_data["id"] == str(character0.id)
+        assert len(response_data["variants"]) == 1
+        assert response_data["variants"] == [
+            {
+                "title": variant.title,
+            }
+        ]
+
+    @pytest.mark.django_db
+    def test_detail_related_entries(self):
+        user = factories.get_non_member_user()
+        self.client.force_authenticate(user=user)
+
+        site = factories.SiteFactory(visibility=Visibility.PUBLIC)
+        character = factories.CharacterFactory.create(
+            title="Ch0",
+            site=site,
+            sort_order=1,
+            approximate_form="Ch0",
+            notes=self.CHARACTER_NOTE,
+        )
+
+        entry1 = factories.DictionaryEntryFactory.create(
+            site=site, visibility=Visibility.PUBLIC
+        )
+        entry2 = factories.DictionaryEntryFactory.create(site=site)
+        factories.DictionaryEntryFactory.create(site=site)
+        factories.DictionaryEntryRelatedCharacterFactory.create(
+            character=character, dictionary_entry=entry1
+        )
+        factories.DictionaryEntryRelatedCharacterFactory.create(
+            character=character, dictionary_entry=entry2
+        )
+
+        response = self.client.get(
+            self.get_detail_endpoint(site_slug=site.slug, key=str(character.id))
+        )
+
+        assert response.status_code == 200
+
+        response_data = json.loads(response.content)
+        assert response_data["id"] == str(character.id)
+        assert len(response_data["relatedEntries"]) == 1
+        assert response_data["relatedEntries"] == [
+            {
+                "id": str(entry1.id),
+                "title": entry1.title,
+                "url": f"http://testserver/api/1.0/sites/{site.slug}/dictionary/{str(entry1.id)}/",
+            }
+        ]
 
     @pytest.mark.django_db
     def test_detail_404_site_not_found(self):

--- a/firstvoices/backend/views/character_views.py
+++ b/firstvoices/backend/views/character_views.py
@@ -1,6 +1,8 @@
+from django.db.models import Prefetch
 from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework.viewsets import ModelViewSet
 
+from backend.models import DictionaryEntry
 from backend.models.characters import Character, IgnoredCharacter
 from backend.serializers.character_serializers import (
     CharacterDetailSerializer,
@@ -44,6 +46,12 @@ class CharactersViewSet(
                 Character.objects.filter(site__slug=site[0].slug)
                 .order_by("sort_order")
                 .prefetch_related("variants")
+                .prefetch_related(
+                    Prefetch(
+                        "related_dictionary_entries",
+                        queryset=DictionaryEntry.objects.visible(self.request.user),
+                    )
+                )
             )
         else:
             return Character.objects.none()


### PR DESCRIPTION
### Description of Changes
- added related dictionary entries to response data for character api
- permissions are applied on the related entries
- also narrowed the test for variant response data, since it broke for this unrelated change

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
