### PR TITLE
FW-4377 Fix ignored character edge case

### DIFF
--- a/firstvoices/backend/models/characters.py
+++ b/firstvoices/backend/models/characters.py
@@ -311,12 +311,13 @@ class Alphabet(BaseSiteContentModel):
         """
         Returns a sorter object containing both base characters and character variants
         to properly split text into characters using the MTD splitter.
+        Ignored characters are added to the order list to ensure they are not removed by the splitter.
         """
 
         return CustomSorter(
             order=[char.title for char in self.base_characters]
-            + [char.title for char in self.variant_characters],
-            ignorable=[char.title for char in self.ignorable_characters],
+            + [char.title for char in self.variant_characters]
+            + [char.title for char in self.ignorable_characters]
         )
 
     def __str__(self):

--- a/firstvoices/backend/serializers/dictionary_serializers.py
+++ b/firstvoices/backend/serializers/dictionary_serializers.py
@@ -79,11 +79,16 @@ class DictionaryEntryDetailSerializer(serializers.HyperlinkedModelSerializer):
         ignored_characters = alphabet.ignorable_characters.values_list(
             "title", flat=True
         )
-        has_ignored_char = any(char in ignored_characters for char in entry.title)
-        if "⚑" in entry.custom_order or has_ignored_char:
+
+        if "⚑" in entry.custom_order:
             return []
         else:
-            return alphabet.get_character_list(entry.title)
+            char_list = alphabet.get_character_list(entry.title)
+            has_ignored_char = set(char_list).intersection(set(ignored_characters))
+            if has_ignored_char:
+                return []
+            else:
+                return char_list
 
     @staticmethod
     def get_split_chars_base(entry):
@@ -91,15 +96,17 @@ class DictionaryEntryDetailSerializer(serializers.HyperlinkedModelSerializer):
         ignored_characters = alphabet.ignorable_characters.values_list(
             "title", flat=True
         )
-        has_ignored_char = any(char in ignored_characters for char in entry.title)
-        if "⚑" in entry.custom_order or has_ignored_char:
+        if "⚑" in entry.custom_order:
             return []
         else:
-            # split, then convert title to base characters
+            # split, check for ignored, then convert title to base characters
             char_list = alphabet.get_character_list(entry.title)
-            base_chars = [alphabet.get_base_form(c) for c in char_list]
-
-            return base_chars
+            has_ignored_char = set(char_list).intersection(set(ignored_characters))
+            if has_ignored_char:
+                return []
+            else:
+                base_chars = [alphabet.get_base_form(c) for c in char_list]
+                return base_chars
 
     @staticmethod
     def get_split_words(entry):

--- a/firstvoices/backend/tests/test_apis/test_dictionary_api.py
+++ b/firstvoices/backend/tests/test_apis/test_dictionary_api.py
@@ -452,7 +452,7 @@ class TestDictionaryEndpoint(BaseSiteControlledContentApiTest):
         factories.IgnoredCharacterFactory.create(site=site, title="-")
 
         factories.DictionaryEntryFactory.create(
-            site=site, visibility=Visibility.PUBLIC, title="x-y yx-y"
+            site=site, visibility=Visibility.PUBLIC, title="x-y y"
         )
         factories.DictionaryEntryFactory.create(
             site=site, visibility=Visibility.PUBLIC, title="x-y-"
@@ -471,15 +471,11 @@ class TestDictionaryEndpoint(BaseSiteControlledContentApiTest):
             "y",
             " ",
             "y",
-            "x-",
-            "y",
         ]
         assert response_data["results"][0]["splitCharsBase"] == [
             "x-",
             "y",
             " ",
-            "y",
-            "x-",
             "y",
         ]
         assert response_data["results"][1]["splitChars"] == []

--- a/firstvoices/backend/tests/test_apis/test_dictionary_api.py
+++ b/firstvoices/backend/tests/test_apis/test_dictionary_api.py
@@ -422,10 +422,10 @@ class TestDictionaryEndpoint(BaseSiteControlledContentApiTest):
 
         factories.CharacterFactory.create(site=site, title="x")
         factories.CharacterFactory.create(site=site, title="y")
-        factories.IgnoredCharacterFactory.create(site=site, title="-")
+        factories.IgnoredCharacterFactory.create(site=site, title="&")
 
         factories.DictionaryEntryFactory.create(
-            site=site, visibility=Visibility.PUBLIC, title="x-y"
+            site=site, visibility=Visibility.PUBLIC, title="x&y"
         )
 
         response = self.client.get(self.get_list_endpoint(site_slug=site.slug))
