### PR TITLE
fw-4383, set video file dimensions on save

### DIFF
--- a/firstvoices/backend/tests/test_models/test_media_models.py
+++ b/firstvoices/backend/tests/test_models/test_media_models.py
@@ -52,6 +52,8 @@ class TestFileModels:
         site = factories.SiteFactory.create()
         instance = factories.VideoFileFactory.create(site=site)
         assert instance.mimetype == "video/mp4"
+        assert instance.height == 46
+        assert instance.width == 80
 
     @pytest.mark.parametrize("media_factory", file_model_factories)
     @pytest.mark.django_db


### PR DESCRIPTION
### Description of Changes
* Missed a spot previously-- this sets the video file dimensions on save
* Moved some code around so pieces could be shared between Video and VideoFile

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
