### PR TITLE
fw-4555, add language codes to site list api

### DIFF
--- a/firstvoices/backend/serializers/site_serializers.py
+++ b/firstvoices/backend/serializers/site_serializers.py
@@ -3,7 +3,7 @@ from drf_spectacular.utils import extend_schema_field, extend_schema_serializer
 from rest_framework import serializers
 
 from backend.models.app import AppJson
-from backend.models.sites import Site
+from backend.models.sites import Language, Site
 from backend.serializers.base_serializers import base_id_fields
 from backend.serializers.fields import SiteViewLinkField
 from backend.serializers.media_serializers import ImageSerializer, VideoSerializer
@@ -111,3 +111,17 @@ class SiteDetailSerializer(SiteSummarySerializer):
             "videos",
             "word_of_the_day",
         )
+
+
+class LanguageSerializer(serializers.Serializer):
+    """
+    Serializes basic details about a language, including a list of language sites.
+    """
+
+    language = serializers.CharField(source="title")
+    language_code = serializers.CharField()
+    sites = SiteSummarySerializer(many=True)
+
+    class Meta:
+        model = Language
+        fields = ("language", "language_code", "sites")

--- a/firstvoices/backend/tests/test_apis/test_sites_api.py
+++ b/firstvoices/backend/tests/test_apis/test_sites_api.py
@@ -46,6 +46,10 @@ class TestSitesEndpoints(MediaTestMixin, BaseApiTest):
         )
         factories.SiteFactory(language=language1, visibility=Visibility.MEMBERS)
 
+        # sites with no language set
+        factories.SiteFactory(language=None, visibility=Visibility.PUBLIC)
+        factories.SiteFactory(language=None, visibility=Visibility.MEMBERS)
+
         backend.tests.factories.access.LanguageFactory.create()
 
         response = self.client.get(self.get_list_endpoint())
@@ -53,13 +57,19 @@ class TestSitesEndpoints(MediaTestMixin, BaseApiTest):
         assert response.status_code == 200
 
         response_data = json.loads(response.content)
-        assert len(response_data) == 2
+        assert len(response_data) == 3
 
-        assert response_data[0]["language"] == "Language 0"
+        assert response_data[0]["language"] == language0.title
+        assert response_data[0]["languageCode"] == language0.language_code
         assert len(response_data[0]["sites"]) == 2
 
-        assert response_data[1]["language"] == "Language 1"
+        assert response_data[1]["language"] == language1.title
+        assert response_data[1]["languageCode"] == language1.language_code
         assert len(response_data[1]["sites"]) == 1
+
+        assert response_data[2]["language"] == "Other"
+        assert response_data[2]["languageCode"] == ""
+        assert len(response_data[2]["sites"]) == 2
 
         site_json = response_data[0]["sites"][0]
         assert site_json == {


### PR DESCRIPTION
### Description of Changes
* Switched to using a LanguageSerializer in order to add more language fields to the response
* Bonus change: use the simpler permission filters in the site querysets

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
