### PR TITLE
FW-4421 Standardize search domain

### DIFF
--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -164,9 +164,9 @@ def get_valid_domain(input_domain_str):
     string_lower = input_domain_str.lower()
 
     if (
-        string_lower == SearchDomains.BOTH
-        or string_lower == SearchDomains.LANGUAGE
-        or string_lower == SearchDomains.ENGLISH
+        string_lower == SearchDomains.BOTH.value
+        or string_lower == SearchDomains.LANGUAGE.value
+        or string_lower == SearchDomains.ENGLISH.value
     ):
         return string_lower
     else:  # if empty string is passed, or invalid option is passed

--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -60,6 +60,7 @@ def get_search_term_query(search_term, domain):
                 "title": {
                     "value": search_term,
                     "fuzziness": "2",  # Documentation recommends "AUTO" for this param
+                    "boost": 1.2,
                 }
             }
         }
@@ -70,18 +71,22 @@ def get_search_term_query(search_term, domain):
                 "title": {
                     "query": search_term,
                     "slop": 3,  # How far apart the terms can be in order to match
-                    "boost": 1.1,
+                    "boost": 1.5,
                 }
             }
         }
     )
     fuzzy_match_translation_query = Q(
-        {"fuzzy": {"translation": {"value": search_term, "fuzziness": "2"}}}
+        {
+            "fuzzy": {
+                "translation": {"value": search_term, "fuzziness": "2", "boost": 1.2}
+            }
+        }
     )
     exact_match_translation_query = Q(
         {
             "match_phrase": {
-                "translation": {"query": search_term, "slop": 3, "boost": 1.1}
+                "translation": {"query": search_term, "slop": 3, "boost": 1.5}
             }
         }
     )
@@ -92,14 +97,14 @@ def get_search_term_query(search_term, domain):
                 "fields": ["title", "full_text_search_field"],
                 "type": "phrase",
                 "operator": "OR",
-                "boost": 1.3,
+                "boost": 1.1,
             }
         }
     )
     text_search_field_match_query = Q(
         {
             "match_phrase": {
-                "full_text_search_field": {"query": search_term, "boost": 1.5}
+                "full_text_search_field": {"query": search_term, "boost": 1.0}
             }
         }
     )

--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -104,7 +104,7 @@ def get_search_term_query(search_term, domain):
         }
     )
 
-    subqueries = [multi_match_query, text_search_field_match_query]
+    subqueries = []
 
     subquery_domains = {
         "both": [
@@ -112,6 +112,8 @@ def get_search_term_query(search_term, domain):
             exact_match_title_query,
             fuzzy_match_translation_query,
             exact_match_translation_query,
+            multi_match_query,
+            text_search_field_match_query,
         ],
         "language": [fuzzy_match_title_query, exact_match_title_query],
         "english": [

--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -8,6 +8,11 @@ from backend.search.indices.dictionary_entry_document import (
 )
 from backend.search.utils.constants import VALID_DOCUMENT_TYPES
 
+BASE_BOOST = 1.0  # default value of boost
+FULL_TEXT_SEARCH_BOOST = 1.1
+FUZZY_MATCH_BOOST = 1.2
+EXACT_MATCH_BOOST = 1.5
+
 
 class SearchDomains(Enum):
     BOTH = "both"
@@ -60,7 +65,7 @@ def get_search_term_query(search_term, domain):
                 "title": {
                     "value": search_term,
                     "fuzziness": "2",  # Documentation recommends "AUTO" for this param
-                    "boost": 1.2,
+                    "boost": FUZZY_MATCH_BOOST,
                 }
             }
         }
@@ -71,7 +76,7 @@ def get_search_term_query(search_term, domain):
                 "title": {
                     "query": search_term,
                     "slop": 3,  # How far apart the terms can be in order to match
-                    "boost": 1.5,
+                    "boost": EXACT_MATCH_BOOST,
                 }
             }
         }
