### PR TITLE
fw-4409, eliminate db lookup for site content hyperlink fields

### DIFF
--- a/firstvoices/backend/serializers/fields.py
+++ b/firstvoices/backend/serializers/fields.py
@@ -1,12 +1,58 @@
-from rest_framework_nested.relations import (
-    NestedHyperlinkedIdentityField,
-    NestedHyperlinkedRelatedField,
-)
+from rest_framework_nested.relations import NestedHyperlinkedRelatedField
 
 
 class SiteHyperlinkedRelatedField(NestedHyperlinkedRelatedField):
-    parent_lookup_kwargs = {"site_slug": "site__slug"}
+    """
+    Supports nested URLs. Will use the view kwarg values named in parent_lookup_kwargs as literal
+    values when reversing the URL, to eliminate extra database queries. This means this will only work within
+    views that have the same nested structure as the target URL (links to objects in the same site). For use in other
+    contexts, see NestedHyperlinkedRelatedField, which uses model attribute lookups instead of url kwarg lookups.
+    """
+
+    parent_lookup_kwargs = {"site_slug": "site_slug"}
+
+    def get_url(self, obj, view_name, request, format):
+        """
+        Given an object, return the URL that hyperlinks to the object.
+
+        May raise a `NoReverseMatch` if the `view_name` and `lookup_field`
+        attributes are not configured to correctly match the URL conf.
+        """
+        # Unsaved objects will not yet have a valid URL.
+        if hasattr(obj, "pk") and obj.pk in (None, ""):
+            return None
+
+        # default lookup from rest_framework.relations.HyperlinkedRelatedField
+        lookup_value = getattr(obj, self.lookup_field)
+        kwargs = {self.lookup_url_kwarg: lookup_value}
+
+        # all levels will be treated as site values, so this is effectively a single-level lookup
+        for parent_lookup_kwarg in list(self.parent_lookup_kwargs.keys()):
+            underscored_lookup = self.parent_lookup_kwargs[parent_lookup_kwarg]
+
+            try:
+                # use the Django ORM to lookup this value, e.g., obj.parent.pk
+                lookup_value = request.parser_context["kwargs"][underscored_lookup]
+            except AttributeError:
+                # Not nested. Act like a standard HyperlinkedRelatedField
+                return super().get_url(obj, view_name, request, format)
+
+            # store the lookup_name and value in kwargs, which is later passed to the reverse method
+            kwargs.update({parent_lookup_kwarg: lookup_value})
+
+        return self.reverse(view_name, kwargs=kwargs, request=request, format=format)
 
 
-class SiteHyperlinkedIdentityField(NestedHyperlinkedIdentityField):
-    parent_lookup_kwargs = {"site_slug": "site__slug"}
+class SiteHyperlinkedIdentityField(SiteHyperlinkedRelatedField):
+    """
+    Supports nested URLs. Will use the view kwarg values named in parent_lookup_kwargs as literal
+    values when reversing the URL, to eliminate extra database queries. This means this will only work within
+    views that have the same nested structure as the target URL. For use in other contexts, see
+    NestedHyperlinkedIdentityField.
+    """
+
+    def __init__(self, view_name=None, **kwargs):
+        assert view_name is not None, "The `view_name` argument is required."
+        kwargs["read_only"] = True
+        kwargs["source"] = "*"
+        super().__init__(view_name=view_name, **kwargs)


### PR DESCRIPTION
### Description of Changes
Straight refactoring with no visible change in the responses. The SiteHyperlinkedRelatedField and Identity field were making one db request every time they generated a url, in order to get the site slug. This would be reasonable if we were linking to objects from multiple sites, but for all of our current cases we are always linking within the same site. I changed it to reuse the site slug from the view’s kwargs, to eliminate the extra db queries. If multi-site cases come up in the future, we can use NestedHyperlinkedRelatedField.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
