### PR TITLE
Fw 4550, add role info to my-sites response

### DIFF
--- a/firstvoices/backend/permissions/filters/view_models.py
+++ b/firstvoices/backend/permissions/filters/view_models.py
@@ -1,4 +1,4 @@
-from . import base
+from . import base, view
 
 #
 # model-specific view permission filters
@@ -20,5 +20,5 @@ def can_view_membership_model(user):
     return (
         base.is_at_least_staff_admin(user)
         | base.has_at_least_language_admin_membership(user)
-        | base.is_own_obj(user)
+        | (base.is_own_obj(user) & view.has_visible_site(user))
     )

--- a/firstvoices/backend/permissions/predicates/view_models.py
+++ b/firstvoices/backend/permissions/predicates/view_models.py
@@ -1,6 +1,6 @@
 from rules import Predicate
 
-from . import base
+from . import base, view
 
 #
 # model-specific view permission predicates
@@ -22,7 +22,7 @@ can_view_membership_model = Predicate(
     (
         base.is_at_least_staff_admin
         | base.has_language_admin_membership
-        | base.is_own_obj
+        | (base.is_own_obj & view.has_visible_site)
     ),
     name="can_view_membership_model",
 )

--- a/firstvoices/backend/serializers/membership_serializers.py
+++ b/firstvoices/backend/serializers/membership_serializers.py
@@ -1,0 +1,39 @@
+from rest_framework import serializers
+from rest_framework.reverse import reverse
+
+from backend.models import Membership
+from backend.serializers.media_serializers import ImageSerializer
+from backend.serializers.site_serializers import (
+    FeatureFlagSerializer,
+    SiteSummarySerializer,
+)
+
+
+class MembershipSiteSummarySerializer(serializers.HyperlinkedModelSerializer):
+    """
+    Summary information about the site of a given Membership, as well as the role info.
+    """
+
+    id = serializers.UUIDField(source="site.id")
+    role = serializers.CharField(source="get_role_display")
+    url = serializers.SerializerMethodField()
+    title = serializers.CharField(source="site.title")
+    slug = serializers.CharField(source="site.slug")
+    language = serializers.StringRelatedField(source="site.language")
+    visibility = serializers.CharField(source="site.get_visibility_display")
+    logo = ImageSerializer(source="site.logo")
+    features = FeatureFlagSerializer(source="site.sitefeature_set", many=True)
+
+    def get_url(self, instance):
+        # the lookup_field of the HyperlinkedIdentityField doesn't handle related fields,
+        # so we reverse the url ourselves
+        return reverse(
+            "api:my-sites-detail",
+            current_app="backend",
+            args=[instance.site.slug],
+            request=self.context["request"],
+        )
+
+    class Meta:
+        model = Membership
+        fields = ("role",) + SiteSummarySerializer.Meta.fields

--- a/firstvoices/backend/tests/test_apis/base_api_test.py
+++ b/firstvoices/backend/tests/test_apis/base_api_test.py
@@ -73,7 +73,30 @@ class ListApiTestMixin:
 
 
 class DetailApiTestMixin:
-    pass
+    """
+    Basic tests for non-site-content detail APIs. Use with BaseApiTest.
+
+    Does NOT include permission-related tests.
+    """
+
+    def get_expected_detail_response(self, instance):
+        return self.get_expected_response(instance)
+
+    @pytest.mark.django_db
+    def test_detail_404(self):
+        response = self.client.get(self.get_detail_endpoint("fake-key"))
+        assert response.status_code == 404
+
+    @pytest.mark.django_db
+    def test_detail_minimal(self):
+        instance = self.create_minimal_instance(visibility=Visibility.PUBLIC)
+
+        response = self.client.get(self.get_detail_endpoint(key=instance.id))
+
+        assert response.status_code == 200
+
+        response_data = json.loads(response.content)
+        assert response_data == self.get_expected_detail_response(instance)
 
 
 class ReadOnlyApiTests(ListApiTestMixin, DetailApiTestMixin, BaseApiTest):

--- a/firstvoices/backend/tests/test_apis/test_my_sites_api.py
+++ b/firstvoices/backend/tests/test_apis/test_my_sites_api.py
@@ -18,7 +18,7 @@ class TestMySitesEndpoint(ReadOnlyApiTests):
 
     def create_minimal_instance(self, visibility):
         # a "my site" is a membership, so we also need a site and an authenticated user
-        site, user = factories.get_site_with_member(
+        _, user = factories.get_site_with_member(
             site_visibility=Visibility.TEAM, user_role=Role.LANGUAGE_ADMIN
         )
         self.client.force_authenticate(user=user)

--- a/firstvoices/backend/tests/test_apis/test_my_sites_api.py
+++ b/firstvoices/backend/tests/test_apis/test_my_sites_api.py
@@ -38,6 +38,17 @@ class TestMySitesEndpoint(ReadOnlyApiTests):
         }
 
     @pytest.mark.django_db
+    def test_detail_minimal(self):
+        instance = self.create_minimal_instance(visibility=Visibility.PUBLIC)
+
+        response = self.client.get(self.get_detail_endpoint(key=instance.site.slug))
+
+        assert response.status_code == 200
+
+        response_data = json.loads(response.content)
+        assert response_data == self.get_expected_detail_response(instance)
+
+    @pytest.mark.django_db
     def test_no_membership(self):
         user = factories.UserFactory.create()
         factories.SiteFactory.create(visibility=Visibility.TEAM)

--- a/firstvoices/backend/tests/test_permissions/test_predicate_view_models.py
+++ b/firstvoices/backend/tests/test_permissions/test_predicate_view_models.py
@@ -83,15 +83,21 @@ class TestCanViewSiteModel:
 
 
 class TestCanViewMembershipModel:
-    @pytest.mark.parametrize(
-        "site_visibility", [Visibility.TEAM, Visibility.MEMBERS, Visibility.PUBLIC]
-    )
+    @pytest.mark.parametrize("site_visibility", [Visibility.MEMBERS, Visibility.PUBLIC])
     @pytest.mark.django_db
     def test_user_can_view_own_membership(self, site_visibility):
         user = UserFactory.create()
         site = SiteFactory.create(visibility=site_visibility)
         membership = MembershipFactory.create(site=site, user=user, role=Role.MEMBER)
         assert view_models.can_view_membership_model(user, membership)
+
+    @pytest.mark.django_db
+    def test_user_blocked_on_team_site_edge_case(self):
+        # test that a member role on a team site is blocked
+        user = UserFactory.create()
+        site = SiteFactory.create(visibility=Visibility.TEAM)
+        membership = MembershipFactory.create(site=site, user=user, role=Role.MEMBER)
+        assert not view_models.can_view_membership_model(user, membership)
 
     @pytest.mark.parametrize(
         "site_visibility", [Visibility.TEAM, Visibility.MEMBERS, Visibility.PUBLIC]


### PR DESCRIPTION
### Description of Changes
* Slightly modified the response of the my-sites api, to include the role as well as the site info. 
* To make this simpler, I changed the queryset from a list of Sites to a list of Memberships, which exposed a small problem with the view_membership_model permission. 
* Enabled the standard pagination
* Enabled the detail view, using the site slug as the lookup key

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
