### PR TITLE
Fix run-pytest.yml to no longer fail on dependabot opened PRs

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
+  pull_request_target:
+    types: [opened, edited]
 
 jobs:
   test:


### PR DESCRIPTION
### Description of Changes
Currently, the tests are failing because the action does not have access to the secrets required when a dependabot opens a PR. This change gives dependabot triggered actions access to the required secrets.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
