### PR TITLE
FW-4395 Fix API docs warnings

### DIFF
--- a/firstvoices/backend/serializers/async_results_serializers.py
+++ b/firstvoices/backend/serializers/async_results_serializers.py
@@ -1,6 +1,8 @@
 from collections import OrderedDict
 
 from celery.result import AsyncResult
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from backend.models.async_results import CustomOrderRecalculationResult
@@ -12,11 +14,13 @@ class CustomOrderRecalculationResultSerializer(serializers.ModelSerializer):
     latest_recalculation_result = serializers.SerializerMethodField()
 
     @staticmethod
+    @extend_schema_field(OpenApiTypes.STR)
     def get_current_task_status(obj):
         async_result = AsyncResult(obj.task_id)
         return async_result.status
 
     @staticmethod
+    @extend_schema_field(OpenApiTypes.STR)
     def get_latest_recalculation_result(obj):
         ordered_result = OrderedDict(
             {
@@ -62,6 +66,7 @@ class CustomOrderRecalculationPreviewResultSerializer(
         source="latest_recalculation_date"
     )
 
+    @extend_schema_field(OpenApiTypes.STR)
     def get_current_preview_task_status(self, obj):
         return self.get_current_task_status(obj)
 

--- a/firstvoices/backend/serializers/dictionary_serializers.py
+++ b/firstvoices/backend/serializers/dictionary_serializers.py
@@ -1,5 +1,7 @@
 import logging
 
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from backend.models import category, dictionary
@@ -101,6 +103,7 @@ class DictionaryEntryDetailSerializer(
             )
             return []
 
+    @extend_schema_field(OpenApiTypes.STR)
     def get_split_chars(self, entry):
         alphabet = self.get_model_from_context("alphabet")
         ignored_characters = self.get_model_from_context("ignored_characters")
@@ -124,6 +127,7 @@ class DictionaryEntryDetailSerializer(
             else:
                 return char_list
 
+    @extend_schema_field(OpenApiTypes.STR)
     def get_split_chars_base(self, entry):
         alphabet = self.get_model_from_context("alphabet")
         ignored_characters = self.get_model_from_context("ignored_characters")
@@ -156,9 +160,11 @@ class DictionaryEntryDetailSerializer(
                 return base_chars
 
     @staticmethod
+    @extend_schema_field(OpenApiTypes.STR)
     def get_split_words(entry):
         return entry.title.split(" ")
 
+    @extend_schema_field(OpenApiTypes.STR)
     def get_split_words_base(self, entry):
         alphabet = self.get_model_from_context("alphabet")
         if alphabet == []:

--- a/firstvoices/backend/serializers/site_serializers.py
+++ b/firstvoices/backend/serializers/site_serializers.py
@@ -1,3 +1,5 @@
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field, extend_schema_serializer
 from rest_framework import serializers
 
 from backend.models.app import AppJson
@@ -42,6 +44,22 @@ class SiteSummarySerializer(LinkedSiteSerializer):
         fields = LinkedSiteSerializer.Meta.fields + ("logo", "features")
 
 
+@extend_schema_serializer(
+    exclude_fields=(
+        "audio",
+        "categories",
+        "characters",
+        "data",
+        "dictionary",
+        "dictionary_cleanup",
+        "dictionary_cleanup_preview",
+        "ignored_characters",
+        "images",
+        "people",
+        "videos",
+        "word_of_the_day",
+    ),
+)
 class SiteDetailSerializer(SiteSummarySerializer):
     """
     Serializes basic details about a site object, including access-controlled related information.
@@ -67,6 +85,7 @@ class SiteDetailSerializer(SiteSummarySerializer):
     videos = SiteViewLinkField(view_name="api:video-list")
     word_of_the_day = SiteViewLinkField(view_name="api:word-of-the-day-list")
 
+    @extend_schema_field(OpenApiTypes.STR)
     def get_menu(self, site):
         return site.menu.json if hasattr(site, "menu") else self.get_default_menu()
 

--- a/firstvoices/backend/serializers/user.py
+++ b/firstvoices/backend/serializers/user.py
@@ -1,3 +1,5 @@
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from backend.models import User
@@ -7,6 +9,7 @@ class CurrentUserSerializer(serializers.ModelSerializer):
     msg = serializers.SerializerMethodField()
     authenticated_id = serializers.CharField(source="id")
 
+    @extend_schema_field(OpenApiTypes.STR)
     def get_msg(self, instance):
         return "if you are seeing this, you made an authenticated request successfully"
 

--- a/firstvoices/backend/views/api_doc_variables.py
+++ b/firstvoices/backend/views/api_doc_variables.py
@@ -1,0 +1,9 @@
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter
+
+site_slug_parameter = OpenApiParameter(
+    name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+)
+id_parameter = OpenApiParameter(
+    name="id", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+)

--- a/firstvoices/backend/views/audio_views.py
+++ b/firstvoices/backend/views/audio_views.py
@@ -1,5 +1,11 @@
 from django.utils.translation import gettext as _
-from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import (
+    OpenApiParameter,
+    OpenApiResponse,
+    extend_schema,
+    extend_schema_view,
+)
 from rest_framework import viewsets
 
 from backend.models.media import Audio
@@ -17,6 +23,11 @@ from . import doc_strings
             403: OpenApiResponse(description=doc_strings.error_403_site_access_denied),
             404: OpenApiResponse(description=doc_strings.error_404_missing_site),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            )
+        ],
     ),
     retrieve=extend_schema(
         description=_("An audio item from the specified site."),
@@ -25,6 +36,14 @@ from . import doc_strings
             403: OpenApiResponse(description=doc_strings.error_403),
             404: OpenApiResponse(description=doc_strings.error_404),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            ),
+            OpenApiParameter(
+                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
+            ),
+        ],
     ),
 )
 class AudioViewSet(

--- a/firstvoices/backend/views/audio_views.py
+++ b/firstvoices/backend/views/audio_views.py
@@ -1,11 +1,5 @@
 from django.utils.translation import gettext as _
-from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import (
-    OpenApiParameter,
-    OpenApiResponse,
-    extend_schema,
-    extend_schema_view,
-)
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import viewsets
 
 from backend.models.media import Audio
@@ -13,6 +7,7 @@ from backend.serializers.media_serializers import AudioSerializer
 from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSetMixin
 
 from . import doc_strings
+from .api_doc_variables import id_parameter, site_slug_parameter
 
 
 @extend_schema_view(
@@ -23,11 +18,7 @@ from . import doc_strings
             403: OpenApiResponse(description=doc_strings.error_403_site_access_denied),
             404: OpenApiResponse(description=doc_strings.error_404_missing_site),
         },
-        parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            )
-        ],
+        parameters=[site_slug_parameter],
     ),
     retrieve=extend_schema(
         description=_("An audio item from the specified site."),
@@ -37,12 +28,8 @@ from . import doc_strings
             404: OpenApiResponse(description=doc_strings.error_404),
         },
         parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            ),
-            OpenApiParameter(
-                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
-            ),
+            site_slug_parameter,
+            id_parameter,
         ],
     ),
 )

--- a/firstvoices/backend/views/category_views.py
+++ b/firstvoices/backend/views/category_views.py
@@ -2,6 +2,7 @@ import itertools
 
 from django.db.models import Prefetch, Q
 from django.utils.translation import gettext as _
+from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
     OpenApiExample,
     OpenApiParameter,
@@ -39,6 +40,9 @@ from . import doc_strings
         },
         parameters=[
             OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            ),
+            OpenApiParameter(
                 name="contains",
                 description=_("Filter by type of dictionary entry associated with it"),
                 required=False,
@@ -54,7 +58,7 @@ from . import doc_strings
                         ),
                     ),
                 ],
-            )
+            ),
         ],
     ),
     retrieve=extend_schema(
@@ -67,6 +71,14 @@ from . import doc_strings
             403: OpenApiResponse(description=doc_strings.error_403),
             404: OpenApiResponse(description=doc_strings.error_404),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            ),
+            OpenApiParameter(
+                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
+            ),
+        ],
     ),
     create=extend_schema(
         description=_("Add a category."),
@@ -78,6 +90,11 @@ from . import doc_strings
             403: OpenApiResponse(description=doc_strings.error_403),
             404: OpenApiResponse(description=doc_strings.error_404_missing_site),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            )
+        ],
     ),
     update=extend_schema(
         description=_("Edit a category."),
@@ -90,6 +107,14 @@ from . import doc_strings
             403: OpenApiResponse(description=doc_strings.error_403),
             404: OpenApiResponse(description=doc_strings.error_404),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            ),
+            OpenApiParameter(
+                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
+            ),
+        ],
     ),
     destroy=extend_schema(
         description=_("Delete a category."),
@@ -101,6 +126,14 @@ from . import doc_strings
             403: OpenApiResponse(description=doc_strings.error_403),
             404: OpenApiResponse(description=doc_strings.error_404),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            ),
+            OpenApiParameter(
+                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
+            ),
+        ],
     ),
 )
 class CategoryViewSet(SiteContentViewSetMixin, FVPermissionViewSetMixin, ModelViewSet):

--- a/firstvoices/backend/views/category_views.py
+++ b/firstvoices/backend/views/category_views.py
@@ -2,7 +2,6 @@ import itertools
 
 from django.db.models import Prefetch, Q
 from django.utils.translation import gettext as _
-from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
     OpenApiExample,
     OpenApiParameter,
@@ -25,6 +24,7 @@ from backend.views.base_views import (
 )
 
 from . import doc_strings
+from .api_doc_variables import id_parameter, site_slug_parameter
 
 
 @extend_schema_view(
@@ -39,9 +39,7 @@ from . import doc_strings
             404: OpenApiResponse(description=doc_strings.error_404_missing_site),
         },
         parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            ),
+            site_slug_parameter,
             OpenApiParameter(
                 name="contains",
                 description=_("Filter by type of dictionary entry associated with it"),
@@ -72,12 +70,8 @@ from . import doc_strings
             404: OpenApiResponse(description=doc_strings.error_404),
         },
         parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            ),
-            OpenApiParameter(
-                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
-            ),
+            site_slug_parameter,
+            id_parameter,
         ],
     ),
     create=extend_schema(
@@ -90,11 +84,7 @@ from . import doc_strings
             403: OpenApiResponse(description=doc_strings.error_403),
             404: OpenApiResponse(description=doc_strings.error_404_missing_site),
         },
-        parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            )
-        ],
+        parameters=[site_slug_parameter],
     ),
     update=extend_schema(
         description=_("Edit a category."),
@@ -108,12 +98,8 @@ from . import doc_strings
             404: OpenApiResponse(description=doc_strings.error_404),
         },
         parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            ),
-            OpenApiParameter(
-                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
-            ),
+            site_slug_parameter,
+            id_parameter,
         ],
     ),
     destroy=extend_schema(
@@ -127,12 +113,8 @@ from . import doc_strings
             404: OpenApiResponse(description=doc_strings.error_404),
         },
         parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            ),
-            OpenApiParameter(
-                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
-            ),
+            site_slug_parameter,
+            id_parameter,
         ],
     ),
 )

--- a/firstvoices/backend/views/character_views.py
+++ b/firstvoices/backend/views/character_views.py
@@ -1,5 +1,11 @@
 from django.db.models import Prefetch
-from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import (
+    OpenApiParameter,
+    OpenApiResponse,
+    extend_schema,
+    extend_schema_view,
+)
 from rest_framework.viewsets import ModelViewSet
 
 from backend.models import DictionaryEntry
@@ -20,6 +26,11 @@ from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSe
             403: OpenApiResponse(description="Todo: Not authorized for this Site"),
             404: OpenApiResponse(description="Todo: Site not found"),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            )
+        ],
     ),
     retrieve=extend_schema(
         description="Details about a specific character in the specified site",
@@ -28,6 +39,14 @@ from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSe
             403: OpenApiResponse(description="Todo: Not authorized for this Site"),
             404: OpenApiResponse(description="Todo: Site not found"),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            ),
+            OpenApiParameter(
+                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
+            ),
+        ],
     ),
 )
 class CharactersViewSet(
@@ -78,6 +97,11 @@ class CharactersViewSet(
             403: OpenApiResponse(description="Todo: Not authorized for this Site"),
             404: OpenApiResponse(description="Todo: Site not found"),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            )
+        ],
     ),
     retrieve=extend_schema(
         description="Details about an ignored character in the specified site",
@@ -86,6 +110,14 @@ class CharactersViewSet(
             403: OpenApiResponse(description="Todo: Not authorized for this Site"),
             404: OpenApiResponse(description="Todo: Site not found"),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            ),
+            OpenApiParameter(
+                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
+            ),
+        ],
     ),
 )
 class IgnoredCharactersViewSet(

--- a/firstvoices/backend/views/character_views.py
+++ b/firstvoices/backend/views/character_views.py
@@ -1,11 +1,5 @@
 from django.db.models import Prefetch
-from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import (
-    OpenApiParameter,
-    OpenApiResponse,
-    extend_schema,
-    extend_schema_view,
-)
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework.viewsets import ModelViewSet
 
 from backend.models import DictionaryEntry
@@ -15,6 +9,7 @@ from backend.serializers.character_serializers import (
     CharacterDetailSerializer,
     IgnoredCharacterSerializer,
 )
+from backend.views.api_doc_variables import id_parameter, site_slug_parameter
 from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSetMixin
 
 
@@ -26,11 +21,7 @@ from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSe
             403: OpenApiResponse(description="Todo: Not authorized for this Site"),
             404: OpenApiResponse(description="Todo: Site not found"),
         },
-        parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            )
-        ],
+        parameters=[site_slug_parameter],
     ),
     retrieve=extend_schema(
         description="Details about a specific character in the specified site",
@@ -40,12 +31,8 @@ from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSe
             404: OpenApiResponse(description="Todo: Site not found"),
         },
         parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            ),
-            OpenApiParameter(
-                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
-            ),
+            site_slug_parameter,
+            id_parameter,
         ],
     ),
 )
@@ -97,11 +84,7 @@ class CharactersViewSet(
             403: OpenApiResponse(description="Todo: Not authorized for this Site"),
             404: OpenApiResponse(description="Todo: Site not found"),
         },
-        parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            )
-        ],
+        parameters=[site_slug_parameter],
     ),
     retrieve=extend_schema(
         description="Details about an ignored character in the specified site",
@@ -111,12 +94,8 @@ class CharactersViewSet(
             404: OpenApiResponse(description="Todo: Site not found"),
         },
         parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            ),
-            OpenApiParameter(
-                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
-            ),
+            site_slug_parameter,
+            id_parameter,
         ],
     ),
 )

--- a/firstvoices/backend/views/custom_order_recalculate_views.py
+++ b/firstvoices/backend/views/custom_order_recalculate_views.py
@@ -1,4 +1,10 @@
-from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import (
+    OpenApiParameter,
+    OpenApiResponse,
+    extend_schema,
+    extend_schema_view,
+)
 from rest_framework.response import Response
 
 from backend.models import CustomOrderRecalculationResult
@@ -26,6 +32,11 @@ from backend.views.exceptions import CeleryError
             403: OpenApiResponse(description="Todo: Not authorized for this Site"),
             404: OpenApiResponse(description="Todo: Site not found"),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            )
+        ],
     ),
     create=extend_schema(
         description="Queues a custom order recalculation task for the specified site.",
@@ -36,6 +47,11 @@ from backend.views.exceptions import CeleryError
             ),
             404: OpenApiResponse(description="Todo: Site not found"),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            )
+        ],
     ),
 )
 class CustomOrderRecalculateView(
@@ -94,6 +110,11 @@ class CustomOrderRecalculateView(
             403: OpenApiResponse(description="Todo: Not authorized for this Site"),
             404: OpenApiResponse(description="Todo: Site not found"),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            )
+        ],
     ),
     create=extend_schema(
         description="Queues a custom order recalculation preview task for the specified site. ",
@@ -104,6 +125,11 @@ class CustomOrderRecalculateView(
             ),
             404: OpenApiResponse(description="Todo: Site not found"),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            )
+        ],
     ),
 )
 class CustomOrderRecalculatePreviewView(

--- a/firstvoices/backend/views/custom_order_recalculate_views.py
+++ b/firstvoices/backend/views/custom_order_recalculate_views.py
@@ -1,10 +1,4 @@
-from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import (
-    OpenApiParameter,
-    OpenApiResponse,
-    extend_schema,
-    extend_schema_view,
-)
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework.response import Response
 
 from backend.models import CustomOrderRecalculationResult
@@ -16,6 +10,7 @@ from backend.tasks.alphabet_tasks import (
     recalculate_custom_order,
     recalculate_custom_order_preview,
 )
+from backend.views.api_doc_variables import site_slug_parameter
 from backend.views.base_views import (
     FVPermissionViewSetMixin,
     ListViewOnlyModelViewSet,
@@ -32,11 +27,7 @@ from backend.views.exceptions import CeleryError
             403: OpenApiResponse(description="Todo: Not authorized for this Site"),
             404: OpenApiResponse(description="Todo: Site not found"),
         },
-        parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            )
-        ],
+        parameters=[site_slug_parameter],
     ),
     create=extend_schema(
         description="Queues a custom order recalculation task for the specified site.",
@@ -47,11 +38,7 @@ from backend.views.exceptions import CeleryError
             ),
             404: OpenApiResponse(description="Todo: Site not found"),
         },
-        parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            )
-        ],
+        parameters=[site_slug_parameter],
     ),
 )
 class CustomOrderRecalculateView(
@@ -110,11 +97,7 @@ class CustomOrderRecalculateView(
             403: OpenApiResponse(description="Todo: Not authorized for this Site"),
             404: OpenApiResponse(description="Todo: Site not found"),
         },
-        parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            )
-        ],
+        parameters=[site_slug_parameter],
     ),
     create=extend_schema(
         description="Queues a custom order recalculation preview task for the specified site. ",
@@ -125,11 +108,7 @@ class CustomOrderRecalculateView(
             ),
             404: OpenApiResponse(description="Todo: Site not found"),
         },
-        parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            )
-        ],
+        parameters=[site_slug_parameter],
     ),
 )
 class CustomOrderRecalculatePreviewView(

--- a/firstvoices/backend/views/data_views.py
+++ b/firstvoices/backend/views/data_views.py
@@ -1,5 +1,11 @@
 from django.db.models import Prefetch
-from drf_spectacular.utils import extend_schema, extend_schema_view, inline_serializer
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import (
+    OpenApiParameter,
+    extend_schema,
+    extend_schema_view,
+    inline_serializer,
+)
 from rest_framework import mixins, serializers, viewsets
 from rules.contrib.rest_framework import AutoPermissionViewSetMixin
 
@@ -32,6 +38,11 @@ def dict_entry_type_mtd_conversion(type):
                 },
             ),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            )
+        ],
     ),
 )
 class SitesDataViewSet(

--- a/firstvoices/backend/views/data_views.py
+++ b/firstvoices/backend/views/data_views.py
@@ -1,16 +1,11 @@
 from django.db.models import Prefetch
-from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import (
-    OpenApiParameter,
-    extend_schema,
-    extend_schema_view,
-    inline_serializer,
-)
+from drf_spectacular.utils import extend_schema, extend_schema_view, inline_serializer
 from rest_framework import mixins, serializers, viewsets
 from rules.contrib.rest_framework import AutoPermissionViewSetMixin
 
 from backend.models.dictionary import DictionaryEntry
 from backend.serializers.site_data_serializers import SiteDataSerializer
+from backend.views.api_doc_variables import site_slug_parameter
 from backend.views.base_views import SiteContentViewSetMixin
 
 
@@ -38,11 +33,7 @@ def dict_entry_type_mtd_conversion(type):
                 },
             ),
         },
-        parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            )
-        ],
+        parameters=[site_slug_parameter],
     ),
 )
 class SitesDataViewSet(

--- a/firstvoices/backend/views/dictionary_views.py
+++ b/firstvoices/backend/views/dictionary_views.py
@@ -1,16 +1,11 @@
 from django.db.models import Prefetch
-from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import (
-    OpenApiParameter,
-    OpenApiResponse,
-    extend_schema,
-    extend_schema_view,
-)
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import viewsets
 
 from backend.models.dictionary import DictionaryEntry
 from backend.models.media import Audio, Image, Video
 from backend.serializers.dictionary_serializers import DictionaryEntryDetailSerializer
+from backend.views.api_doc_variables import id_parameter, site_slug_parameter
 from backend.views.base_views import (
     DictionarySerializerContextMixin,
     FVPermissionViewSetMixin,
@@ -26,11 +21,7 @@ from backend.views.base_views import (
             403: OpenApiResponse(description="Todo: Not authorized for this Site"),
             404: OpenApiResponse(description="Todo: Site not found"),
         },
-        parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            )
-        ],
+        parameters=[site_slug_parameter],
     ),
     retrieve=extend_schema(
         description="A dictionary entry from the specified site.",
@@ -40,12 +31,8 @@ from backend.views.base_views import (
             404: OpenApiResponse(description="Todo: Not Found"),
         },
         parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            ),
-            OpenApiParameter(
-                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
-            ),
+            site_slug_parameter,
+            id_parameter,
         ],
     ),
 )

--- a/firstvoices/backend/views/dictionary_views.py
+++ b/firstvoices/backend/views/dictionary_views.py
@@ -1,5 +1,11 @@
 from django.db.models import Prefetch
-from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import (
+    OpenApiParameter,
+    OpenApiResponse,
+    extend_schema,
+    extend_schema_view,
+)
 from rest_framework import viewsets
 
 from backend.models.dictionary import DictionaryEntry
@@ -20,6 +26,11 @@ from backend.views.base_views import (
             403: OpenApiResponse(description="Todo: Not authorized for this Site"),
             404: OpenApiResponse(description="Todo: Site not found"),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            )
+        ],
     ),
     retrieve=extend_schema(
         description="A dictionary entry from the specified site.",
@@ -28,6 +39,14 @@ from backend.views.base_views import (
             403: OpenApiResponse(description="Todo: Error Not Authorized"),
             404: OpenApiResponse(description="Todo: Not Found"),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            ),
+            OpenApiParameter(
+                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
+            ),
+        ],
     ),
 )
 class DictionaryViewSet(

--- a/firstvoices/backend/views/image_views.py
+++ b/firstvoices/backend/views/image_views.py
@@ -1,5 +1,11 @@
 from django.utils.translation import gettext as _
-from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import (
+    OpenApiParameter,
+    OpenApiResponse,
+    extend_schema,
+    extend_schema_view,
+)
 from rest_framework import viewsets
 
 from backend.models.media import Image
@@ -17,6 +23,11 @@ from . import doc_strings
             403: OpenApiResponse(description=doc_strings.error_403_site_access_denied),
             404: OpenApiResponse(description=doc_strings.error_404_missing_site),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            )
+        ],
     ),
     retrieve=extend_schema(
         description=_("An image from the specified site."),
@@ -25,6 +36,14 @@ from . import doc_strings
             403: OpenApiResponse(description=doc_strings.error_403),
             404: OpenApiResponse(description=doc_strings.error_404),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            ),
+            OpenApiParameter(
+                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
+            ),
+        ],
     ),
 )
 class ImageViewSet(

--- a/firstvoices/backend/views/image_views.py
+++ b/firstvoices/backend/views/image_views.py
@@ -1,11 +1,5 @@
 from django.utils.translation import gettext as _
-from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import (
-    OpenApiParameter,
-    OpenApiResponse,
-    extend_schema,
-    extend_schema_view,
-)
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import viewsets
 
 from backend.models.media import Image
@@ -13,6 +7,7 @@ from backend.serializers.media_serializers import ImageSerializer
 from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSetMixin
 
 from . import doc_strings
+from .api_doc_variables import id_parameter, site_slug_parameter
 
 
 @extend_schema_view(
@@ -23,11 +18,7 @@ from . import doc_strings
             403: OpenApiResponse(description=doc_strings.error_403_site_access_denied),
             404: OpenApiResponse(description=doc_strings.error_404_missing_site),
         },
-        parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            )
-        ],
+        parameters=[site_slug_parameter],
     ),
     retrieve=extend_schema(
         description=_("An image from the specified site."),
@@ -37,12 +28,8 @@ from . import doc_strings
             404: OpenApiResponse(description=doc_strings.error_404),
         },
         parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            ),
-            OpenApiParameter(
-                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
-            ),
+            site_slug_parameter,
+            id_parameter,
         ],
     ),
 )

--- a/firstvoices/backend/views/person_views.py
+++ b/firstvoices/backend/views/person_views.py
@@ -1,5 +1,11 @@
 from django.utils.translation import gettext as _
-from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import (
+    OpenApiParameter,
+    OpenApiResponse,
+    extend_schema,
+    extend_schema_view,
+)
 from rest_framework.viewsets import ModelViewSet
 
 from backend.models.media import Person
@@ -24,6 +30,11 @@ from . import doc_strings
             403: OpenApiResponse(description=doc_strings.error_403_site_access_denied),
             404: OpenApiResponse(description=doc_strings.error_404_missing_site),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            )
+        ],
     ),
     retrieve=extend_schema(
         description=_("Details about a specific person."),
@@ -35,6 +46,14 @@ from . import doc_strings
             403: OpenApiResponse(description=doc_strings.error_403),
             404: OpenApiResponse(description=doc_strings.error_404),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            ),
+            OpenApiParameter(
+                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
+            ),
+        ],
     ),
     create=extend_schema(
         description=_("Add a person."),
@@ -46,6 +65,14 @@ from . import doc_strings
             403: OpenApiResponse(description=doc_strings.error_403),
             404: OpenApiResponse(description=doc_strings.error_404_missing_site),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            ),
+            OpenApiParameter(
+                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
+            ),
+        ],
     ),
     update=extend_schema(
         description=_("Edit a person."),
@@ -58,6 +85,14 @@ from . import doc_strings
             403: OpenApiResponse(description=doc_strings.error_403),
             404: OpenApiResponse(description=doc_strings.error_404),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            ),
+            OpenApiParameter(
+                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
+            ),
+        ],
     ),
     destroy=extend_schema(
         description=_("Delete a person."),
@@ -69,6 +104,14 @@ from . import doc_strings
             403: OpenApiResponse(description=doc_strings.error_403),
             404: OpenApiResponse(description=doc_strings.error_404),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            ),
+            OpenApiParameter(
+                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
+            ),
+        ],
     ),
 )
 class PersonViewSet(SiteContentViewSetMixin, FVPermissionViewSetMixin, ModelViewSet):

--- a/firstvoices/backend/views/person_views.py
+++ b/firstvoices/backend/views/person_views.py
@@ -1,11 +1,5 @@
 from django.utils.translation import gettext as _
-from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import (
-    OpenApiParameter,
-    OpenApiResponse,
-    extend_schema,
-    extend_schema_view,
-)
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework.viewsets import ModelViewSet
 
 from backend.models.media import Person
@@ -17,6 +11,7 @@ from backend.views.base_views import (
 )
 
 from . import doc_strings
+from .api_doc_variables import id_parameter, site_slug_parameter
 
 
 @extend_schema_view(
@@ -30,11 +25,7 @@ from . import doc_strings
             403: OpenApiResponse(description=doc_strings.error_403_site_access_denied),
             404: OpenApiResponse(description=doc_strings.error_404_missing_site),
         },
-        parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            )
-        ],
+        parameters=[site_slug_parameter],
     ),
     retrieve=extend_schema(
         description=_("Details about a specific person."),
@@ -47,12 +38,8 @@ from . import doc_strings
             404: OpenApiResponse(description=doc_strings.error_404),
         },
         parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            ),
-            OpenApiParameter(
-                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
-            ),
+            site_slug_parameter,
+            id_parameter,
         ],
     ),
     create=extend_schema(
@@ -66,12 +53,8 @@ from . import doc_strings
             404: OpenApiResponse(description=doc_strings.error_404_missing_site),
         },
         parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            ),
-            OpenApiParameter(
-                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
-            ),
+            site_slug_parameter,
+            id_parameter,
         ],
     ),
     update=extend_schema(
@@ -86,12 +69,8 @@ from . import doc_strings
             404: OpenApiResponse(description=doc_strings.error_404),
         },
         parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            ),
-            OpenApiParameter(
-                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
-            ),
+            site_slug_parameter,
+            id_parameter,
         ],
     ),
     destroy=extend_schema(
@@ -105,12 +84,8 @@ from . import doc_strings
             404: OpenApiResponse(description=doc_strings.error_404),
         },
         parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            ),
-            OpenApiParameter(
-                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
-            ),
+            site_slug_parameter,
+            id_parameter,
         ],
     ),
 )

--- a/firstvoices/backend/views/search/base_search_views.py
+++ b/firstvoices/backend/views/search/base_search_views.py
@@ -1,4 +1,3 @@
-from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
     OpenApiExample,
     OpenApiParameter,
@@ -18,6 +17,7 @@ from backend.search.utils.query_builder_utils import (
     get_valid_document_types,
     get_valid_domain,
 )
+from backend.views.api_doc_variables import site_slug_parameter
 from backend.views.exceptions import ElasticSearchConnectionError
 
 
@@ -39,9 +39,7 @@ from backend.views.exceptions import ElasticSearchConnectionError
             403: OpenApiResponse(description="Todo: Not authorized"),
         },
         parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            ),
+            site_slug_parameter,
             OpenApiParameter(
                 name="q",
                 description="search term",

--- a/firstvoices/backend/views/search/base_search_views.py
+++ b/firstvoices/backend/views/search/base_search_views.py
@@ -1,3 +1,4 @@
+from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
     OpenApiExample,
     OpenApiParameter,
@@ -38,6 +39,9 @@ from backend.views.exceptions import ElasticSearchConnectionError
             403: OpenApiResponse(description="Todo: Not authorized"),
         },
         parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            ),
             OpenApiParameter(
                 name="q",
                 description="search term",

--- a/firstvoices/backend/views/sites_views.py
+++ b/firstvoices/backend/views/sites_views.py
@@ -52,7 +52,7 @@ def group_sites_by_language(request, sites):
         "under 'Other'.",
         responses={
             200: inline_serializer(
-                name="InlineLanguageSerializer",
+                name="SitesInlineLanguageSerializer",
                 fields={
                     "language": serializers.CharField(),
                     "sites": SiteSummarySerializer(many=True),
@@ -120,7 +120,7 @@ class SiteViewSet(AutoPermissionViewSetMixin, ModelViewSet):
         "membership to any site then the list will be empty.",
         responses={
             200: inline_serializer(
-                name="InlineLanguageSerializer",
+                name="MySitesInlineLanguageSerializer",
                 fields={
                     "language": serializers.CharField(),
                     "sites": SiteSummarySerializer(many=True),

--- a/firstvoices/backend/views/video_views.py
+++ b/firstvoices/backend/views/video_views.py
@@ -1,11 +1,5 @@
 from django.utils.translation import gettext as _
-from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import (
-    OpenApiParameter,
-    OpenApiResponse,
-    extend_schema,
-    extend_schema_view,
-)
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import viewsets
 
 from backend.models.media import Video
@@ -13,6 +7,7 @@ from backend.serializers.media_serializers import VideoSerializer
 from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSetMixin
 
 from . import doc_strings
+from .api_doc_variables import id_parameter, site_slug_parameter
 
 
 @extend_schema_view(
@@ -23,11 +18,7 @@ from . import doc_strings
             403: OpenApiResponse(description=doc_strings.error_403_site_access_denied),
             404: OpenApiResponse(description=doc_strings.error_404_missing_site),
         },
-        parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            )
-        ],
+        parameters=[site_slug_parameter],
     ),
     retrieve=extend_schema(
         description=_("A video from the specified site."),
@@ -37,12 +28,8 @@ from . import doc_strings
             404: OpenApiResponse(description=doc_strings.error_404),
         },
         parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            ),
-            OpenApiParameter(
-                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
-            ),
+            site_slug_parameter,
+            id_parameter,
         ],
     ),
 )

--- a/firstvoices/backend/views/video_views.py
+++ b/firstvoices/backend/views/video_views.py
@@ -1,5 +1,11 @@
 from django.utils.translation import gettext as _
-from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import (
+    OpenApiParameter,
+    OpenApiResponse,
+    extend_schema,
+    extend_schema_view,
+)
 from rest_framework import viewsets
 
 from backend.models.media import Video
@@ -17,6 +23,11 @@ from . import doc_strings
             403: OpenApiResponse(description=doc_strings.error_403_site_access_denied),
             404: OpenApiResponse(description=doc_strings.error_404_missing_site),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            )
+        ],
     ),
     retrieve=extend_schema(
         description=_("A video from the specified site."),
@@ -25,6 +36,14 @@ from . import doc_strings
             403: OpenApiResponse(description=doc_strings.error_403),
             404: OpenApiResponse(description=doc_strings.error_404),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            ),
+            OpenApiParameter(
+                name="id", type=OpenApiTypes.UUID, location=OpenApiParameter.PATH
+            ),
+        ],
     ),
 )
 class VideoViewSet(

--- a/firstvoices/backend/views/word_of_the_day_views.py
+++ b/firstvoices/backend/views/word_of_the_day_views.py
@@ -1,7 +1,13 @@
 from secrets import choice
 
 from django.utils.timezone import datetime, timedelta
-from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import (
+    OpenApiParameter,
+    OpenApiResponse,
+    extend_schema,
+    extend_schema_view,
+)
 from rest_framework import mixins, viewsets
 from rest_framework.response import Response
 
@@ -27,6 +33,11 @@ from backend.views.base_views import (
             403: OpenApiResponse(description="Todo: Not authorized for this Site"),
             404: OpenApiResponse(description="Todo: Site not found"),
         },
+        parameters=[
+            OpenApiParameter(
+                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+            )
+        ],
     ),
 )
 class WordOfTheDayView(

--- a/firstvoices/backend/views/word_of_the_day_views.py
+++ b/firstvoices/backend/views/word_of_the_day_views.py
@@ -1,13 +1,7 @@
 from secrets import choice
 
 from django.utils.timezone import datetime, timedelta
-from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import (
-    OpenApiParameter,
-    OpenApiResponse,
-    extend_schema,
-    extend_schema_view,
-)
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import mixins, viewsets
 from rest_framework.response import Response
 
@@ -18,6 +12,7 @@ from backend.models.dictionary import (
 )
 from backend.permissions import utils
 from backend.serializers.word_of_the_day_serializers import WordOfTheDayListSerializer
+from backend.views.api_doc_variables import site_slug_parameter
 from backend.views.base_views import (
     DictionarySerializerContextMixin,
     FVPermissionViewSetMixin,
@@ -33,11 +28,7 @@ from backend.views.base_views import (
             403: OpenApiResponse(description="Todo: Not authorized for this Site"),
             404: OpenApiResponse(description="Todo: Site not found"),
         },
-        parameters=[
-            OpenApiParameter(
-                name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
-            )
-        ],
+        parameters=[site_slug_parameter],
     ),
 )
 class WordOfTheDayView(


### PR DESCRIPTION
### Description of Changes
These changes add missing parameters and field types to the `@extend_shema_...` decorators to remove the majority of the warnings when loading the API docs page. Note that nothing has visibly changed as [drf-spectacular](https://github.com/tfranzel/drf-spectacular) will automatically fall back on defaults, but the warnings are now gone. In the future, the API docs page could be updated with things like detailed examples to closely match the expected responses.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
