### PR TITLE
FW-4406 Convert Parts of Speech to Flat List

### DIFF
--- a/firstvoices/backend/serializers/parts_of_speech_serializers.py
+++ b/firstvoices/backend/serializers/parts_of_speech_serializers.py
@@ -3,15 +3,15 @@ from rest_framework import serializers
 from backend.models.part_of_speech import PartOfSpeech
 
 
-class PartsOfSpeechChildrenSerializer(serializers.ModelSerializer):
+class PartsOfSpeechParentSerializer(serializers.ModelSerializer):
     class Meta:
         model = PartOfSpeech
         fields = ["id", "title"]
 
 
 class PartsOfSpeechSerializer(serializers.ModelSerializer):
-    children = PartsOfSpeechChildrenSerializer(many=True)
+    parent = PartsOfSpeechParentSerializer()
 
     class Meta:
         model = PartOfSpeech
-        fields = ["id", "title", "children"]
+        fields = ["id", "title", "parent"]

--- a/firstvoices/backend/tests/test_apis/test_parts_of_speech_api.py
+++ b/firstvoices/backend/tests/test_apis/test_parts_of_speech_api.py
@@ -1,105 +1,92 @@
 import json
 
-from rest_framework.reverse import reverse
-from rest_framework.test import APIClient
-
 from backend.models.constants import AppRole
 from backend.tests.factories import get_app_admin
 
+from .base_api_test import BaseApiTest
 
-class TestPartsOfSpeechAPI:
+
+class TestPartsOfSpeechAPI(BaseApiTest):
     """Tests for parts-of-speech views."""
 
     FIXTURE_FILE = "partsOfSpeech_initial.json"
     API_LIST_VIEW = "api:partofspeech-list"
     API_DETAIL_VIEW = "api:partofspeech-detail"
-    APP_NAME = "backend"
+    NUMBER_OF_PARTS_OF_SPEECH = 41
 
-    def test_base_case_list_view(self, db):
-        # Testing the view returns a list of parts-of-speech
+    def test_list_view(self, db):
+        """Test that the list view returns the expected number of parts-of-speech."""
 
-        client = APIClient()
         member_user = get_app_admin(AppRole.STAFF)
-        client.force_authenticate(user=member_user)
-        response = client.get(reverse(self.API_LIST_VIEW, current_app=self.APP_NAME))
-        content = json.loads(response.content)["results"]
+        self.client.force_authenticate(user=member_user)
+        response = self.client.get(self.get_list_endpoint())
+        response_data = json.loads(response.content)
 
         assert response.status_code == 200
-        assert len(content) > 0
+        assert response_data["count"] == self.NUMBER_OF_PARTS_OF_SPEECH
 
-    def test_retrieve_base_case(self, db):
-        """Test case for retrieve case to verify different querysets working for list and detail view."""
+    def test_list_view_format(self, db):
+        """Test that the list view returns the expected fields."""
 
-        client = APIClient()
         member_user = get_app_admin(AppRole.STAFF)
-        client.force_authenticate(user=member_user)
-        response_list = client.get(
-            reverse(
-                self.API_LIST_VIEW,
-                current_app=self.APP_NAME,
-            ),
-            format="json",
-        )
-        content_list = json.loads(response_list.content)["results"]
+        self.client.force_authenticate(user=member_user)
+
+        response = self.client.get(self.get_list_endpoint())
+        response_data = json.loads(response.content)["results"]
+
+        assert response.status_code == 200
+        assert isinstance(response_data, list)
+        assert len(response_data) > 0
+
+        item = None
+        for x in response_data:
+            if x["parent"]:
+                item = x
+                break
+
+        # Checking for required keys and their response structure
+        assert "id" in item
+        assert "title" in item
+        assert "parent" in item
+
+        assert isinstance(item["id"], str)
+        assert isinstance(item["title"], str)
+        assert isinstance(item["parent"], dict)
+
+    def test_detail_view(self, db):
+        """Test that the detail view returns the expected data."""
+        member_user = get_app_admin(AppRole.STAFF)
+        self.client.force_authenticate(user=member_user)
+
+        response_list = self.client.get(self.get_list_endpoint(), format="json")
+        list_data = json.loads(response_list.content)["results"]
 
         # Looking for a specific item with no children, to test the retrieve queryset
         # test will fail if fixture not loaded since there will be no items without any children in the response to
         # choose the first element from. If fixture is modified in such as way that all elements now have children at
         # top level, Create another fixture for testing purposes with one such element.
