### PR TITLE
FW-4365 enable confusable cleanup for regex special chars

### DIFF
--- a/firstvoices/backend/models/characters.py
+++ b/firstvoices/backend/models/characters.py
@@ -272,10 +272,14 @@ class Alphabet(BaseSiteContentModel):
         if self.input_to_canonical_map:
             preprocess_settings = self.default_g2p_config["preprocess_config"]
 
+            # need to query for self to grab unescaped json: see FW-4365, FW-4559
+            readable_self = Alphabet.objects.only("input_to_canonical_map").get(
+                id=self.id
+            )
             return g2p.Transducer(
                 g2p.Mapping(
                     **preprocess_settings,
-                    mapping=self.input_to_canonical_map,
+                    mapping=readable_self.input_to_canonical_map,
                 )
             )
         else:

--- a/firstvoices/backend/tests/test_models/test_alphabet_model.py
+++ b/firstvoices/backend/tests/test_models/test_alphabet_model.py
@@ -106,10 +106,6 @@ class TestAlphabetModel:
         IgnoredCharacterFactory(site=alphabet.site, title="/")
         assert alphabet.clean_confusables("A/A") == "a/a"
 
-    @pytest.mark.skip(
-        "test bug: incorrect serialization when reading json from testdb and building transducer. "
-        "requires manual test."
-    )
     @pytest.mark.django_db
     def test_clean_confusables_regex_escape(self):
         """Default confusables transducer ignores regex rules"""


### PR DESCRIPTION
### Description of Changes
A bugfix with hacky solution. This enables confusables to contain regex special characters and still function -- regex special characters will be correctly recognized in the confusables cleanup process. For example `( -> C` or `h. -> ḥ`

### Checklist
- README / documentation has been updated if needed
- [X] PR title / commit messages contain Jira ticket number if applicable
- [X] Tests have been updated / created if applicable
- Admin Panel has been updated if models have been added or modified
- Migrations have been updated and committed if applicable
- Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
