### PR TITLE
FW-4202 Site Data API

### DIFF
--- a/firstvoices/backend/models/characters.py
+++ b/firstvoices/backend/models/characters.py
@@ -353,3 +353,6 @@ class Alphabet(BaseSiteContentModel):
         Converts a string to a string with all variant characters replaced with their base characters.
         """
         return self.presort_transducer(text).output_string
+
+    def get_numerical_sort_form(self, text):
+        return self.sorter.word_as_values(text)

--- a/firstvoices/backend/models/characters.py
+++ b/firstvoices/backend/models/characters.py
@@ -214,7 +214,6 @@ class Alphabet(BaseSiteContentModel):
             "delete": predicates.is_superadmin,
         }
 
-
     logger = logging.getLogger(__name__)
 
     # from all fv-character:confusables for a site
@@ -355,4 +354,4 @@ class Alphabet(BaseSiteContentModel):
         return self.presort_transducer(text).output_string
 
     def get_numerical_sort_form(self, text):
-        return self.sorter.word_as_values(text)
+        return self.sorter.word_as_values(self.get_base_form(text))

--- a/firstvoices/backend/serializers/site_data_serializers.py
+++ b/firstvoices/backend/serializers/site_data_serializers.py
@@ -149,8 +149,7 @@ class DictionaryEntryDataSerializer(serializers.ModelSerializer):
     def get_sorting_form(self, dictionaryentry):
         alphabet_mapper = dictionaryentry.site.alphabet_set.all().first()
         if alphabet_mapper is not None:
-            sort_form = alphabet_mapper.get_base_form(dictionaryentry.title)
-            return alphabet_mapper.get_numerical_sort_form(sort_form)
+            return alphabet_mapper.get_numerical_sort_form(dictionaryentry.title)
         else:
             return dictionaryentry.title
 

--- a/firstvoices/backend/serializers/site_data_serializers.py
+++ b/firstvoices/backend/serializers/site_data_serializers.py
@@ -56,17 +56,8 @@ class SiteDataSerializer(SiteContentLinkedTitleSerializer):
 
 
 class CategoriesDataSerializer(serializers.ModelSerializer):
-    category = serializers.SerializerMethodField()
-    parent_category = serializers.SerializerMethodField()
-
-    def get_category(self, category):
-        return category.title
-
-    def get_parent_category(self, category):
-        if category.parent is not None:
-            return category.parent.title
-        else:
-            return None
+    category = serializers.CharField(source="title")
+    parent_category = serializers.CharField(source="parent")
 
     class Meta:
         model = Category
@@ -78,26 +69,20 @@ class CategoriesDataSerializer(serializers.ModelSerializer):
 
 class DictionaryEntryDataSerializer(serializers.ModelSerializer):
     source = serializers.SerializerMethodField()
-    entryID = serializers.SerializerMethodField()
-    word = serializers.SerializerMethodField()
+    entryID = serializers.UUIDField(source="id")
+    word = serializers.CharField(source="title")
     definition = serializers.SerializerMethodField()
     audio = serializers.SerializerMethodField()
     img = serializers.SerializerMethodField()
     theme = CategoriesDataSerializer(source="categories", many=True)
     secondary_theme = serializers.SerializerMethodField()
     optional = serializers.SerializerMethodField()
-    compare_form = serializers.SerializerMethodField()
+    compare_form = serializers.CharField(source="title")
     sort_form = serializers.SerializerMethodField()
     sorting_form = serializers.SerializerMethodField()
 
     def get_source(self, dictionaryentry):
         return dict_entry_type_mtd_conversion(dictionaryentry.type)
-
-    def get_entryID(self, dictionaryentry):
-        return dictionaryentry.id
-
-    def get_word(self, dictionaryentry):
-        return dictionaryentry.title
 
     def get_definition(self, dictionaryentry):
         if dictionaryentry.translation_set.first() is not None:
@@ -105,6 +90,7 @@ class DictionaryEntryDataSerializer(serializers.ModelSerializer):
         else:
             return None
 
+    # These are placeholder values and need to be updated when the audio models have been implemented.
     def get_audio(self, dictionaryentry):
         return [
             {
@@ -114,6 +100,7 @@ class DictionaryEntryDataSerializer(serializers.ModelSerializer):
             }
         ]
 
+    # These are placeholder values and need to be updated when the image models have been implemented.
     def get_img(self, dictionaryentry):
         return (
             "https://v2.dev.firstvoices.com/nuxeo/nxfile/default/5c9eef16-4665-40b9-89ce-debc0301f93b/file:content"
@@ -151,9 +138,6 @@ class DictionaryEntryDataSerializer(serializers.ModelSerializer):
                 ),
             },
         )
-
-    def get_compare_form(self, dictionaryentry):
-        return dictionaryentry.title
 
     def get_sort_form(self, dictionaryentry):
         alphabet_mapper = dictionaryentry.site.alphabet_set.all().first()

--- a/firstvoices/backend/serializers/site_data_serializers.py
+++ b/firstvoices/backend/serializers/site_data_serializers.py
@@ -1,0 +1,222 @@
+from collections import OrderedDict
+from datetime import datetime
+
+from rest_framework import pagination, serializers
+
+from backend.models import Category, Site
+from backend.models.dictionary import DictionaryEntry
+from backend.predicates import utils
+from backend.serializers.base_serializers import SiteContentLinkedTitleSerializer
+
+
+def dict_entry_type_mtd_conversion(type):
+    match type:
+        case DictionaryEntry.TypeOfDictionaryEntry.WORD:
+            return "words"
+        case DictionaryEntry.TypeOfDictionaryEntry.PHRASE:
+            return "phrases"
+        case _:
+            return None
+
+
+class SiteDataSerializer(SiteContentLinkedTitleSerializer):
+    site_data_export = serializers.SerializerMethodField()
+
+    def get_site_data_export(self, site):
+        request = self.context.get("request")
+        characters_list = [
+            character
+            for character in utils.filter_by_viewable(
+                request.user, site.character_set.all()
+            ).order_by("sort_order")
+        ]
+        config = {
+            "L1": {
+                "name": None if site is None else site.title,
+                "lettersInLanguage": [character.title for character in characters_list],
+                "transducers": {},
+            },
+            "L2": {"name": "English"},
+            "build": datetime.now().strftime("%Y%m%d%H%M"),
+        }
+
+        queryset = site.dictionaryentry_set
+        request = self.context.get("request")
+        serializer = DictionaryEntryDataSerializer(
+            queryset, many=True, context={"request": request}
+        )
+
+        paginator = DictionaryEntryPaginator()
+        paginated_data = paginator.paginate_queryset(
+            queryset=serializer.data, request=request
+        )
+        dictionary_entries = paginator.get_paginated_response(paginated_data)
+
+        return {"config": config, "paginatedDictionaryData": dictionary_entries}
+
+    class Meta:
+        model = Site
+        fields = ("site_data_export",)
+
+
+class CategoriesDataSerializer(serializers.ModelSerializer):
+    category = serializers.SerializerMethodField()
+    parent_category = serializers.SerializerMethodField()
+
+    def get_category(self, category):
+        return category.title
+
+    def get_parent_category(self, category):
+        if category.parent is not None:
+            return category.parent.title
+        else:
+            return None
+
+    class Meta:
+        model = Category
+        fields = (
+            "category",
+            "parent_category",
+        )
+
+
+class DictionaryEntryDataSerializer(serializers.ModelSerializer):
+    source = serializers.SerializerMethodField()
+    entryID = serializers.SerializerMethodField()
+    word = serializers.SerializerMethodField()
+    definition = serializers.SerializerMethodField()
+    audio = serializers.SerializerMethodField()
+    img = serializers.SerializerMethodField()
+    theme = CategoriesDataSerializer(source="categories", many=True)
+    secondary_theme = serializers.SerializerMethodField()
+    optional = serializers.SerializerMethodField()
+    compare_form = serializers.SerializerMethodField()
+    sort_form = serializers.SerializerMethodField()
+    sorting_form = serializers.SerializerMethodField()
+
+    def get_source(self, dictionaryentry):
+        return dict_entry_type_mtd_conversion(dictionaryentry.type)
+
+    def get_entryID(self, dictionaryentry):
+        return dictionaryentry.id
+
+    def get_word(self, dictionaryentry):
+        return dictionaryentry.title
+
+    def get_definition(self, dictionaryentry):
+        if dictionaryentry.translation_set.first() is not None:
+            return dictionaryentry.translation_set.first().text
+        else:
+            return None
+
+    def get_audio(self, dictionaryentry):
+        return [
+            {
+                "speaker": None,
+                "filename": "https://v2.dev.firstvoices.com/nuxeo/nxfile/default/136e1a0a-a707-41a9-9ec8-1a4f05b55454"
+                "/file:content/TestMP3.mp3",
+            }
+        ]
+
+    def get_img(self, dictionaryentry):
+        return (
+            "https://v2.dev.firstvoices.com/nuxeo/nxfile/default/5c9eef16-4665-40b9-89ce-debc0301f93b/file:content"
+            "/pexels-stijn-dijkstra-2583852.jpg"
+        )
+
+    def get_secondary_theme(self, dictionaryentry):
+        return None
+
+    def get_optional(self, dictionaryentry):
+        return (
+            {
+                **(
+                    {
+                        "Reference": dictionaryentry.acknowledgement_set.first().text,
+                    }
+                    if dictionaryentry.acknowledgement_set.first() is not None
+                    else {}
+                ),
+                **(
+                    {
+                        "Part of Speech": dictionaryentry.translation_set.first().part_of_speech.title,
+                    }
+                    if dictionaryentry.translation_set.first() is not None
+                    and dictionaryentry.translation_set.first().part_of_speech
+                    is not None
+                    else {}
+                ),
+                **(
+                    {
+                        "Note": dictionaryentry.note_set.first().text,
+                    }
+                    if dictionaryentry.note_set.first() is not None
+                    else {}
+                ),
+            },
+        )
+
+    def get_compare_form(self, dictionaryentry):
+        return dictionaryentry.title
+
+    def get_sort_form(self, dictionaryentry):
+        request = self.context.get("request")
+        alphabet_mapper = utils.filter_by_viewable(
+            request.user, dictionaryentry.site.alphabet_set.all()
+        ).first()
+        if alphabet_mapper is not None:
+            return alphabet_mapper.get_sort_form(dictionaryentry.title)
+        else:
+            return dictionaryentry.title
+
+    def get_sorting_form(self, dictionaryentry):
+        request = self.context.get("request")
+        alphabet_mapper = utils.filter_by_viewable(
+            request.user, dictionaryentry.site.alphabet_set.all()
+        ).first()
+        if alphabet_mapper is not None:
+            sort_form = alphabet_mapper.get_sort_form(dictionaryentry.title)
+            return alphabet_mapper.get_numerical_sort_form(sort_form)
+        else:
+            return dictionaryentry.title
+
+    class Meta:
+        model = DictionaryEntry
+        fields = (
+            "source",
+            "entryID",
+            "word",
+            "definition",
+            "audio",
+            "img",
+            "theme",
+            "secondary_theme",
+            "optional",
+            "compare_form",
+            "sort_form",
+            "sorting_form",
+        )
+
+
+class DictionaryEntryPaginator(pagination.PageNumberPagination):
+    def get_paginated_response(self, data):
+        return OrderedDict(
+            [
+                ("count", self.page.paginator.count),
+                ("pages", self.page.paginator.num_pages),
+                ("pageSize", self.get_page_size(self.request)),
+                (
+                    "next",
+                    self.page.next_page_number() if self.page.has_next() else None,
+                ),
+                ("next_url", self.get_next_link()),
+                (
+                    "previous",
+                    self.page.previous_page_number()
+                    if self.page.has_previous()
+                    else None,
+                ),
+                ("previous_url", self.get_previous_link()),
+                ("data", data),
+            ]
+        )

--- a/firstvoices/backend/serializers/site_data_serializers.py
+++ b/firstvoices/backend/serializers/site_data_serializers.py
@@ -38,8 +38,11 @@ class SiteDataSerializer(SiteContentLinkedTitleSerializer):
             "L2": {"name": "English"},
             "build": datetime.now().strftime("%Y%m%d%H%M"),
         }
-
-        queryset = site.dictionaryentry_set
+        queryset = (
+            site.dictionaryentry_set
+            if site is not None and site.dictionaryentry_set is not None
+            else None
+        )
         request = self.context.get("request")
         dictionary_entries = DictionaryEntryDataSerializer(
             queryset, many=True, context={"request": request}

--- a/firstvoices/backend/tests/test_apis/test_sites_data_api.py
+++ b/firstvoices/backend/tests/test_apis/test_sites_data_api.py
@@ -1,0 +1,337 @@
+import json
+import time
+
+import pytest
+from django.utils import timezone
+from rest_framework.reverse import reverse
+from rest_framework.test import APIClient
+
+from backend.tests import factories
+
+from ...models import DictionaryEntry, PartOfSpeech
+from ...models.constants import Visibility
+from ..factories import (
+    AcknowledgementFactory,
+    CategoryFactory,
+    CharacterFactory,
+    CharacterVariantFactory,
+    DictionaryEntryCategoryFactory,
+    NoteFactory,
+    TranslationFactory,
+)
+
+
+class TestSitesDataEndpoint:
+    """
+    Tests that check the sites-data endpoint for correct formatting and behavior.
+    """
+
+    API_LIST_VIEW = "api:data-list"
+    APP_NAME = "backend"
+
+    client = None
+
+    def get_list_endpoint(self, site_slug):
+        return reverse(self.API_LIST_VIEW, current_app=self.APP_NAME, args=[site_slug])
+
+    def setup_method(self):
+        self.client = APIClient()
+        self.user = factories.get_non_member_user()
+        self.client.force_authenticate(user=self.user)
+
+    def isTimeFormat(self, input):
+        try:
+            time.strptime(input, "%Y%m%d%H%M")
+            return True
+        except ValueError:
+            return False
+
+    @pytest.mark.django_db
+    def test_list_404_site_not_found(self):
+        response = self.client.get(self.get_list_endpoint(site_slug="missing-site"))
+
+        assert response.status_code == 404
+
+    @pytest.mark.django_db
+    def test_list_403_site_not_visible(self):
+        site = factories.SiteFactory.create(visibility=Visibility.TEAM)
+
+        response = self.client.get(self.get_list_endpoint(site_slug=site.slug))
+
+        assert response.status_code == 403
+
+    @pytest.mark.django_db
+    def test_empty_config(self):
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+
+        response = self.client.get(self.get_list_endpoint(site_slug=site.slug))
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)[0]
+
+        config = response_data["siteDataExport"]["config"]
+        assert config["L1"] == {
+            "name": site.title,
+            "lettersInLanguage": [],
+            "transducers": {},
+        }
+        assert config["L2"] == {"name": "English"}
+        assert self.isTimeFormat(config["build"])
+
+    @pytest.mark.django_db
+    def test_full_config(self):
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+        char_a = CharacterFactory(site=site, title="a")
+        char_b = CharacterFactory(site=site, title="b")
+        char_c = CharacterFactory(site=site, title="c")
+
+        response = self.client.get(self.get_list_endpoint(site_slug=site.slug))
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)[0]
+
+        config = response_data["siteDataExport"]["config"]
+        assert config["L1"] == {
+            "name": site.title,
+            "lettersInLanguage": [char_a.title, char_b.title, char_c.title],
+            "transducers": {},
+        }
+        assert config["L2"] == {"name": "English"}
+        assert self.isTimeFormat(config["build"])
+
+    @pytest.mark.django_db
+    def test_dictionary_empty(self):
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+
+        response = self.client.get(self.get_list_endpoint(site_slug=site.slug))
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)[0]
+
+        dictionary_entries = response_data["siteDataExport"]["data"]
+        assert len(dictionary_entries) == 0
+
+    @pytest.mark.django_db
+    def test_dictionary_entries(self):
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+        entry_one = factories.DictionaryEntryFactory.create(
+            site=site,
+            visibility=Visibility.PUBLIC,
+            type=DictionaryEntry.TypeOfDictionaryEntry.WORD,
+            title="title_one",
+        )
+        entry_two = factories.DictionaryEntryFactory.create(
+            site=site,
+            visibility=Visibility.PUBLIC,
+            type=DictionaryEntry.TypeOfDictionaryEntry.PHRASE,
+            title="title_two",
+        )
+
+        response = self.client.get(self.get_list_endpoint(site_slug=site.slug))
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)[0]
+
+        dictionary_entries = response_data["siteDataExport"]["data"]
+        assert len(dictionary_entries) == 2
+
+        assert dictionary_entries[0] == {
+            "source": "words",
+            "entryID": str(entry_one.id),
+            "word": entry_one.title,
+            "definition": None,
+            "audio": [
+                {
+                    "speaker": None,
+                    "filename": "https://v2.dev.firstvoices.com/nuxeo/nxfile/default/136e1a0a-a707-41a9-9ec8"
+                    "-1a4f05b55454/file:content/TestMP3.mp3",
+                }
+            ],
+            "img": "https://v2.dev.firstvoices.com/nuxeo/nxfile/default/5c9eef16-4665-40b9-89ce-debc0301f93b/file"
+            ":content/pexels-stijn-dijkstra-2583852.jpg",
+            "theme": [],
+            "secondary_theme": None,
+            "optional": [{}],
+            "compare_form": entry_one.title,
+            "sort_form": entry_one.title,
+            "sorting_form": [
+                10116,
+                10105,
+                10116,
+                10108,
+                10101,
+                10095,
+                10111,
+                10110,
+                10101,
+            ],
+        }
+        assert len(dictionary_entries[0]) == 12
+
+        assert dictionary_entries[1] == {
+            "source": "phrases",
+            "entryID": str(entry_two.id),
+            "word": entry_two.title,
+            "definition": None,
+            "audio": [
+                {
+                    "speaker": None,
+                    "filename": "https://v2.dev.firstvoices.com/nuxeo/nxfile/default/136e1a0a-a707-41a9-9ec8"
+                    "-1a4f05b55454/file:content/TestMP3.mp3",
+                }
+            ],
+            "img": "https://v2.dev.firstvoices.com/nuxeo/nxfile/default/5c9eef16-4665-40b9-89ce-debc0301f93b/file"
+            ":content/pexels-stijn-dijkstra-2583852.jpg",
+            "theme": [],
+            "secondary_theme": None,
+            "optional": [{}],
+            "compare_form": entry_two.title,
+            "sort_form": entry_two.title,
+            "sorting_form": [
+                10116,
+                10105,
+                10116,
+                10108,
+                10101,
+                10095,
+                10116,
+                10119,
+                10111,
+            ],
+        }
+        assert len(dictionary_entries[1]) == 12
+
+    @pytest.mark.django_db
+    def test_dictionary_entries_definition(self):
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+        entry_one = factories.DictionaryEntryFactory.create(
+            site=site,
+            visibility=Visibility.PUBLIC,
+            type=DictionaryEntry.TypeOfDictionaryEntry.WORD,
+        )
+
+        translation = TranslationFactory.create(
+            dictionary_entry=entry_one, text="test translation"
+        )
+
+        response = self.client.get(self.get_list_endpoint(site_slug=site.slug))
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)[0]
+
+        dictionary_entries = response_data["siteDataExport"]["data"]
+        assert len(dictionary_entries) == 1
+
+        assert dictionary_entries[0]["definition"] == translation.text
+
+    @pytest.mark.django_db
+    def test_dictionary_entries_themes(self):
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+        entry_one = factories.DictionaryEntryFactory.create(
+            site=site,
+            visibility=Visibility.PUBLIC,
+            type=DictionaryEntry.TypeOfDictionaryEntry.WORD,
+        )
+
+        entry_two = factories.DictionaryEntryFactory.create(
+            site=site,
+            visibility=Visibility.PUBLIC,
+            type=DictionaryEntry.TypeOfDictionaryEntry.WORD,
+        )
+
+        category1 = CategoryFactory(site=site, title="test category A")
+        DictionaryEntryCategoryFactory(category=category1, dictionary_entry=entry_one)
+
+        category2 = CategoryFactory(site=site, title="test category B")
+        category3 = CategoryFactory(
+            site=site, title="test category C", parent=category2
+        )
+        DictionaryEntryCategoryFactory(category=category3, dictionary_entry=entry_two)
+
+        response = self.client.get(self.get_list_endpoint(site_slug=site.slug))
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)[0]
+
+        dictionary_entries = response_data["siteDataExport"]["data"]
+        assert len(dictionary_entries) == 2
+
+        assert dictionary_entries[0]["theme"] == [
+            {"category": category1.title, "parent_category": None}
+        ]
+        assert len(dictionary_entries[0]["theme"]) == 1
+
+        assert dictionary_entries[1]["theme"] == [
+            {"category": category3.title, "parent_category": category2.title}
+        ]
+        assert len(dictionary_entries[1]["theme"]) == 1
+
+    @pytest.mark.django_db
+    def test_dictionary_entries_optional(self):
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+        entry_one = factories.DictionaryEntryFactory.create(
+            site=site,
+            visibility=Visibility.PUBLIC,
+            type=DictionaryEntry.TypeOfDictionaryEntry.WORD,
+        )
+
+        acknowledgement = AcknowledgementFactory.create(
+            dictionary_entry=entry_one, text="test acknowledgement"
+        )
+        p1 = PartOfSpeech(
+            title="part_of_speech_1",
+            created=timezone.now(),
+            last_modified=timezone.now(),
+            created_by=self.user,
+            last_modified_by=self.user,
+        )
+        p1.save()
+        translation = TranslationFactory.create(
+            dictionary_entry=entry_one, part_of_speech=p1
+        )
+        note = NoteFactory.create(dictionary_entry=entry_one, text="test note")
+
+        response = self.client.get(self.get_list_endpoint(site_slug=site.slug))
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)[0]
+
+        dictionary_entries = response_data["siteDataExport"]["data"]
+        assert len(dictionary_entries) == 1
+
+        assert dictionary_entries[0]["optional"] == [
+            {
+                "Reference": acknowledgement.text,
+                "Part of Speech": translation.part_of_speech.title,
+                "Note": note.text,
+            }
+        ]
+        assert len(dictionary_entries[0]["optional"][0]) == 3
+
+    @pytest.mark.django_db
+    def test_dictionary_entries_form(self):
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+
+        char_a = CharacterFactory(site=site, title="a", sort_order=1)
+        CharacterVariantFactory(site=site, title="A", base_character=char_a)
+        CharacterFactory(site=site, title="b", sort_order=2)
+        CharacterFactory(site=site, title="c", sort_order=3)
+
+        entry_one = factories.DictionaryEntryFactory.create(
+            site=site,
+            visibility=Visibility.PUBLIC,
+            type=DictionaryEntry.TypeOfDictionaryEntry.WORD,
+            title="Abc",
+        )
+
+        response = self.client.get(self.get_list_endpoint(site_slug=site.slug))
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)[0]
+
+        dictionary_entries = response_data["siteDataExport"]["data"]
+        assert len(dictionary_entries) == 1
+
+        assert dictionary_entries[0]["compare_form"] == entry_one.title
+        assert dictionary_entries[0]["sort_form"] == "abc"
+        assert dictionary_entries[0]["sorting_form"] == [1, 2, 3]

--- a/firstvoices/backend/tests/test_apis/test_sites_data_api.py
+++ b/firstvoices/backend/tests/test_apis/test_sites_data_api.py
@@ -39,7 +39,7 @@ class TestSitesDataEndpoint:
         self.user = factories.get_non_member_user()
         self.client.force_authenticate(user=self.user)
 
-    def isTimeFormat(self, input):
+    def is_time_format(self, input):
         try:
             time.strptime(input, "%Y%m%d%H%M")
             return True
@@ -76,7 +76,7 @@ class TestSitesDataEndpoint:
             "transducers": {},
         }
         assert config["L2"] == {"name": "English"}
-        assert self.isTimeFormat(config["build"])
+        assert self.is_time_format(config["build"])
 
     @pytest.mark.django_db
     def test_full_config(self):
@@ -97,7 +97,7 @@ class TestSitesDataEndpoint:
             "transducers": {},
         }
         assert config["L2"] == {"name": "English"}
-        assert self.isTimeFormat(config["build"])
+        assert self.is_time_format(config["build"])
 
     @pytest.mark.django_db
     def test_dictionary_empty(self):

--- a/firstvoices/backend/urls.py
+++ b/firstvoices/backend/urls.py
@@ -6,6 +6,7 @@ from backend.views.category_views import CategoryViewSet
 from backend.views.character_views import CharactersViewSet, IgnoredCharactersViewSet
 from backend.views.debug.async_example import ExampleAsyncTaskView
 from backend.views.debug.elastic_example import ExampleElasticSearch
+from backend.views.data_views import SitesDataViewSet
 from backend.views.dictionary_views import DictionaryViewSet
 from backend.views.parts_of_speech_views import PartsOfSpeechViewSet
 from backend.views.sites_views import MySitesViewSet, SiteViewSet
@@ -28,6 +29,7 @@ sites_router.register(
 )
 sites_router.register(r"dictionary", DictionaryViewSet, basename="dictionaryentry")
 sites_router.register(r"categories", CategoryViewSet, basename="category")
+sites_router.register(r"data", SitesDataViewSet, basename="data")
 
 app_name = "api"
 

--- a/firstvoices/backend/views/data_views.py
+++ b/firstvoices/backend/views/data_views.py
@@ -1,0 +1,62 @@
+from drf_spectacular.utils import extend_schema, extend_schema_view, inline_serializer
+from rest_framework import mixins, serializers, viewsets
+from rules.contrib.rest_framework import AutoPermissionViewSetMixin
+
+from backend.models.dictionary import DictionaryEntry
+from backend.predicates import utils
+from backend.serializers.site_data_serializers import SiteDataSerializer
+from backend.views.base_views import SiteContentViewSetMixin
+
+
+def dict_entry_type_mtd_conversion(type):
+    match type:
+        case DictionaryEntry.TypeOfDictionaryEntry.WORD:
+            return "words"
+        case DictionaryEntry.TypeOfDictionaryEntry.PHRASE:
+            return "phrases"
+        case _:
+            return None
+
+
+@extend_schema_view(
+    list=extend_schema(
+        description="Returns a site data object in the MTD format to be used in PWAs. The endpoint returns a config "
+        "containing the alphabet and site info, as well as data containing an export of site dictionary "
+        "entries and categories. Additional information on the MTD format can be found on the Mother "
+        "Tongues documentation: https://docs.mothertongues.org/docs/mtd-guides-prepare",
+        responses={
+            200: inline_serializer(
+                name="InlineUserSerializer",
+                fields={
+                    "siteDataExport": serializers.DictField(),
+                },
+            ),
+        },
+    ),
+)
+class SitesDataViewSet(
+    AutoPermissionViewSetMixin,
+    SiteContentViewSetMixin,
+    mixins.ListModelMixin,
+    viewsets.GenericViewSet,
+):
+    http_method_names = ["get"]
+    serializer_class = SiteDataSerializer
+    pagination_class = None
+
+    def get_queryset(self):
+        sites = (
+            utils.filter_by_viewable(self.request.user, self.get_validated_site())
+            .select_related("language")
+            .prefetch_related(
+                "dictionaryentry_set",
+                "character_set",
+                "dictionaryentry_set__translation_set__part_of_speech",
+                "alphabet_set",
+                "dictionaryentry_set__acknowledgement_set",
+                "dictionaryentry_set__note_set",
+                "dictionaryentry_set__categories",
+                "dictionaryentry_set__categories__parent",
+            )
+        )
+        return sites

--- a/firstvoices/backend/views/data_views.py
+++ b/firstvoices/backend/views/data_views.py
@@ -20,10 +20,10 @@ def dict_entry_type_mtd_conversion(type):
 
 @extend_schema_view(
     list=extend_schema(
-        description="Returns a site data object in the MTD format to be used in PWAs. The endpoint returns a config "
-        "containing the alphabet and site info, as well as data containing an export of site dictionary "
-        "entries and categories. Additional information on the MTD format can be found on the Mother "
-        "Tongues documentation: https://docs.mothertongues.org/docs/mtd-guides-prepare",
+        description="Returns a site data object in the MTD format. The endpoint returns a config containing the "
+        "alphabet and site info, as well as data containing an export of site dictionary entries and "
+        "categories. Additional information on the MTD format can be found on the Mother Tongues "
+        "documentation: https://docs.mothertongues.org/docs/mtd-guides-prepare",
         responses={
             200: inline_serializer(
                 name="InlineUserSerializer",

--- a/firstvoices/backend/views/data_views.py
+++ b/firstvoices/backend/views/data_views.py
@@ -3,7 +3,7 @@ from rest_framework import mixins, serializers, viewsets
 from rules.contrib.rest_framework import AutoPermissionViewSetMixin
 
 from backend.models.dictionary import DictionaryEntry
-from backend.predicates import utils
+from backend.permissions import utils
 from backend.serializers.site_data_serializers import SiteDataSerializer
 from backend.views.base_views import SiteContentViewSetMixin
 

--- a/firstvoices/firstvoices/settings.py
+++ b/firstvoices/firstvoices/settings.py
@@ -83,6 +83,9 @@ REST_FRAMEWORK = {
     "UNAUTHENTICATED_USER": None,
     "DEFAULT_PAGINATION_CLASS": "backend.pagination.PageNumberPagination",
     "PAGE_SIZE": 100,
+    "JSON_UNDERSCOREIZE": {
+        "ignore_fields": ("site_data_export",),
+    },
 }
 
 # local only


### PR DESCRIPTION
### Description of Changes
These changes add a basic site data export API to give the APP developers a starting point to work with. It is worth noting that this API currently contains some placeholder hardcoded values and will be enhanced as detailed in FW-4347.

The API can be accessed at `/api/1.0/sites/<site-slug>/data/`.

The API contains a `siteDataExport` field containing `config` and `data` objects in the Mother Tongues format. The `config` object contains some site information and a site's alphabet. The `data` object contains an export of dictionary entries.

Planned enhancements to be completed in FW-4347 include the following:
- Pagination of the `data` object
- `audio` and `img` fields contain dynamic content once media upload has been implemented
- Additional fields as needed by the APP developers
- Removing the nesting of the `data` and `config` objects inside of the `siteDataExport` field (This is currently a workaround for the camel-case parser auto formatting the fields and removing the underscores as needed for the Mother Tongues format).

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [x] Pull the branch and test locally

### Additional Notes
N/A
