### PR TITLE
Fw 4464 add a full text field to mappings and also subquery for full text search

### DIFF
--- a/firstvoices/backend/search/indices/dictionary_entry_document.py
+++ b/firstvoices/backend/search/indices/dictionary_entry_document.py
@@ -108,6 +108,9 @@ def update_translation(sender, instance, **kwargs):
         existing_entry = get_object_from_index(
             ELASTICSEARCH_DICTIONARY_ENTRY_INDEX, dictionary_entry.id
         )
+        if not existing_entry:
+            raise NotFoundError
+
         dictionary_entry_doc = DictionaryEntryDocument.get(id=existing_entry["_id"])
         dictionary_entry_doc.update(
             translation=" ".join(translations_text),
@@ -145,6 +148,9 @@ def update_notes(sender, instance, **kwargs):
         existing_entry = get_object_from_index(
             ELASTICSEARCH_DICTIONARY_ENTRY_INDEX, dictionary_entry.id
         )
+        if not existing_entry:
+            raise NotFoundError
+
         dictionary_entry_doc = DictionaryEntryDocument.get(id=existing_entry["_id"])
         dictionary_entry_doc.update(note=" ".join(notes_text))
     except ConnectionError:

--- a/firstvoices/backend/search/indices/dictionary_entry_document.py
+++ b/firstvoices/backend/search/indices/dictionary_entry_document.py
@@ -5,7 +5,7 @@ from django.dispatch import receiver
 from elasticsearch.exceptions import ConnectionError, NotFoundError
 from elasticsearch_dsl import Document, Index, Keyword, Text
 
-from backend.models.dictionary import DictionaryEntry, Translation
+from backend.models.dictionary import DictionaryEntry, Note, Translation
 from backend.search.utils.constants import (
     ES_CONNECTION_ERROR,
     ES_NOT_FOUND_ERROR,
@@ -26,13 +26,16 @@ dictionary_entries.settings(
 @dictionary_entries.document
 class DictionaryEntryDocument(Document):
     # generic fields, will be moved to a base search document once we have songs and stories
-    _id = Text()
+    document_id = Text()
     site_slug = Keyword()
+    full_text_search_field = Text()
 
     # Dictionary Related fields
     type = Keyword()
-    title = Text(analyzer="standard", ignore_above=256)
-    translation = Text(analyzer="standard", ignore_above=256)
+    title = Text(analyzer="standard", copy_to="full_text_search_field")
+    translation = Text(analyzer="standard", copy_to="full_text_search_field")
+    note = Text(copy_to="full_text_search_field")
+    part_of_speech = Text(copy_to="full_text_search_field")
 
     class Index:
         name = ELASTICSEARCH_DICTIONARY_ENTRY_INDEX
@@ -44,7 +47,7 @@ def update_index(sender, instance, **kwargs):
     # Add document to es index
     try:
         index_entry = DictionaryEntryDocument(
-            _id=instance.id,
+            document_id=instance.id,
             site_slug=instance.site.slug,
             title=instance.title,
             type=instance.type,
@@ -81,14 +84,27 @@ def delete_from_index(sender, instance, **kwargs):
 
 
 # Translation update
+@receiver(post_delete, sender=Translation)
 @receiver(post_save, sender=Translation)
 def update_translation(sender, instance, **kwargs):
     logger = logging.getLogger(ELASTICSEARCH_LOGGER)
     dictionary_entry = instance.dictionary_entry
+    translation_set = dictionary_entry.translation_set.all()
+
+    translations_text = []
+    part_of_speech_titles = []
+
+    for t in translation_set:
+        translations_text.append(t.text)
+        if t.part_of_speech:
+            part_of_speech_titles.append(t.part_of_speech.title)
 
     try:
         dictionary_entry_doc = DictionaryEntryDocument.get(id=dictionary_entry.id)
-        dictionary_entry_doc.update(translation=instance.text)
+        dictionary_entry_doc.update(
+            translation=" ".join(translations_text),
+            part_of_speech=" ".join(part_of_speech_titles),
+        )
     except ConnectionError:
         logger.warning(
             ES_CONNECTION_ERROR % (SearchIndexEntryTypes.DICTIONARY_ENTRY, instance.id)
@@ -97,22 +113,29 @@ def update_translation(sender, instance, **kwargs):
         logger.warning(
             ES_NOT_FOUND_ERROR
             % (
-                "translation_post_save",
+                "translation_update_signal",
                 SearchIndexEntryTypes.DICTIONARY_ENTRY,
                 dictionary_entry.id,
             )
         )
 
 
-# Translation update
-@receiver(post_delete, sender=Translation)
-def delete_translation(sender, instance, **kwargs):
+# Note update
+@receiver(post_delete, sender=Note)
+@receiver(post_save, sender=Note)
+def update_notes(sender, instance, **kwargs):
     logger = logging.getLogger(ELASTICSEARCH_LOGGER)
     dictionary_entry = instance.dictionary_entry
+    notes_set = dictionary_entry.note_set.all()
+
+    notes_text = []
+
+    for note in notes_set:
+        notes_text.append(note.text)
 
     try:
         dictionary_entry_doc = DictionaryEntryDocument.get(id=dictionary_entry.id)
-        dictionary_entry_doc.update(translation=None)
+        dictionary_entry_doc.update(note=" ".join(notes_text))
     except ConnectionError:
         logger.warning(
             ES_CONNECTION_ERROR % (SearchIndexEntryTypes.DICTIONARY_ENTRY, instance.id)
@@ -121,7 +144,7 @@ def delete_translation(sender, instance, **kwargs):
         logger.warning(
             ES_NOT_FOUND_ERROR
             % (
-                "translation_post_delete",
+                "notes_update_signal",
                 SearchIndexEntryTypes.DICTIONARY_ENTRY,
                 dictionary_entry.id,
             )

--- a/firstvoices/backend/search/utils/constants.py
+++ b/firstvoices/backend/search/utils/constants.py
@@ -1,6 +1,9 @@
 from django.db.models import TextChoices
 from django.utils.translation import gettext as _
 
+# Index names
+ELASTICSEARCH_DICTIONARY_ENTRY_INDEX = "dictionary_entry"
+
 # Error messages
 ES_CONNECTION_ERROR = (
     "Elasticsearch server down. Document could not be updated in index. %s id: %s"

--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -42,7 +42,7 @@ def get_search_term_query(search_term):
                 "title": {
                     "query": search_term,
                     "slop": 3,  # How far apart the terms can be in order to match
-                    "boost": 1.3,
+                    "boost": 1.1,
                 }
             }
         }
@@ -57,6 +57,24 @@ def get_search_term_query(search_term):
             }
         }
     )
+    multi_match_query = Q(
+        {
+            "multi_match": {
+                "query": search_term,
+                "fields": ["title", "full_text_search_field"],
+                "type": "phrase",
+                "operator": "OR",
+                "boost": 1.3,
+            }
+        }
+    )
+    text_search_field_match_query = Q(
+        {
+            "match_phrase": {
+                "full_text_search_field": {"query": search_term, "boost": 1.5}
+            }
+        }
+    )
     return Q(
         "bool",
         should=[
@@ -64,6 +82,8 @@ def get_search_term_query(search_term):
             exact_match_title_query,
             fuzzy_match_translation_query,
             exact_match_translation_query,
+            multi_match_query,
+            text_search_field_match_query,
         ],
         minimum_should_match=1,
     )

--- a/firstvoices/backend/tests/test_search/test_query_params.py
+++ b/firstvoices/backend/tests/test_search/test_query_params.py
@@ -22,7 +22,7 @@ class TestQueryParams:
             "'fuzzy': {'title': {'value': 'test', 'fuzziness': '2'}}"
         )
         expected_exact_match_title_string = (
-            "'match_phrase': {'title': {'query': 'test', 'slop': 3, 'boost': 1.3}}"
+            "'match_phrase': {'title': {'query': 'test', 'slop': 3, 'boost': 1.1}}"
         )
         expected_fuzzy_match_translation_string = (
             "'fuzzy': {'translation': {'value': 'test', 'fuzziness': '2'}}"
@@ -31,11 +31,21 @@ class TestQueryParams:
             "'match_phrase': {'translation': {'query': "
             "'test', 'slop': 3, 'boost': 1.1}}"
         )
+        expected_multi_match_string = (
+            "'multi_match': {'query': 'test', 'fields': ['title', "
+            "'full_text_search_field'], 'type': 'phrase', 'operator': 'OR', 'boost': 1.3}"
+        )
+        expected_match_full_text_search_string = (
+            "'match_phrase': {'full_text_search_field': "
+            "{'query': 'test', 'boost': 1.5}}"
+        )
 
         assert expected_fuzzy_match_title_string in str(search_query)
         assert expected_exact_match_title_string in str(search_query)
         assert expected_fuzzy_match_translation_string in str(search_query)
         assert expected_exact_match_translation_string in str(search_query)
+        assert expected_multi_match_string in str(search_query)
+        assert expected_match_full_text_search_string in str(search_query)
 
     def test_valid_with_special_chars_query(self):
         # relates to: SearchQueryTest.java - testValidQuery()
@@ -48,7 +58,7 @@ class TestQueryParams:
         )
         expected_exact_match_string = (
             "'match_phrase': {'title': {'query': "
-            "'A Valid Query **With $@&*456Ŧ specials!', 'slop': 3, 'boost': 1.3}}"
+            "'A Valid Query **With $@&*456Ŧ specials!', 'slop': 3, 'boost': 1.1}}"
         )
         expected_fuzzy_match_translation_string = (
             "'fuzzy': {'translation': {'value': "
@@ -58,8 +68,18 @@ class TestQueryParams:
             "'match_phrase': {'translation': {'query': "
             "'A Valid Query **With $@&*456Ŧ specials!', 'slop': 3, 'boost': 1.1}}"
         )
+        expected_multi_match_string = (
+            "'multi_match': {'query': 'A Valid Query **With $@&*456Ŧ specials!', 'fields': ['title', "
+            "'full_text_search_field'], 'type': 'phrase', 'operator': 'OR', 'boost': 1.3}"
+        )
+        expected_match_full_text_search_string = (
+            "'match_phrase': {'full_text_search_field': {'query': 'A Valid Query **With $@&*456Ŧ specials!', 'boost': "
+            "1.5}}"
+        )
 
         assert expected_fuzzy_match_string in str(search_query)
         assert expected_exact_match_string in str(search_query)
         assert expected_fuzzy_match_translation_string in str(search_query)
         assert expected_exact_match_translation_string in str(search_query)
+        assert expected_multi_match_string in str(search_query)
+        assert expected_match_full_text_search_string in str(search_query)


### PR DESCRIPTION
### Description of Changes
- renamed `_id` to `document_id` to have separate postgres and elasticsearch ids
- Added a full_text_search_field where title, translation, notes and parts of speech text are copied to be queried. Title, translation are also queried separately.
- Refactored create/update/delete signals for dictionary_entry index document to reflect the primary key change mentioned above 
- Added subquery for the full_text_search_field and also updated the tests to reflect the change
- Added `notes` update signal, and updated `translation` update signal to add index parts of speech text
- moved ELASTICSEARCH_DICTIONARY_ENTRY_INDEX variable to utils/constants
- Added a function to object_utils to fetch entry from index based on `document_id`

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
