### PR TITLE
Fw 4268 implement dictionary search with parameters

### DIFF
--- a/firstvoices/backend/management/commands/_helper.py
+++ b/firstvoices/backend/management/commands/_helper.py
@@ -10,6 +10,7 @@ from backend.search.indices.dictionary_entry_document import (
     DictionaryEntryDocument,
 )
 from backend.search.utils.object_utils import (
+    get_categories_ids,
     get_notes_text,
     get_translation_and_part_of_speech_text,
 )
@@ -93,6 +94,8 @@ def dictionary_entry_iterator():
             part_of_speech_text,
         ) = get_translation_and_part_of_speech_text(entry)
         notes_text = get_notes_text(entry)
+        categories = get_categories_ids(entry)
+
         index_entry = DictionaryEntryDocument(
             document_id=str(entry.id),
             site_id=str(entry.site.id),
@@ -101,6 +104,7 @@ def dictionary_entry_iterator():
             translation=translations_text,
             part_of_speech=part_of_speech_text,
             note=notes_text,
+            categories=categories,
         )
         yield index_entry.to_dict(True)
 

--- a/firstvoices/backend/search/indices/dictionary_entry_document.py
+++ b/firstvoices/backend/search/indices/dictionary_entry_document.py
@@ -34,7 +34,7 @@ class DictionaryEntryDocument(Document):
     translation = Text(analyzer="standard", copy_to="full_text_search_field")
     note = Text(copy_to="full_text_search_field")
     part_of_speech = Text(copy_to="full_text_search_field")
-    categories = Text()  # Keyword vs Text
+    categories = Keyword()
 
     class Index:
         name = ELASTICSEARCH_DICTIONARY_ENTRY_INDEX

--- a/firstvoices/backend/search/indices/dictionary_entry_document.py
+++ b/firstvoices/backend/search/indices/dictionary_entry_document.py
@@ -14,6 +14,7 @@ from backend.search.utils.constants import (
     SearchIndexEntryTypes,
 )
 from backend.search.utils.object_utils import (
+    get_categories_ids,
     get_notes_text,
     get_object_from_index,
     get_translation_and_part_of_speech_text,
@@ -33,6 +34,7 @@ class DictionaryEntryDocument(Document):
     translation = Text(analyzer="standard", copy_to="full_text_search_field")
     note = Text(copy_to="full_text_search_field")
     part_of_speech = Text(copy_to="full_text_search_field")
+    categories = Text()  # Keyword vs Text
 
     class Index:
         name = ELASTICSEARCH_DICTIONARY_ENTRY_INDEX
@@ -51,6 +53,7 @@ def update_index(sender, instance, **kwargs):
             part_of_speech_text,
         ) = get_translation_and_part_of_speech_text(instance)
         notes_text = get_notes_text(instance)
+        categories = get_categories_ids(instance)
 
         if existing_entry:
             # Check if object is already indexed, then update
@@ -62,6 +65,7 @@ def update_index(sender, instance, **kwargs):
                 translation=translations_text,
                 part_of_speech=part_of_speech_text,
                 note=notes_text,
+                categories=categories,
             )
         else:
             # Create new entry if it doesn't exist
@@ -73,6 +77,7 @@ def update_index(sender, instance, **kwargs):
                 translation=translations_text,
                 part_of_speech=part_of_speech_text,
                 note=notes_text,
+                categories=categories,
             )
             index_entry.save()
     except ConnectionError:

