### PR TITLE
FW-4416 Add util script to fetch exports from AWS S3 Buckets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -296,3 +296,6 @@ firstvoices/celerybeat-schedule.db
 
 # tmp files for tests
 firstvoices/backend/tests/tmp/
+
+# Downloaded export data directory
+/firstvoices/scripts/utils/export_data/

--- a/.gitignore
+++ b/.gitignore
@@ -298,4 +298,4 @@ firstvoices/celerybeat-schedule.db
 firstvoices/backend/tests/tmp/
 
 # Downloaded export data directory
-/firstvoices/scripts/utils/export_data/
+firstvoices/scripts/utils/export_data/

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ ___
    - `SENTRY_RELEASE`: a custom release version to tag Sentry events with (defaults to the commit SHA if not set).
    - `SENTRY_TRACES_SAMPLE_RATE`: the sample rate for error events, in the range of 0.0 to 1.0 (defaults to 1.0 if not set, meaning 100% of the errors are sent).
    - `DJANGO_ADMIN_URL`: sets the URL of the admin panel for security purposes (defaults to `admin/` if not set).
-   - `EXPORT_DATA_S3_BUCKET`: the name of the S3 Bucket that export data is stored in (if using the aws_download_utils.py script to download export data).
+   - `DATA_S3_BUCKET`: the name of the S3 Bucket that export data is stored in (if using the aws_download_utils.py script to download export data).
    - If using [venv](https://docs.python.org/3/library/venv.html)
      - You can add `export <variable name>=<variable value>` to the `<name for your venv>/bin/activate` file.
    - If using [direnv](https://direnv.net/)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ ___
    - `SENTRY_RELEASE`: a custom release version to tag Sentry events with (defaults to the commit SHA if not set).
    - `SENTRY_TRACES_SAMPLE_RATE`: the sample rate for error events, in the range of 0.0 to 1.0 (defaults to 1.0 if not set, meaning 100% of the errors are sent).
    - `DJANGO_ADMIN_URL`: sets the URL of the admin panel for security purposes (defaults to `admin/` if not set).
+   - `EXPORT_DATA_S3_BUCKET`: the name of the S3 Bucket that export data is stored in (if using the aws_download_utils.py script to download export data).
    - If using [venv](https://docs.python.org/3/library/venv.html)
      - You can add `export <variable name>=<variable value>` to the `<name for your venv>/bin/activate` file.
    - If using [direnv](https://direnv.net/)

--- a/firstvoices/scripts/utils/aws_download_utils.py
+++ b/firstvoices/scripts/utils/aws_download_utils.py
@@ -170,7 +170,3 @@ def download_latest_exports():
     for key in output_keys:
         download_file_from_s3(key)
     return True
-
-
-if __name__ == "__main__":
-    download_latest_exports()

--- a/firstvoices/scripts/utils/aws_download_utils.py
+++ b/firstvoices/scripts/utils/aws_download_utils.py
@@ -29,9 +29,9 @@ def get_aws_resource():
         )
         return False
 
-    if os.getenv("EXPORT_DATA_S3_BUCKET") is None:
+    if os.getenv("DATA_S3_BUCKET") is None:
         logger.error(
-            'Please set the "EXPORT_DATA_S3_BUCKET" environment variable to access AWS.'
+            'Please set the "DATA_S3_BUCKET" environment variable to access AWS.'
         )
         return False
 
@@ -49,7 +49,7 @@ def get_bucket():
         logger.error("Could not get AWS session.")
         return False
 
-    bucket = s3.Bucket(os.getenv("EXPORT_DATA_S3_BUCKET"))
+    bucket = s3.Bucket(os.getenv("DATA_S3_BUCKET"))
     if bucket is False:
         logger.error("Could not get AWS Bucket.")
         return False
@@ -59,7 +59,7 @@ def get_bucket():
 
 def download_file_from_s3(key):
     """
-    Downloads a single file from the S3 bucket specified by the EXPORT_DATA_S3_BUCKET environment variable given an
+    Downloads a single file from the S3 bucket specified by the DATA_S3_BUCKET environment variable given an
     object key. Files are stored in the "scripts/export_data/<timestamp for the file>/" directory.
 
     :param key: The object key string for the file.
@@ -87,7 +87,7 @@ def download_file_from_s3(key):
         os.makedirs(storage_directory)
     try:
         client.download_file(
-            os.getenv("EXPORT_DATA_S3_BUCKET"), key, f"{storage_directory}/{file_name}"
+            os.getenv("DATA_S3_BUCKET"), key, f"{storage_directory}/{file_name}"
         )
         logger.info(
             f"Downloaded file ({file_name}) to ({storage_directory}) successfully."

--- a/firstvoices/scripts/utils/aws_download_utils.py
+++ b/firstvoices/scripts/utils/aws_download_utils.py
@@ -1,0 +1,144 @@
+import logging
+import os
+import re
+from datetime import datetime
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+
+def get_session():
+    """
+    Gets a boto3 AWS session which can be used to access various AWS services.
+
+    :return: A boto3 AWS sessions if the environment variables are set, else false.
+    """
+
+    if os.getenv("AWS_ACCESS_KEY_ID") is None:
+        logger.error(
+            'Please set the "AWS_ACCESS_KEY_ID" environment variable to access AWS.'
+        )
+        return False
+    if os.getenv("AWS_SECRET_ACCESS_KEY") is None:
+        logger.error(
+            'Please set the "AWS_SECRET_ACCESS_KEY" environment variable to access AWS.'
+        )
+        return False
+
+    if os.getenv("EXPORT_DATA_S3_BUCKET") is None:
+        logger.error(
+            'Please set the "EXPORT_DATA_S3_BUCKET" environment variable to access AWS.'
+        )
+        return False
+
+    return boto3.Session(
+        aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+        aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+    )
+
+
+def download_file_from_s3(key):
+    """
+    Downloads a single file from the S3 bucket specified by the EXPORT_DATA_S3_BUCKET environment variable given an
+    object key. Files are stored in the "scripts/export_data/<timestamp for the file>/" directory.
+
+    :param key: The object key string for the file.
+    :return: True if the file was successfully downloaded, else False.
+    """
+
+    if key is None:
+        logger.error("Missing key for file to download.")
+        return False
+
+    file_name = re.sub(r".*\/", "", key)
+    timestamp = re.search(
+        r"\d{4}-\d{2}-\d{2}-\d{2}:\d{2}:\d{2}.\d{6}", file_name
+    ).group(0)
+
+    client = get_session().resource("s3").meta.client
+    if not client:
+        logger.error(
+            f"Could not get client. File ({file_name}) was not downloaded successfully."
+        )
+        return False
+
+    storage_directory = (
+        f"{os.path.dirname(os.path.abspath(__file__))}/export_data/{timestamp}"
+    )
+    if not os.path.exists(storage_directory):
+        os.makedirs(storage_directory)
+    try:
+        client.download_file(
+            os.getenv("EXPORT_DATA_S3_BUCKET"), key, f"{storage_directory}/{file_name}"
+        )
+        logger.info(
+            f"Downloaded file ({file_name}) to ({storage_directory}) successfully."
+        )
+    except ClientError as e:
+        logging.error(f"Object ({key}) was not downloaded from AWS successfully.", e)
+        return False
+    return True
+
+
+def download_directory_from_s3(directory_name):
+    """
+    Downloads all files from the S3 bucket given a directory name (the timestamp that the export was created at).
+    Files are stored in the "scripts/export_data/<timestamp for the files>/" directory.
+
+    :param directory_name: The name of the directory to download all files from (the directory name is a timestamp
+    string in isoformat).
+    :return: True if the files were successfully downloaded, else False.
+    """
+
+    s3 = get_session().resource("s3")
+    if not s3:
+        logger.error("Could not get AWS session.")
+        return False
+
+    bucket = s3.Bucket(os.getenv("EXPORT_DATA_S3_BUCKET"))
+    if not bucket:
+        logger.error("Could not get AWS Bucket.")
+        return False
+
+    objects = bucket.objects.filter(Prefix=directory_name)
+    for file in objects:
+        download_file_from_s3(file.key)
+    return True
+
+
+def download_exports_after_timestamp(timestamp):
+    """
+    Downloads all files from the S3 bucket that have a timestamp greater or equal to the input timestamp. Files are
+    stored in the "scripts/export_data/<timestamp for the files>/" directory.
+
+    :param timestamp: The timestamp in isoformat specifying the time cutoff. All files with a timestamp after this
+    timestamp will be downloaded.
+    :return: True if the files were successfully downloaded, else False.
+    """
+
+    s3 = get_session().resource("s3")
+    if not s3:
+        logger.error("Could not get AWS session.")
+        return False
+
+    bucket = s3.Bucket(os.getenv("EXPORT_DATA_S3_BUCKET"))
+    if not bucket:
+        logger.error("Could not get AWS Bucket.")
+        return False
+
+    objects = bucket.objects.all()
+
+    objects_after_timestamp = [
+        file
+        for file in objects
+        if datetime.fromisoformat(
+            re.search(r"\d{4}-\d{2}-\d{2}-\d{2}:\d{2}:\d{2}.\d{6}", file.key).group(0)
+        )
+        >= datetime.fromisoformat(timestamp)
+    ]
+
+    for file in objects_after_timestamp:
+        download_file_from_s3(file.key)
+    return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ async-timeout==4.0.2
 attrs==23.1.0
 billiard==3.6.4.0
 boto3==1.26.143
+botocore>=1.29.139
 celery==5.2.7
 certifi==2023.5.7
 cffi==1.15.1


### PR DESCRIPTION
### Description of Changes
This PR adds a small utility script which can be used in the data import tool.

All files are saved in the following location: `firstvoices/scripts/export_data/<timestamp for the file>/<filename>.csv`

The script contains the following core functions (as well as a few helper functions):
- `download_file_from_s3(key)` which takes in a key and saves the corresponding file locally.
- `download_directory_from_s3(directory_name)` which takes in a directory name (or prefix corresponding to a timestamp in the s3 bucket key) and saves all files with that prefix in the key.
- `download_exports_after_timestamp(timestamp)` which takes in a timestamp and will download all files with a timestamp greater than or equal to the input timestamp.
- `download_latest_exports()` finds the most recent timestamp in the S3 Bucket and downloads all files with that exact timestamp.

See FW-4416 on Jira for testing instructions.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
