### PR TITLE
fw-4212, remove edit permission for staff admins

### DIFF
--- a/firstvoices/backend/models/category.py
+++ b/firstvoices/backend/models/category.py
@@ -26,9 +26,9 @@ class Category(BaseSiteContentModel):
         ordering = ["title"]
         rules_permissions = {
             "view": predicates.has_visible_site,
-            "add": predicates.is_at_least_language_admin,
-            "change": predicates.is_at_least_language_admin,
-            "delete": predicates.is_at_least_language_admin,
+            "add": predicates.is_language_admin_or_super,
+            "change": predicates.is_language_admin_or_super,
+            "delete": predicates.is_language_admin_or_super,
         }
 
     def __str__(self):

--- a/firstvoices/backend/permissions/filters/base.py
+++ b/firstvoices/backend/permissions/filters/base.py
@@ -117,27 +117,6 @@ def is_superadmin(user):
 
 
 #
-# Role-based filters for site + app role combos
-#
-
-
-def is_at_least_member(user):
-    return has_at_least_member_membership(user) | is_at_least_staff_admin(user)
-
-
-def is_at_least_assistant(user):
-    return has_at_least_assistant_membership(user) | is_at_least_staff_admin(user)
-
-
-def is_at_least_editor(user):
-    return has_at_least_editor_membership(user) | is_at_least_staff_admin(user)
-
-
-def is_at_least_language_admin(user):
-    return has_at_least_language_admin_membership(user) | is_at_least_staff_admin(user)
-
-
-#
 # access-based filters
 #
 def has_public_access_to_obj(user=None):

--- a/firstvoices/backend/permissions/predicates/__init__.py
+++ b/firstvoices/backend/permissions/predicates/__init__.py
@@ -1,3 +1,4 @@
 from .base import *  # noqa F401
+from .edit import *  # noqa F401
 from .view import *  # noqa F401
 from .view_models import *  # noqa F401

--- a/firstvoices/backend/permissions/predicates/base.py
+++ b/firstvoices/backend/permissions/predicates/base.py
@@ -66,7 +66,7 @@ def has_at_least_editor_membership(user, obj):
 
 
 @predicate
-def has_at_least_language_admin_membership(user, obj):
+def has_language_admin_membership(user, obj):
     return get_site_role(user, obj) >= Role.LANGUAGE_ADMIN
 
 
@@ -78,25 +78,6 @@ def is_at_least_staff_admin(user, obj):
 @predicate
 def is_superadmin(user, obj):
     return get_app_role(user) == AppRole.SUPERADMIN
-
-
-#
-# role predicates for site + app roles
-#
-is_at_least_member = predicate(
-    has_at_least_member_membership | is_at_least_staff_admin, name="is_at_least_member"
-)
-is_at_least_assistant = predicate(
-    has_at_least_assistant_membership | is_at_least_staff_admin,
-    name="is_at_least_assistant",
-)
-is_at_least_editor = predicate(
-    has_at_least_editor_membership | is_at_least_staff_admin, name="is_at_least_editor"
-)
-is_at_least_language_admin = predicate(
-    has_at_least_language_admin_membership | is_at_least_staff_admin,
-    name="is_at_least_language_admin",
-)
 
 
 #

--- a/firstvoices/backend/permissions/predicates/edit.py
+++ b/firstvoices/backend/permissions/predicates/edit.py
@@ -1,0 +1,24 @@
+from rules import predicate
+
+from .base import (
+    has_at_least_assistant_membership,
+    has_at_least_editor_membership,
+    has_language_admin_membership,
+    is_superadmin,
+)
+
+#
+# role-based predicates for edit permissions
+#
+
+is_at_least_assistant_or_super = predicate(
+    has_at_least_assistant_membership | is_superadmin,
+    name="is_at_least_assistant_or_super",
+)
+is_at_least_editor_or_super = predicate(
+    has_at_least_editor_membership | is_superadmin, name="is_at_least_editor_or_super"
+)
+is_language_admin_or_super = predicate(
+    has_language_admin_membership | is_superadmin,
+    name="is_at_least_language_admin_or_super",
+)

