### PR TITLE
fw-4165, add back groups property on user model

### DIFF
--- a/firstvoices/backend/models/user.py
+++ b/firstvoices/backend/models/user.py
@@ -52,12 +52,8 @@ class User(AbstractUser):
     def is_authenticated(self):
         return True
 
-    @property
-    def groups(self):
-        return None
-
     def __str__(self):
-        return str(self.id)
+        return str(self.email)
 
     @property
     def natural_key(self):


### PR DESCRIPTION
### Description of Changes
* Django's backend for model authentication expects this property to exist, so we can run into unexpected exceptions when it doesn't.
* Bonus change: user string display is email instead of the inscrutable id

### Checklist
- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
