### PR TITLE
fw-4369, check visibility of site, not site summary info

### DIFF
--- a/firstvoices/backend/permissions/predicates/base.py
+++ b/firstvoices/backend/permissions/predicates/base.py
@@ -89,8 +89,10 @@ has_public_access_to_obj = predicate(
 has_member_access_to_obj = (
     is_at_least_member & ~is_team_obj & ~has_team_site
 )  # noqa E1130
-has_team_access_to_obj = is_at_least_assistant
+has_team_access = is_at_least_assistant
 
 has_public_access_to_site = has_public_site  # just a convenient alias
 has_member_access_to_site = is_at_least_member & ~has_team_site  # noqa E1130
-has_team_access_to_site = is_at_least_assistant
+
+has_public_access_to_site_obj = predicate(is_public_obj)
+has_member_access_to_site_obj = is_at_least_member & ~is_team_obj  # noqa E1130

--- a/firstvoices/backend/permissions/predicates/view.py
+++ b/firstvoices/backend/permissions/predicates/view.py
@@ -11,7 +11,7 @@ is_visible_object = Predicate(
         base.has_public_access_to_obj
         | base.is_at_least_staff_admin
         | base.has_member_access_to_obj
-        | base.has_team_access_to_obj
+        | base.has_team_access
     ),
     name="is_visible_object",
 )
@@ -21,7 +21,17 @@ has_visible_site = Predicate(
         base.has_public_access_to_site
         | base.is_at_least_staff_admin
         | base.has_member_access_to_site
-        | base.has_team_access_to_site
+        | base.has_team_access
     ),
     name="has_visible_site",
+)
+
+is_visible_site_object = Predicate(
+    (
+        base.has_public_access_to_site_obj
+        | base.is_at_least_staff_admin
+        | base.has_member_access_to_site_obj
+        | base.has_team_access
+    ),
+    name="is_visible_site_object",
 )

--- a/firstvoices/backend/permissions/predicates/view_models.py
+++ b/firstvoices/backend/permissions/predicates/view_models.py
@@ -12,7 +12,7 @@ can_view_site_model = Predicate(
         base.is_public_obj
         | base.is_members_obj
         | base.is_at_least_staff_admin
-        | base.has_team_access_to_obj
+        | base.has_team_access
     ),
     name="can_view_site_model",
 )

--- a/firstvoices/backend/tests/test_apis/base_api_test.py
+++ b/firstvoices/backend/tests/test_apis/base_api_test.py
@@ -60,11 +60,15 @@ class BaseSiteContentApiTest:
 
         assert response.status_code == 404
 
+    @pytest.mark.parametrize(
+        "visibility",
+        [Visibility.MEMBERS, Visibility.TEAM],
+    )
     @pytest.mark.django_db
-    def test_list_403_site_not_visible(self):
+    def test_list_403_site_not_visible(self, visibility):
         user = factories.get_non_member_user()
         self.client.force_authenticate(user=user)
-        site = factories.SiteFactory.create(visibility=Visibility.TEAM)
+        site = factories.SiteFactory.create(visibility=visibility)
 
         response = self.client.get(self.get_list_endpoint(site_slug=site.slug))
 

--- a/firstvoices/backend/tests/test_permissions/test_predicate_base.py
+++ b/firstvoices/backend/tests/test_permissions/test_predicate_base.py
@@ -278,7 +278,7 @@ class TestBaseObjectAccessPredicates:
         obj = ControlledSiteContentFactory.create(site=site, visibility=obj_visibility)
         team_user = UserFactory.create()
         MembershipFactory(site=site, user=team_user, role=role)
-        assert base.has_team_access_to_obj(team_user, obj)
+        assert base.has_team_access(team_user, obj)
 
     @pytest.mark.django_db
     def test_has_team_access_wrong_role(self):
@@ -286,21 +286,21 @@ class TestBaseObjectAccessPredicates:
         obj = ControlledSiteContentFactory.create(site=site, visibility=Visibility.TEAM)
         member_user = UserFactory.create()
         MembershipFactory(site=site, user=member_user, role=Role.MEMBER)