@@ -452,10 +452,7 @@ class TestDictionaryEndpoint(BaseSiteControlledContentApiTest):
         factories.IgnoredCharacterFactory.create(site=site, title="-")
 
         factories.DictionaryEntryFactory.create(
-            site=site, visibility=Visibility.PUBLIC, title="x-y y"
-        )
-        factories.DictionaryEntryFactory.create(
-            site=site, visibility=Visibility.PUBLIC, title="x-y-"
+            site=site, visibility=Visibility.PUBLIC, title="x-y"
         )
 
         response = self.client.get(self.get_list_endpoint(site_slug=site.slug))
@@ -463,23 +460,11 @@ class TestDictionaryEndpoint(BaseSiteControlledContentApiTest):
         assert response.status_code == 200
 
         response_data = json.loads(response.content)
-        assert response_data["count"] == 2
-        assert len(response_data["results"]) == 2
+        assert response_data["count"] == 1
+        assert len(response_data["results"]) == 1
 
-        assert response_data["results"][0]["splitChars"] == [
-            "x-",
-            "y",
-            " ",
-            "y",
-        ]
-        assert response_data["results"][0]["splitCharsBase"] == [
-            "x-",
-            "y",
-            " ",
-            "y",
-        ]
-        assert response_data["results"][1]["splitChars"] == []
-        assert response_data["results"][1]["splitCharsBase"] == []
+        assert response_data["results"][0]["splitChars"] == ["x-", "y"]
+        assert response_data["results"][0]["splitCharsBase"] == ["x-", "y"]
 
     @pytest.mark.django_db
     def test_word_lists(self):

--- a/firstvoices/backend/tests/test_models/test_alphabet_model.py
+++ b/firstvoices/backend/tests/test_models/test_alphabet_model.py
@@ -164,3 +164,20 @@ class TestAlphabetModel:
 
         s = "XxYy"
         assert alphabet.get_base_form(s) == "xxyy"
+
+    @pytest.mark.django_db
+    def test_get_base_form_with_special_characters(self, alphabet):
+        """Get base form of text with confusables applied"""
+        CharacterFactory(site=alphabet.site, title="-")
+        CharacterFactory(site=alphabet.site, title=".")
+        CharacterFactory(site=alphabet.site, title="&")
+        a = CharacterFactory(site=alphabet.site, title="a")
+        b = CharacterFactory(site=alphabet.site, title="b")
+        c = CharacterFactory(site=alphabet.site, title="c")
+        CharacterVariantFactory(site=alphabet.site, title="A", base_character=a)
+        CharacterVariantFactory(site=alphabet.site, title="B", base_character=b)
+        CharacterVariantFactory(site=alphabet.site, title="C", base_character=c)
+
+        s = "ABC-.-&"
+        base = alphabet.get_base_form(s)
+        assert base == "abc-.-&"

--- a/firstvoices/backend/tests/test_utils.py
+++ b/firstvoices/backend/tests/test_utils.py
@@ -85,3 +85,9 @@ class TestCharacterUtils:
         assert sorter.word_as_chars("aa") == ["aa"]
         assert sorter.word_as_chars("cch") == ["c", "ch"]
         assert sorter.word_as_chars("aach") == ["aa", "ch"]
+
+    def test_word_as_chars_special_characters(self):
+        sorter = CustomSorter(order=["a", "aa", "c", "ch.", "h", "x-", "y", "-", "."])
+        assert sorter.word_as_chars("x-y") == ["x-", "y"]
+        assert sorter.word_as_chars("cch..") == ["c", "ch.", "."]
+        assert sorter.word_as_chars("c-h") == ["c", "-", "h"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ Flask-Cors==3.0.10
 Flask-RESTful==0.3.9
 Flask-SocketIO==4.3.2
 flask-talisman==1.0.0
-g2p==1.0.20230417 # https://github.com/roedoejet/g2p
+g2p==1.1.20230511 # https://github.com/roedoejet/g2p
 greenlet==2.0.2
 gunicorn==20.1.0
 humanfriendly==10.0


### PR DESCRIPTION
### Description of Changes
- Fixes an edge case where valid characters containing ignored characters would make a dictionary entry ineligible for the games character split.
- Bumps g2p version to fix escape characters being added where they should not be. (Thanks to Aidan's incredibly quick fix!)

### Checklist
- [x] ~~README / documentation has been updated if needed~~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [x] Pull the branch and test locally

### Additional Notes
N/A
