### PR TITLE
FW-4394 Reduce duplicate queries in dictionary entry views

### DIFF
--- a/firstvoices/backend/serializers/dictionary_serializers.py
+++ b/firstvoices/backend/serializers/dictionary_serializers.py
@@ -77,7 +77,7 @@ class DictionaryEntryDetailSerializer(serializers.HyperlinkedModelSerializer):
 
     logger = logging.getLogger(__name__)
 
-    def retrieve_model_or_context(self, model_name):
+    def get_model_from_context(self, model_name):
         if self.context is not None and model_name in self.context:
             return self.context[model_name]
         else:
@@ -87,8 +87,8 @@ class DictionaryEntryDetailSerializer(serializers.HyperlinkedModelSerializer):
             return []
 
     def get_split_chars(self, entry):
-        alphabet = self.retrieve_model_or_context("alphabet")
-        ignored_characters = self.retrieve_model_or_context("ignored_characters")
+        alphabet = self.get_model_from_context("alphabet")
+        ignored_characters = self.get_model_from_context("ignored_characters")
 
         if "⚑" in entry.custom_order:
             return []
@@ -110,8 +110,8 @@ class DictionaryEntryDetailSerializer(serializers.HyperlinkedModelSerializer):
                 return char_list
 
     def get_split_chars_base(self, entry):
-        alphabet = self.retrieve_model_or_context("alphabet")
-        ignored_characters = self.retrieve_model_or_context("ignored_characters")
+        alphabet = self.get_model_from_context("alphabet")
+        ignored_characters = self.get_model_from_context("ignored_characters")
         if "⚑" in entry.custom_order:
             return []
         else:
@@ -145,7 +145,7 @@ class DictionaryEntryDetailSerializer(serializers.HyperlinkedModelSerializer):
         return entry.title.split(" ")
 
     def get_split_words_base(self, entry):
-        alphabet = self.retrieve_model_or_context("alphabet")
+        alphabet = self.get_model_from_context("alphabet")
         if alphabet == []:
             return entry.title
         # convert title to base characters

--- a/firstvoices/backend/views/base_views.py
+++ b/firstvoices/backend/views/base_views.py
@@ -42,9 +42,7 @@ class FVPermissionViewSetMixin(AutoPermissionViewSetMixin):
         # paginated response
         page = self.paginate_queryset(queryset)
         if page is not None:
-            serializer = self.get_serializer(
-                page, many=True, context={"request": request}
-            )
+            serializer = self.get_serializer(page, many=True)
             return self.get_paginated_response(serializer.data)
 
         # non-paginated response

--- a/firstvoices/backend/views/base_views.py
+++ b/firstvoices/backend/views/base_views.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 from rules.contrib.rest_framework import AutoPermissionViewSetMixin
 
 from backend import permissions
-from backend.models import Site
+from backend.models import Alphabet, Character, CharacterVariant, IgnoredCharacter, Site
 from backend.permissions import utils
 
 
@@ -71,3 +71,33 @@ class SiteContentViewSetMixin:
             return site
         else:
             raise PermissionDenied
+
+
+class DictionarySerializerContextMixin:
+    """
+    Adds context to a view which is passed to the dictionary serializer to remove the need for duplicate queries.
+    """
+
+    def get_serializer_context(self):
+        """
+        A helper function to gather additional model context which can be reused for multiple dictionary entries.
+        """
+
+        site = self.get_validated_site()[0]
+
+        context = super().get_serializer_context()
+
+        alphabet = Alphabet.objects.filter(site=site).first()
+        ignored_characters = IgnoredCharacter.objects.filter(site=site).values_list(
+            "title", flat=True
+        )
+        base_characters = Character.objects.filter(site=site).order_by("sort_order")
+        character_variants = CharacterVariant.objects.filter(site=site)
+        ignorable_characters = IgnoredCharacter.objects.filter(site=site)
+
+        context["alphabet"] = alphabet
+        context["ignored_characters"] = ignored_characters
+        context["base_characters"] = base_characters
+        context["character_variants"] = character_variants
+        context["ignorable_characters"] = ignorable_characters
+        return context