-        assert not base.has_team_access_to_obj(member_user, obj)
+        assert not base.has_team_access(member_user, obj)
 
     @pytest.mark.django_db
     def test_has_team_access_guest_user(self):
         site = SiteFactory.create(visibility=Visibility.PUBLIC)
         obj = ControlledSiteContentFactory.create(site=site, visibility=Visibility.TEAM)
         guest_user = AnonymousUserFactory.build()
-        assert not base.has_team_access_to_obj(guest_user, obj)
+        assert not base.has_team_access(guest_user, obj)
 
     @pytest.mark.django_db
     def test_has_team_access_non_member(self):
         site = SiteFactory.create(visibility=Visibility.PUBLIC)
         obj = ControlledSiteContentFactory.create(site=site, visibility=Visibility.TEAM)
         non_member_user = UserFactory.create()
-        assert not base.has_team_access_to_obj(non_member_user, obj)
+        assert not base.has_team_access(non_member_user, obj)
 
     @pytest.mark.django_db
     def test_team_is_blocked_from_team_content_on_other_sites(self):
@@ -372,7 +372,7 @@ class TestBaseSiteAccessPredicates:
         obj = UncontrolledSiteContentFactory.create(site=site)
         team_user = UserFactory.create()
         MembershipFactory(site=site, user=team_user, role=role)
-        assert base.has_team_access_to_site(team_user, obj)
+        assert base.has_team_access(team_user, obj)
 
     @pytest.mark.django_db
     def test_has_team_access_wrong_role(self):
@@ -380,21 +380,21 @@ class TestBaseSiteAccessPredicates:
         obj = UncontrolledSiteContentFactory.create(site=site)
         member_user = UserFactory.create()
         MembershipFactory(site=site, user=member_user, role=Role.MEMBER)
-        assert not base.has_team_access_to_site(member_user, obj)
+        assert not base.has_team_access(member_user, obj)
 
     @pytest.mark.django_db
     def test_has_team_access_guest_user(self):
         site = SiteFactory.create(visibility=Visibility.TEAM)
         obj = UncontrolledSiteContentFactory.create(site=site)
         guest_user = AnonymousUserFactory.build()
-        assert not base.has_team_access_to_site(guest_user, obj)
+        assert not base.has_team_access(guest_user, obj)
 
     @pytest.mark.django_db
     def test_has_team_access_non_member(self):
         site = SiteFactory.create(visibility=Visibility.TEAM)
         obj = UncontrolledSiteContentFactory.create(site=site)
         non_member_user = UserFactory.create()
-        assert not base.has_team_access_to_site(non_member_user, obj)
+        assert not base.has_team_access(non_member_user, obj)
 
     @pytest.mark.django_db
     def test_team_has_member_access_on_different_site(self):

--- a/firstvoices/backend/views/base_views.py
+++ b/firstvoices/backend/views/base_views.py
@@ -3,6 +3,7 @@ from django.http import Http404
 from rest_framework.response import Response
 from rules.contrib.rest_framework import AutoPermissionViewSetMixin
 
+from backend import permissions
 from backend.models import Site
 from backend.permissions import utils
 
@@ -65,8 +66,10 @@ class SiteContentViewSetMixin:
         if len(site) == 0:
             raise Http404
 
-        allowed_site = utils.filter_by_viewable(self.request.user, site)
-        if len(allowed_site) == 0:
+        # Check if site content is visible. This uses a different permission rule than for viewing the fields on the
+        # Site model itself, which are mainly used in site listings. That's why we're checking is_visible_object
+        # rather than the model's view permission.
+        if permissions.predicates.is_visible_site_object(self.request.user, site[0]):
+            return site
+        else:
             raise PermissionDenied
-
-        return allowed_site


### PR DESCRIPTION
### Description of Changes
When checking whether a site content should return 403, use a different (more strict) rule than when checking whether the fields of the site model are visible.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
