### PR TITLE
Added error handling if a superuser membership is already present

### DIFF
--- a/firstvoices/scripts/create_local_superadmin_membership.py
+++ b/firstvoices/scripts/create_local_superadmin_membership.py
@@ -1,5 +1,7 @@
 import os
 
+from django.db.utils import IntegrityError
+
 from backend.models import User
 from backend.models.app import AppMembership
 from backend.models.constants import AppRole
@@ -9,5 +11,8 @@ from backend.models.constants import AppRole
 id = os.getenv("DJANGO_SUPERUSER_EMAIL")
 user = User.objects.filter(id=id).first()
 
-membership = AppMembership(user=user, role=AppRole.SUPERADMIN)
-membership.save()
+try:
+    membership = AppMembership(user=user, role=AppRole.SUPERADMIN)
+    membership.save()
+except IntegrityError:
+    print("Superuser membership already added with the given DJANGO_SUPERUSER_EMAIL.")

--- a/firstvoices/scripts/create_local_superadmin_membership.py
+++ b/firstvoices/scripts/create_local_superadmin_membership.py
@@ -14,5 +14,8 @@ user = User.objects.filter(id=id).first()
 try:
     membership = AppMembership(user=user, role=AppRole.SUPERADMIN)
     membership.save()
-except IntegrityError:
-    print("Superuser membership already added with the given DJANGO_SUPERUSER_EMAIL.")
+except IntegrityError as e:
+    if "unique constraint" in e.args[0]:  # Check if it is a unique constraint violation
+        print(
+            "Superuser membership already added with the given DJANGO_SUPERUSER_EMAIL."
+        )


### PR DESCRIPTION
### Description of Changes
Added error handling for when the script tries to add superuser membership for the given email. It previously threw an error if the membership already existed.

### Checklist
- ~README / documentation has been updated if needed~
- ~PR title / commit messages contain Jira ticket number if applicable~
- ~Tests have been updated / created if applicable~
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