-        items = [entry for entry in content_list if len(entry["children"]) == 0]
-        item = items[0]
-        pk = item["id"]
+        item = None
+        for x in list_data:
+            if x["parent"]:
+                item = x
+                break
 
-        response = client.get(
-            reverse(self.API_DETAIL_VIEW, current_app="backend", args=[pk]),
-            format="json",
-        )
-        response_obj = json.loads(response.content)
+        response = self.client.get(self.get_detail_endpoint(item["id"]))
+        response_data = json.loads(response.content)
 
         assert response.status_code == 200
-        assert "id" in response_obj
-        assert "title" in response_obj
-        assert "children" in response_obj
+        assert "id" in response_data
+        assert "title" in response_data
+        assert "parent" in response_data
 
-        assert isinstance(response_obj["id"], str)
-        assert isinstance(response_obj["title"], str)
-        assert isinstance(response_obj["children"], list)
+        assert isinstance(response_data["id"], str)
+        assert isinstance(response_data["title"], str)
+        assert isinstance(response_data["parent"], dict)
 
-    def test_retrieve_not_found(self, db):
-        # Testing the view returns 404 if parts of speech not found
+    def test_detail_not_found(self, db):
+        """Test that the detail view returns 404 for an invalid id."""
 
-        client = APIClient()
         member_user = get_app_admin(AppRole.STAFF)
-        client.force_authenticate(user=member_user)
-        response = client.get(
-            reverse(
-                self.API_DETAIL_VIEW,
-                current_app=self.APP_NAME,
-                args=["123_not_valid_key"],
-            ),
-            format="json",
-        )
+        self.client.force_authenticate(user=member_user)
+        response = self.client.get(self.get_detail_endpoint("invalid_id"))
         assert response.status_code == 404
-
-    def test_response_format_list_view(self, db):
-        # Testing the format of the content returned by list view for parts of speech
-
-        client = APIClient()
-        member_user = get_app_admin(AppRole.STAFF)
-        client.force_authenticate(user=member_user)
-        response = client.get(reverse(self.API_LIST_VIEW, current_app=self.APP_NAME))
-        content = json.loads(response.content)["results"]
-
-        assert isinstance(content, list)
-        assert len(content) > 0
-
-        sample_obj = content[1]
-
-        # Checking for required keys and their response structure
-        assert "id" in sample_obj
-        assert "title" in sample_obj
-        assert "children" in sample_obj
-
-        assert isinstance(sample_obj["id"], str)
-        assert isinstance(sample_obj["title"], str)
-        assert isinstance(sample_obj["children"], list)

--- a/firstvoices/backend/views/parts_of_speech_views.py
+++ b/firstvoices/backend/views/parts_of_speech_views.py
@@ -21,4 +21,4 @@ from backend.views.base_views import FVPermissionViewSetMixin
 class PartsOfSpeechViewSet(FVPermissionViewSetMixin, ModelViewSet):
     http_method_names = ["get"]
     serializer_class = PartsOfSpeechSerializer
-    queryset = PartOfSpeech.objects.prefetch_related("children").all()
+    queryset = PartOfSpeech.objects.prefetch_related("parent").all()

--- a/firstvoices/backend/views/parts_of_speech_views.py
+++ b/firstvoices/backend/views/parts_of_speech_views.py
@@ -22,9 +22,3 @@ class PartsOfSpeechViewSet(FVPermissionViewSetMixin, ModelViewSet):
     http_method_names = ["get"]
     serializer_class = PartsOfSpeechSerializer
     queryset = PartOfSpeech.objects.prefetch_related("children").all()
-
-    @staticmethod
-    def get_list_queryset():
-        return PartOfSpeech.objects.prefetch_related("children").exclude(
-            parent__isnull=False
-        )


### PR DESCRIPTION
### Description of Changes
This PR changes the parts of speech API such that it return a flat list of all items, and converts the "children" field to a "parent" field. The tests have also been updated to better fit the BaseApiTest class.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