--- a/firstvoices/backend/search/query_builder.py
+++ b/firstvoices/backend/search/query_builder.py
@@ -47,7 +47,9 @@ def get_search_query(
         search_query = search_query.query(get_types_query(types))
 
     if starts_with_char:
-        search_query = search_query.query(get_starts_with_query(starts_with_char))
+        search_query = search_query.query(
+            get_starts_with_query(site_id, starts_with_char)
+        )
 
     if category_id and category_id != "all":
         search_query = search_query.query(get_category_query(category_id))

--- a/firstvoices/backend/search/query_builder.py
+++ b/firstvoices/backend/search/query_builder.py
@@ -25,7 +25,7 @@ def get_search_query(
     types=VALID_DOCUMENT_TYPES,
     domain="both",
     starts_with_char="",
-    category_id="all",
+    category_id="",
     kids=False,
     games=False,
 ):
@@ -55,7 +55,7 @@ def get_search_query(
             get_starts_with_query(site_id, starts_with_char)
         )
 
-    if category_id and category_id != "all":
+    if category_id:
         search_query = search_query.query(get_category_query(category_id))
 
     if kids:

--- a/firstvoices/backend/search/query_builder.py
+++ b/firstvoices/backend/search/query_builder.py
@@ -6,6 +6,7 @@ from backend.search.utils.query_builder_utils import (
     get_indices,
     get_search_term_query,
     get_site_filter_query,
+    get_starts_with_query,
     get_types_query,
 )
 
@@ -15,7 +16,9 @@ def get_search_object(indices):
     return s
 
 
-def get_search_query(q=None, site_id=None, types=VALID_DOCUMENT_TYPES, domain="both"):
+def get_search_query(
+    q=None, site_id=None, types=VALID_DOCUMENT_TYPES, domain="both", starts_with_char=""
+):
     # Building initial query
     indices = get_indices(types)
     search_object = get_search_object(indices)
@@ -36,5 +39,8 @@ def get_search_query(q=None, site_id=None, types=VALID_DOCUMENT_TYPES, domain="b
     types_query = get_types_query(types)
     if types_query:
         search_query = search_query.query(get_types_query(types))
+
+    if starts_with_char:
+        search_query = search_query.query(get_starts_with_query(starts_with_char))
 
     return search_query

--- a/firstvoices/backend/search/query_builder.py
+++ b/firstvoices/backend/search/query_builder.py
@@ -2,6 +2,7 @@ from elasticsearch_dsl import Search
 
 from backend.search.utils.constants import VALID_DOCUMENT_TYPES
 from backend.search.utils.query_builder_utils import (
+    get_category_query,
     get_cleaned_search_term,
     get_indices,
     get_search_term_query,
@@ -17,7 +18,12 @@ def get_search_object(indices):
 
 
 def get_search_query(
-    q=None, site_id=None, types=VALID_DOCUMENT_TYPES, domain="both", starts_with_char=""
+    q=None,
+    site_id=None,
+    types=VALID_DOCUMENT_TYPES,
+    domain="both",
+    starts_with_char="",
+    category_id="all",
 ):
     # Building initial query
     indices = get_indices(types)
@@ -42,5 +48,8 @@ def get_search_query(
 
     if starts_with_char:
         search_query = search_query.query(get_starts_with_query(starts_with_char))
+
+    if category_id and category_id != "all":
+        search_query = search_query.query(get_category_query(category_id))
 
     return search_query

--- a/firstvoices/backend/search/utils/object_utils.py
+++ b/firstvoices/backend/search/utils/object_utils.py
@@ -112,8 +112,6 @@ def get_notes_text(dictionary_entry_instance):
 
 def get_categories_ids(dictionary_entry_instance):
     return [
-        str(category.id)
-        for category in dictionary_entry_instance.categories.values_list(
-            "id", flat=True
-        )
+        str(id)
+        for id in dictionary_entry_instance.categories.values_list("id", flat=True)
     ]

--- a/firstvoices/backend/search/utils/object_utils.py
+++ b/firstvoices/backend/search/utils/object_utils.py
@@ -106,3 +106,11 @@ def get_notes_text(dictionary_entry_instance):
     for note in notes_set:
         notes_text.append(note.text)
     return " ".join(notes_text)
+
+
+def get_categories_ids(dictionary_entry_instance):
+    categories_set = dictionary_entry_instance.categories.all()
+    categories_list = []
+    for category in categories_set:
+        categories_list.append(str(category.id))
+    return " ".join(categories_list)

--- a/firstvoices/backend/search/utils/object_utils.py
+++ b/firstvoices/backend/search/utils/object_utils.py
@@ -113,4 +113,4 @@ def get_categories_ids(dictionary_entry_instance):
     categories_list = []
     for category in categories_set:
         categories_list.append(str(category.id))
-    return " ".join(categories_list)
+    return categories_list

--- a/firstvoices/backend/search/utils/object_utils.py
+++ b/firstvoices/backend/search/utils/object_utils.py
@@ -111,8 +111,9 @@ def get_notes_text(dictionary_entry_instance):
 
 
 def get_categories_ids(dictionary_entry_instance):
-    categories_set = dictionary_entry_instance.categories.all()
-    categories_list = []
-    for category in categories_set:
-        categories_list.append(str(category.id))
-    return categories_list
+    return [
+        str(category.id)
+        for category in dictionary_entry_instance.categories.values_list(
+            "id", flat=True
+        )
+    ]

--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -162,7 +162,8 @@ def get_starts_with_query(site_id, starts_with_char):
     # Check if a custom_order_character is present, if present, look up in the custom_order field
     # if not, look in the title field
     alphabet = Alphabet.objects.filter(site_id=site_id).first()
-    custom_order_character = alphabet.get_custom_order(starts_with_char)
+    cleaned_char = alphabet.clean_confusables(starts_with_char)
+    custom_order_character = alphabet.get_custom_order(cleaned_char)
 
     if unknown_character_flag in custom_order_character:
         # unknown custom_order character present, look in title field

--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -176,7 +176,6 @@ def get_starts_with_query(site_id, starts_with_char):
 
 def get_category_query(category_id):
     query_categories = []
-    # todo: fix category list on admin to show only categories related to current site
 
     # category_id passed down here is validated in the view, assuming the following will always return a category
     category = Category.objects.filter(id=category_id)[0]

--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -241,18 +241,16 @@ def get_valid_starts_with_char(input_str):
 
 def get_valid_category_id(site, input_category):
     # If input_category is empty, category filter should not be added
-    if input_category == "":
-        return "all"
-
-    try:
-        # If category does not belong to the site specified, return empty result set
-        valid_category = site.category_set.filter(id=input_category)
-        if not len(valid_category):
+    if input_category:
+        try:
+            # If category does not belong to the site specified, return empty result set
+            valid_category = site.category_set.filter(id=input_category)
+            if len(valid_category):
+                return valid_category[0].id
+        except ValidationError:
             return None
-    except ValidationError:
-        return None
 
-    return valid_category[0].id
+    return None
 
 
 def get_valid_boolean(input_val):

--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -153,10 +153,13 @@ def get_site_filter_query(site_id):
     return Q("bool", filter=[Q("term", site_id=site_id)])
 
 
-# Search params validation
-def get_valid_document_types(input_types):
-    allowed_values = VALID_DOCUMENT_TYPES
+def get_starts_with_query(starts_with_char):
+    # todo: Confirm what field we need to check prefix in
+    return Q("bool", filter=[Q("prefix", title=starts_with_char)])
 
+
+# Search params validation
+def get_valid_document_types(input_types, allowed_values=VALID_DOCUMENT_TYPES):
     if not input_types:
         return allowed_values
 
@@ -187,3 +190,10 @@ def get_valid_domain(input_domain_str):
         return string_lower
     else:  # if invalid string is passed
         return None
+
+
+def get_valid_starts_with_char(input_str):
+    # Starting alphabet can be a combination of characters as well
+    # taking only first word if multiple words are supplied
+    valid_str = str(input_str).strip().lower().split(" ")[0]
+    return valid_str

--- a/firstvoices/backend/tests/test_search/test_query_builder_utils.py
+++ b/firstvoices/backend/tests/test_search/test_query_builder_utils.py
@@ -2,9 +2,11 @@ import pytest
 
 from backend.search.utils.constants import VALID_DOCUMENT_TYPES
 from backend.search.utils.query_builder_utils import (
+    get_valid_category_id,
     get_valid_document_types,
     get_valid_domain,
 )
+from backend.tests import factories
 
 
 class TestValidDocumentTypes:
@@ -48,3 +50,21 @@ class TestValidDomains:
     def test_invalid_input(self):
         actual_domain = get_valid_domain("bananas")
         assert actual_domain is None
+
+
+@pytest.mark.django_db
+class TestValidCategory:
+    def setup(self):
+        self.site = factories.SiteFactory()
+        self.category = factories.ParentCategoryFactory(site=self.site)
+
+    def test_valid_input(self):
+        expected_category_id = self.category.id
+        actual_category_id = get_valid_category_id(self.site, self.category.id)
+
+        assert expected_category_id == actual_category_id
+
+    def test_invalid_input(self):
+        actual_category_id = get_valid_category_id(self.site, "not_real_category")
+
+        assert actual_category_id is None

--- a/firstvoices/backend/tests/test_search/test_query_params.py
+++ b/firstvoices/backend/tests/test_search/test_query_params.py
@@ -172,11 +172,6 @@ class TestCategory:
 
         assert "categories" not in str(search_query)
 
-    def test_invalid_category(self):
-        # Category is validated at view level before category_id is passed into get_search_query()
-        # function which is tested in test_query_builder_utils.py
-        pass
-
     def test_category_without_children(self):
         # relates to: DictionaryObjectTest.java - testCategoryNoChildren()
         search_query = get_search_query(category_id=self.child_category.id)

--- a/firstvoices/backend/urls.py
+++ b/firstvoices/backend/urls.py
@@ -14,6 +14,7 @@ from backend.views.image_views import ImageViewSet
 from backend.views.parts_of_speech_views import PartsOfSpeechViewSet
 from backend.views.person_views import PersonViewSet
 from backend.views.search.base_search_views import BaseSearchViewSet
+from backend.views.search.dictionary_search_views import DictionarySearchViewSet
 from backend.views.search.site_search_views import SiteSearchViewsSet
 from backend.views.sites_views import MySitesViewSet, SiteViewSet
 from backend.views.user import UserViewSet
@@ -53,6 +54,9 @@ sites_router.register(
 sites_router.register(r"images", ImageViewSet, basename="image")
 sites_router.register(r"people", PersonViewSet, basename="person")
 sites_router.register(r"search", SiteSearchViewsSet, basename="site-search")
+sites_router.register(
+    r"dictionary-search", DictionarySearchViewSet, basename="dictionary-search"
+)
 sites_router.register(r"word-of-the-day", WordOfTheDayView, basename="word-of-the-day")
 sites_router.register(r"videos", VideoViewSet, basename="video")
 

--- a/firstvoices/backend/urls.py
+++ b/firstvoices/backend/urls.py
@@ -37,6 +37,9 @@ sites_router.register(r"audio", AudioViewSet, basename="audio")
 sites_router.register(r"categories", CategoryViewSet, basename="category")
 sites_router.register(r"characters", CharactersViewSet, basename="character")
 sites_router.register(r"data", SitesDataViewSet, basename="data")
+sites_router.register(
+    r"dictionary/search", DictionarySearchViewSet, basename="dictionary-search"
+)
 sites_router.register(r"dictionary", DictionaryViewSet, basename="dictionaryentry")
 sites_router.register(
     r"dictionary-cleanup/preview",
@@ -54,9 +57,6 @@ sites_router.register(
 sites_router.register(r"images", ImageViewSet, basename="image")
 sites_router.register(r"people", PersonViewSet, basename="person")
 sites_router.register(r"search", SiteSearchViewsSet, basename="site-search")
-sites_router.register(
-    r"dictionary-search", DictionarySearchViewSet, basename="dictionary-search"
-)
 sites_router.register(r"word-of-the-day", WordOfTheDayView, basename="word-of-the-day")
 sites_router.register(r"videos", VideoViewSet, basename="video")
 

--- a/firstvoices/backend/views/search/base_search_views.py
+++ b/firstvoices/backend/views/search/base_search_views.py
@@ -170,6 +170,50 @@ from backend.views.exceptions import ElasticSearchConnectionError
                     ),
                 ],
             ),
+            OpenApiParameter(
+                name="category",
+                description="Return entries which are associated with the given category or its child categories.",
+                required=False,
+                default="",
+                type=str,
+                examples=[
+                    OpenApiExample(
+                        "",
+                        value="",
+                        description="Default case. Do not add categories filter.",
+                    ),
+                    OpenApiExample(
+                        "valid UUID",
+                        value="valid UUID",
+                        description="Return entries which are associated with "
+                        "the given category or its child categories.",
+                    ),
+                    OpenApiExample(
+                        "invalid UUID",
+                        value="invalid UUID",
+                        description="Cannot validate given id, returns empty result set.",
+                    ),
+                ],
+            ),
+            OpenApiParameter(
+                name="startsWithChar",
+                description="Return entries that start with the specified character.",
+                required=False,
+                default="",
+                type=str,
+                examples=[
+                    OpenApiExample(
+                        "",
+                        value="",
+                        description="Default case. Do not add startsWithChar filter.",
+                    ),
+                    OpenApiExample(
+                        "a",
+                        value="a",
+                        description="Return all entries starting with a.",
+                    ),
+                ],
+            ),
         ],
     ),
 )

--- a/firstvoices/backend/views/search/base_search_views.py
+++ b/firstvoices/backend/views/search/base_search_views.py
@@ -284,7 +284,8 @@ class BaseSearchViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
             return Response(data=[])
 
         # If invalid category id, return empty list as a response
-        if not search_params["category_id"]:
+        # explicitly checking if its None since it can be empty in case of non dictionary-search
+        if search_params["category_id"] is None:
             return Response(data=[])
 
         # Get search query

--- a/firstvoices/backend/views/search/base_search_views.py
+++ b/firstvoices/backend/views/search/base_search_views.py
@@ -142,9 +142,10 @@ class BaseSearchViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
 
         search_params = {
             "q": input_q,
-            "site_id": "",
             "types": valid_types_list,
             "domain": valid_domain,
+            "site_id": "",  # used in site-search
+            "starts_with_char": "",  # used in dictionary-search
         }
 
         return search_params
@@ -163,9 +164,10 @@ class BaseSearchViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         # Get search query
         search_query = get_search_query(
             q=search_params["q"],
-            site_id=search_params["site_id"],
             types=search_params["types"],
             domain=search_params["domain"],
+            site_id=search_params["site_id"],
+            starts_with_char=search_params["starts_with_char"],
         )
 
         # Get search results

--- a/firstvoices/backend/views/search/base_search_views.py
+++ b/firstvoices/backend/views/search/base_search_views.py
@@ -146,6 +146,7 @@ class BaseSearchViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
             "domain": valid_domain,
             "site_id": "",  # used in site-search
             "starts_with_char": "",  # used in dictionary-search
+            "category_id": "",  # used in dictionary-search
         }
 
         return search_params