@@ -79,14 +84,22 @@ def get_search_term_query(search_term, domain):
     fuzzy_match_translation_query = Q(
         {
             "fuzzy": {
-                "translation": {"value": search_term, "fuzziness": "2", "boost": 1.2}
+                "translation": {
+                    "value": search_term,
+                    "fuzziness": "2",
+                    "boost": FUZZY_MATCH_BOOST,
+                }
             }
         }
     )
     exact_match_translation_query = Q(
         {
             "match_phrase": {
-                "translation": {"query": search_term, "slop": 3, "boost": 1.5}
+                "translation": {
+                    "query": search_term,
+                    "slop": 3,
+                    "boost": EXACT_MATCH_BOOST,
+                }
             }
         }
     )
@@ -97,14 +110,14 @@ def get_search_term_query(search_term, domain):
                 "fields": ["title", "full_text_search_field"],
                 "type": "phrase",
                 "operator": "OR",
-                "boost": 1.1,
+                "boost": FULL_TEXT_SEARCH_BOOST,
             }
         }
     )
     text_search_field_match_query = Q(
         {
             "match_phrase": {
-                "full_text_search_field": {"query": search_term, "boost": 1.0}
+                "full_text_search_field": {"query": search_term, "boost": BASE_BOOST}
             }
         }
     )

--- a/firstvoices/backend/tests/test_search/test_query_params.py
+++ b/firstvoices/backend/tests/test_search/test_query_params.py
@@ -113,10 +113,6 @@ class TestDomain:
         search_query = get_search_query(q="test_query", domain="english")
         search_query = search_query.to_dict()
 
-        # defaults to be tested once
-        assert self.expected_multi_match_string in str(search_query)
-        assert self.expected_match_full_text_search_string in str(search_query)
-
         # should contain translation matching
         assert self.expected_exact_match_translation_string in str(search_query)
         assert self.expected_fuzzy_match_translation_string in str(search_query)
@@ -150,3 +146,7 @@ class TestDomain:
         # should also contain translation matching
         assert self.expected_exact_match_translation_string in str(search_query)
         assert self.expected_fuzzy_match_translation_string in str(search_query)
+
+        # Should also contain the full text search matches
+        assert self.expected_multi_match_string in str(search_query)
+        assert self.expected_match_full_text_search_string in str(search_query)

--- a/firstvoices/backend/tests/test_search/test_query_params.py
+++ b/firstvoices/backend/tests/test_search/test_query_params.py
@@ -19,25 +19,26 @@ class TestQueryParams:
         search_query = search_query.to_dict()
 
         expected_fuzzy_match_title_string = (
-            "'fuzzy': {'title': {'value': 'test', 'fuzziness': '2'}}"
+            "'fuzzy': {'title': {'value': 'test', 'fuzziness': '2', 'boost': 1.2}}"
         )
         expected_exact_match_title_string = (
-            "'match_phrase': {'title': {'query': 'test', 'slop': 3, 'boost': 1.1}}"
+            "'match_phrase': {'title': {'query': 'test', 'slop': 3, 'boost': 1.5}}"
         )
         expected_fuzzy_match_translation_string = (
-            "'fuzzy': {'translation': {'value': 'test', 'fuzziness': '2'}}"
+            "'fuzzy': {'translation': {'value': 'test', 'fuzziness': '2', "
+            "'boost': 1.2}}"
         )
         expected_exact_match_translation_string = (
             "'match_phrase': {'translation': {'query': "
-            "'test', 'slop': 3, 'boost': 1.1}}"
+            "'test', 'slop': 3, 'boost': 1.5}}"
         )
         expected_multi_match_string = (
             "'multi_match': {'query': 'test', 'fields': ['title', "
-            "'full_text_search_field'], 'type': 'phrase', 'operator': 'OR', 'boost': 1.3}"
+            "'full_text_search_field'], 'type': 'phrase', 'operator': 'OR', 'boost': 1.1}"
         )
         expected_match_full_text_search_string = (
             "'match_phrase': {'full_text_search_field': "
-            "{'query': 'test', 'boost': 1.5}}"
+            "{'query': 'test', 'boost': 1.0}}"
         )
 
         assert expected_fuzzy_match_title_string in str(search_query)
