### PR TITLE
FW-4421 refactored get_valid_domain to return None for invalid input

### DIFF
--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -174,7 +174,10 @@ def get_valid_document_types(input_types):
 
 
 def get_valid_domain(input_domain_str):
-    string_lower = input_domain_str.lower()
+    string_lower = input_domain_str.strip().lower()
+
+    if not string_lower:
+        return "both"
 
     if (
         string_lower == SearchDomains.BOTH.value
@@ -182,5 +185,5 @@ def get_valid_domain(input_domain_str):
         or string_lower == SearchDomains.ENGLISH.value
     ):
         return string_lower
-    else:  # if empty string is passed, or invalid option is passed
-        return "both"
+    else:  # if invalid string is passed
+        return None

--- a/firstvoices/backend/tests/test_search/test_query_builder_utils.py
+++ b/firstvoices/backend/tests/test_search/test_query_builder_utils.py
@@ -1,7 +1,10 @@
 import pytest
 
 from backend.search.utils.constants import VALID_DOCUMENT_TYPES
-from backend.search.utils.query_builder_utils import get_valid_document_types
+from backend.search.utils.query_builder_utils import (
+    get_valid_document_types,
+    get_valid_domain,
+)
 
 
 class TestValidDocumentTypes:
@@ -26,3 +29,22 @@ class TestValidDocumentTypes:
     def test_empty_input_return_all_types(self):
         actual_types = get_valid_document_types("")
         assert VALID_DOCUMENT_TYPES == actual_types
+
+
+class TestValidDomains:
+    @pytest.mark.parametrize(
+        "input_domain, expected_domain",
+        [
+            ("english", "english"),
+            ("LANGUAGE", "language"),
+            ("both", "both"),
+            (" ", "both"),
+        ],
+    )
+    def test_valid_inputs(self, input_domain, expected_domain):
+        actual_domain = get_valid_domain(input_domain)
+        assert expected_domain == actual_domain
+
+    def test_invalid_input(self):
+        actual_domain = get_valid_domain("bananas")
+        assert actual_domain is None

--- a/firstvoices/backend/tests/test_search/test_query_params.py
+++ b/firstvoices/backend/tests/test_search/test_query_params.py
@@ -138,7 +138,9 @@ class TestDomain:
 
     def test_both(self):
         # relates to: SearchQueryTest.java - testBoth()
-        search_query = get_search_query(q="test_query")  # default domain is "both"
+        search_query = get_search_query(
+            q="test_query", domain="both"
+        )  # default domain is "both"
         search_query = search_query.to_dict()
 
         # should contain title matching

--- a/firstvoices/backend/tests/test_search/test_query_params.py
+++ b/firstvoices/backend/tests/test_search/test_query_params.py
@@ -138,9 +138,7 @@ class TestDomain:
 
     def test_both(self):
         # relates to: SearchQueryTest.java - testBoth()
-        search_query = get_search_query(
-            q="test_query", domain="both"
-        )  # default domain is "both"
+        search_query = get_search_query(q="test_query", domain="both")
         search_query = search_query.to_dict()
 
         # should contain title matching

--- a/firstvoices/backend/views/search/base_search_views.py
+++ b/firstvoices/backend/views/search/base_search_views.py
@@ -144,6 +144,10 @@ class BaseSearchViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         if not search_params["types"]:
             return Response(data=[])
 
+        # If invalid domain is passed, return emtpy list as a response
+        if not search_params["domain"]:
+            return Response(data=[])
+
         # Get search query
         search_query = get_search_query(
             q=search_params["q"],

--- a/firstvoices/backend/views/search/base_search_views.py
+++ b/firstvoices/backend/views/search/base_search_views.py
@@ -93,6 +93,11 @@ from backend.views.exceptions import ElasticSearchConnectionError
                 type=str,
                 examples=[
                     OpenApiExample(
+                        "",
+                        value="",
+                        description="Defaults to both.",
+                    ),
+                    OpenApiExample(
                         "both",
                         value="both",
                         description="Searches in both the Language and English domains.",
@@ -106,6 +111,11 @@ from backend.views.exceptions import ElasticSearchConnectionError
                         "language",
                         value="language",
                         description="Performs a search focused on titles and language.",
+                    ),
+                    OpenApiExample(
+                        "invalid_domain",
+                        value="None",
+                        description="If invalid domain is passed, the API returns an empty set of results.",
                     ),
                 ],
             ),


### PR DESCRIPTION
### Description of Changes
updated validation function for `domain`. It now returns `None` internally, which in turn returns empty result set as a response. It defaults to `both` if no or empty input is passed.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