@@ -161,6 +162,10 @@ class BaseSearchViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         if not search_params["domain"]:
             return Response(data=[])
 
+        # If invalid category id, return empty list as a response
+        if not search_params["category_id"]:
+            return Response(data=[])
+
         # Get search query
         search_query = get_search_query(
             q=search_params["q"],
@@ -168,6 +173,7 @@ class BaseSearchViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
             domain=search_params["domain"],
             site_id=search_params["site_id"],
             starts_with_char=search_params["starts_with_char"],
+            category_id=search_params["category_id"],
         )
 
         # Get search results

--- a/firstvoices/backend/views/search/dictionary_search_views.py
+++ b/firstvoices/backend/views/search/dictionary_search_views.py
@@ -18,7 +18,8 @@ class DictionarySearchViewSet(SiteSearchViewsSet):
 
         category_input_str = self.request.GET.get("category", "")
         category_id = get_valid_category_id(
-            category_input_str, self.get_validated_site()
+            self.get_validated_site()[0],
+            category_input_str,
         )
 
         if starts_with_char:

--- a/firstvoices/backend/views/search/dictionary_search_views.py
+++ b/firstvoices/backend/views/search/dictionary_search_views.py
@@ -1,0 +1,29 @@
+from backend.search.utils.query_builder_utils import (
+    get_valid_document_types,
+    get_valid_starts_with_char,
+)
+from backend.views.search.site_search_views import SiteSearchViewsSet
+
+
+class DictionarySearchViewSet(SiteSearchViewsSet):
+    def get_search_params(self):
+        """
+        Add category, and alphabetCharacter to search params
+        """
+        search_params = super().get_search_params()
+
+        starts_with_input_str = self.request.GET.get("startsWithChar", "")
+        starts_with_char = get_valid_starts_with_char(starts_with_input_str)
+
+        if starts_with_char:
+            search_params["starts_with_char"] = starts_with_char
+
+        # limit types to only words and phrases
+        input_types_str = self.request.GET.get("types", "")
+        valid_types_list = get_valid_document_types(
+            input_types_str, allowed_values=["words", "phrases"]
+        )
+
+        search_params["types"] = valid_types_list
+
+        return search_params