--- a/firstvoices/backend/permissions/predicates/view_models.py
+++ b/firstvoices/backend/permissions/predicates/view_models.py
@@ -21,7 +21,7 @@ can_view_site_model = Predicate(
 can_view_membership_model = Predicate(
     (
         base.is_at_least_staff_admin
-        | base.has_at_least_language_admin_membership
+        | base.has_language_admin_membership
         | base.is_own_obj
     ),
     name="can_view_membership_model",

--- a/firstvoices/backend/tests/test_permissions/test_predicate_base.py
+++ b/firstvoices/backend/tests/test_permissions/test_predicate_base.py
@@ -143,7 +143,7 @@ class TestBaseSiteRolePredicates:
         site = SiteFactory.create(id=1)
         MembershipFactory.create(user=user, site=site, role=role)
         obj = ControlledSiteContentFactory.build(site=site)
-        assert base.has_at_least_language_admin_membership(user, obj)
+        assert base.has_language_admin_membership(user, obj)
 
     @pytest.mark.django_db
     @pytest.mark.parametrize("role", [Role.MEMBER, Role.ASSISTANT, Role.EDITOR])
@@ -152,7 +152,7 @@ class TestBaseSiteRolePredicates:
         site = SiteFactory.create(id=1)
         MembershipFactory.create(user=user, site=site, role=role)
         obj = ControlledSiteContentFactory.build(site=site)
-        assert base.has_at_least_language_admin_membership(user, obj) is False
+        assert base.has_language_admin_membership(user, obj) is False
 
     @pytest.mark.django_db
     @pytest.mark.parametrize(
@@ -161,7 +161,7 @@ class TestBaseSiteRolePredicates:
             base.has_at_least_member_membership,
             base.has_at_least_assistant_membership,
             base.has_at_least_editor_membership,
-            base.has_at_least_language_admin_membership,
+            base.has_language_admin_membership,
         ],
     )
     def test_is_anonymous(self, predicate):
@@ -202,23 +202,6 @@ class TestBaseAppRolePredicates:
         user = UserFactory.create()
         obj = SiteFactory.create()
         assert not base.is_superadmin(user, obj)
-
-
-class TestBaseComboRolePredicates:
-    @pytest.mark.django_db
-    @pytest.mark.parametrize(
-        "predicate",
-        [
-            base.is_at_least_member,
-            base.is_at_least_assistant,
-            base.is_at_least_editor,
-            base.is_at_least_language_admin,
-        ],
-    )
-    def test_is_at_least_x_for_app_admin(self, predicate):
-        user = get_app_admin(AppRole.STAFF)
-        obj = SiteFactory.create()
-        assert predicate(user, obj)
 
 
 class TestBaseObjectAccessPredicates:

--- a/firstvoices/backend/tests/test_permissions/test_predicate_edit.py
+++ b/firstvoices/backend/tests/test_permissions/test_predicate_edit.py
@@ -1,0 +1,35 @@
+import pytest
+
+from backend.models.constants import AppRole
+from backend.permissions.predicates import edit
+from backend.tests.factories import SiteFactory, get_app_admin
+
+
+class TestEditRolePredicates:
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        "predicate",
+        [
+            edit.is_at_least_assistant_or_super,
+            edit.is_at_least_editor_or_super,
+            edit.is_language_admin_or_super,
+        ],
+    )
+    def test_superadmin_can_edit(self, predicate):
+        user = get_app_admin(AppRole.SUPERADMIN)
+        obj = SiteFactory.create()
+        assert predicate(user, obj)
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        "predicate",
+        [
+            edit.is_at_least_assistant_or_super,
+            edit.is_at_least_editor_or_super,
+            edit.is_language_admin_or_super,
+        ],
+    )
+    def test_staff_admin_can_not_edit(self, predicate):
+        user = get_app_admin(AppRole.STAFF)
+        obj = SiteFactory.create()
+        assert not predicate(user, obj)


### PR DESCRIPTION
### Description of Changes
* staff admins can't edit categories, so i changed the predicates to reflect that
* i moved the edit-specific predicates to their own file and removed the matching filters, since we never need to retrieve a queryset based on edit permissions

### Checklist
- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