@@ -54,27 +55,27 @@ class TestQueryParams:
 
         expected_fuzzy_match_string = (
             "'fuzzy': {'title': {'value': 'A Valid Query **With $@&*456Ŧ specials!', "
-            "'fuzziness': '2'}}"
+            "'fuzziness': '2', 'boost': 1.2}}"
         )
         expected_exact_match_string = (
             "'match_phrase': {'title': {'query': "
-            "'A Valid Query **With $@&*456Ŧ specials!', 'slop': 3, 'boost': 1.1}}"
+            "'A Valid Query **With $@&*456Ŧ specials!', 'slop': 3, 'boost': 1.5}}"
         )
         expected_fuzzy_match_translation_string = (
             "'fuzzy': {'translation': {'value': "
-            "'A Valid Query **With $@&*456Ŧ specials!', 'fuzziness': '2'}}"
+            "'A Valid Query **With $@&*456Ŧ specials!', 'fuzziness': '2', 'boost': 1.2}}"
         )
         expected_exact_match_translation_string = (
             "'match_phrase': {'translation': {'query': "
-            "'A Valid Query **With $@&*456Ŧ specials!', 'slop': 3, 'boost': 1.1}}"
+            "'A Valid Query **With $@&*456Ŧ specials!', 'slop': 3, 'boost': 1.5}}"
         )
         expected_multi_match_string = (
             "'multi_match': {'query': 'A Valid Query **With $@&*456Ŧ specials!', 'fields': ['title', "
-            "'full_text_search_field'], 'type': 'phrase', 'operator': 'OR', 'boost': 1.3}"
+            "'full_text_search_field'], 'type': 'phrase', 'operator': 'OR', 'boost': 1.1}"
         )
         expected_match_full_text_search_string = (
             "'match_phrase': {'full_text_search_field': {'query': 'A Valid Query **With $@&*456Ŧ specials!', 'boost': "
-            "1.5}}"
+            "1.0}}"
         )
 
         assert expected_fuzzy_match_string in str(search_query)
@@ -87,25 +88,26 @@ class TestQueryParams:
 
 class TestDomain:
     expected_fuzzy_match_string = (
-        "'fuzzy': {'title': {'value': 'test_query', 'fuzziness': '2'}}"
+        "'fuzzy': {'title': {'value': 'test_query', 'fuzziness': '2', 'boost': 1.2}}"
     )
     expected_exact_match_string = (
-        "'match_phrase': {'title': {'query': 'test_query', 'slop': 3, 'boost': 1.1}}"
+        "'match_phrase': {'title': {'query': 'test_query', 'slop': 3, 'boost': 1.5}}"
     )
     expected_fuzzy_match_translation_string = (
-        "'fuzzy': {'translation': {'value': 'test_query', 'fuzziness': '2'}}"
+        "'fuzzy': {'translation': {'value': 'test_query', 'fuzziness': '2',"
+        " 'boost': 1.2}}"
     )
     expected_exact_match_translation_string = (
         "'match_phrase': {'translation': {'query': "
-        "'test_query', 'slop': 3, 'boost': 1.1}}"
+        "'test_query', 'slop': 3, 'boost': 1.5}}"
     )
     expected_multi_match_string = (
         "'multi_match': {'query': 'test_query', 'fields': ['title', "
-        "'full_text_search_field'], 'type': 'phrase', 'operator': 'OR', 'boost': 1.3}"
+        "'full_text_search_field'], 'type': 'phrase', 'operator': 'OR', 'boost': 1.1}"
     )
     expected_match_full_text_search_string = (
         "'match_phrase': {'full_text_search_field': {'query': 'test_query', 'boost': "
-        "1.5}}"
+        "1.0}}"
     )
 
     def test_english(self):


### PR DESCRIPTION
### Description of Changes
Previously the full text search was added to all 3 cases for the `domain` parameter, i.e. `both, language and english`.
This PR limits the full text search to only `both` option. In case of `language` or `english` option, only specific fields will be searched and not the full text field.
The boost values are also adjusted to give priority to exact matches, then fuzzy matches and then the `full_text_search_field`.

### Checklist
- [x] README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