--- a/firstvoices/backend/views/search/dictionary_search_views.py
+++ b/firstvoices/backend/views/search/dictionary_search_views.py
@@ -1,4 +1,5 @@
 from backend.search.utils.query_builder_utils import (
+    get_valid_category_id,
     get_valid_document_types,
     get_valid_starts_with_char,
 )
@@ -15,8 +16,16 @@ class DictionarySearchViewSet(SiteSearchViewsSet):
         starts_with_input_str = self.request.GET.get("startsWithChar", "")
         starts_with_char = get_valid_starts_with_char(starts_with_input_str)
 
+        category_input_str = self.request.GET.get("category", "")
+        category_id = get_valid_category_id(
+            category_input_str, self.get_validated_site()
+        )
+
         if starts_with_char:
             search_params["starts_with_char"] = starts_with_char
+
+        if category_id:
+            search_params["category_id"] = category_id
 
         # limit types to only words and phrases
         input_types_str = self.request.GET.get("types", "")


### PR DESCRIPTION
### Description of Changes
dictionary-search api added at `/api/1.0/sites/{{site-slug}}/dictionary-search/` with the following parameters
1. category - Accepts id for a category filter. Returns all the entries associated with the given category or its child categories.
2. startsWithChar - Accepts a char (or combination of chars) and returns entries which has the given char at the beginning.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