--- a/firstvoices/backend/views/dictionary_views.py
+++ b/firstvoices/backend/views/dictionary_views.py
@@ -2,6 +2,7 @@ from django.db.models import Prefetch
 from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import viewsets
 
+from backend.models import Alphabet, Character, CharacterVariant, IgnoredCharacter
 from backend.models.dictionary import DictionaryEntry
 from backend.serializers.dictionary_serializers import DictionaryEntryDetailSerializer
 from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSetMixin
@@ -57,3 +58,27 @@ class DictionaryViewSet(
             )
         else:
             return DictionaryEntry.objects.none()
+
+    def get_serializer_context(self):
+        """
+        A helper function to gather additional model context which can be reused for multiple dictionary entries.
+        """
+
+        site = self.get_validated_site()[0]
+
+        context = super().get_serializer_context()
+
+        alphabet = Alphabet.objects.filter(site=site).first()
+        ignored_characters = IgnoredCharacter.objects.filter(site=site).values_list(
+            "title", flat=True
+        )
+        base_characters = Character.objects.filter(site=site).order_by("sort_order")
+        character_variants = CharacterVariant.objects.filter(site=site)
+        ignorable_characters = IgnoredCharacter.objects.filter(site=site)
+
+        context["alphabet"] = alphabet
+        context["ignored_characters"] = ignored_characters
+        context["base_characters"] = base_characters
+        context["character_variants"] = character_variants
+        context["ignorable_characters"] = ignorable_characters
+        return context

--- a/firstvoices/backend/views/word_of_the_day_views.py
+++ b/firstvoices/backend/views/word_of_the_day_views.py
@@ -5,6 +5,7 @@ from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_
 from rest_framework import mixins, viewsets
 from rest_framework.response import Response
 
+from backend.models import Alphabet, Character, CharacterVariant, IgnoredCharacter
 from backend.models.dictionary import (
     DictionaryEntry,
     TypeOfDictionaryEntry,
@@ -140,6 +141,30 @@ class WordOfTheDayView(
 
         # serialize and return the data, with context to support hyperlinking
         serializer = self.serializer_class(
-            queryset, many=True, context={"request": request}
+            queryset, many=True, context=self.get_serializer_context()
         )
         return Response(serializer.data)
+
+    def get_serializer_context(self):
+        """
+        A helper function to gather additional model context which can be reused for multiple dictionary entries.
+        """
+
+        site = self.get_validated_site()[0]
+
+        context = super().get_serializer_context()
+
+        alphabet = Alphabet.objects.filter(site=site).first()
+        ignored_characters = IgnoredCharacter.objects.filter(site=site).values_list(
+            "title", flat=True
+        )
+        base_characters = Character.objects.filter(site=site).order_by("sort_order")
+        character_variants = CharacterVariant.objects.filter(site=site)
+        ignorable_characters = IgnoredCharacter.objects.filter(site=site)
+
+        context["alphabet"] = alphabet
+        context["ignored_characters"] = ignored_characters
+        context["base_characters"] = base_characters
+        context["character_variants"] = character_variants
+        context["ignorable_characters"] = ignorable_characters
+        return context


### PR DESCRIPTION
### Description of Changes
These changes add a context object to the dictionary views which is then passed to the dictionary entry serializer. This context object contains alphabet, ignored character, base character, character variant, and ignorable character information. This information can be collected once and reused during the fetching of each dictionary entry instead of re-querying the database each time.

If testing locally, please try the dictionary list view and detail views and compare the number of queries before and after the changes. The number should at least stay the same or decrease significantly. The changes are more noticeable on a site with a larger number of characters, character variants, ignored characters, and dictionary entries. The number of queries can be seen by using the toolbar in debug mode.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [x] Pull the branch and test locally

### Additional Notes
N/A
