### PR TITLE
Fw 4577 rename english to translation in search domain param

### DIFF
--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -23,7 +23,7 @@ EXACT_MATCH_BOOST = 1.5
 class SearchDomains(Enum):
     BOTH = "both"
     LANGUAGE = "language"
-    ENGLISH = "english"
+    TRANSLATION = "translation"
 
 
 def get_indices(types):
@@ -140,7 +140,7 @@ def get_search_term_query(search_term, domain):
             text_search_field_match_query,
         ],
         "language": [fuzzy_match_title_query, exact_match_title_query],
-        "english": [
+        "translation": [
             fuzzy_match_translation_query,
             exact_match_translation_query,
         ],
@@ -281,7 +281,7 @@ def get_valid_domain(input_domain_str):
     if (
         string_lower == SearchDomains.BOTH.value
         or string_lower == SearchDomains.LANGUAGE.value
-        or string_lower == SearchDomains.ENGLISH.value
+        or string_lower == SearchDomains.TRANSLATION.value
     ):
         return string_lower
     else:  # if invalid string is passed

--- a/firstvoices/backend/tests/test_search/test_query_builder_utils.py
+++ b/firstvoices/backend/tests/test_search/test_query_builder_utils.py
@@ -37,7 +37,7 @@ class TestValidDomains:
     @pytest.mark.parametrize(
         "input_domain, expected_domain",
         [
-            ("english", "english"),
+            ("TRANSLATION", "translation"),
             ("LANGUAGE", "language"),
             ("both", "both"),
             (" ", "both"),

--- a/firstvoices/backend/tests/test_search/test_query_params.py
+++ b/firstvoices/backend/tests/test_search/test_query_params.py
@@ -115,7 +115,7 @@ class TestDomain:
 
     def test_english(self):
         # relates to: SearchQueryTest.java - testEnglish()
-        search_query = get_search_query(q="test_query", domain="english")
+        search_query = get_search_query(q="test_query", domain="translation")
         search_query = search_query.to_dict()
 
         # should contain translation matching

--- a/firstvoices/backend/views/search/base_search_views.py
+++ b/firstvoices/backend/views/search/base_search_views.py
@@ -107,8 +107,8 @@ from backend.views.exceptions import ElasticSearchConnectionError
                         description="Searches in both the Language and English domains.",
                     ),
                     OpenApiExample(
-                        "english",
-                        value="english",
+                        "translation",
+                        value="translation",
                         description="Performs a search focused on translations.",
                     ),
                     OpenApiExample(

--- a/firstvoices/backend/views/search/base_search_views.py
+++ b/firstvoices/backend/views/search/base_search_views.py
@@ -310,7 +310,7 @@ class BaseSearchViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         )
 
         # Sort by score, then by custom sort order
-        search_query = search_query.sort("_score", "custom_order")
+        search_query = search_query.sort("_score", "custom_order", "title")
 
         # Get search results
         try:


### PR DESCRIPTION
### Description of Changes
Renamed "english" to "translation" as a option for `domain` parameter in search API.
bonus change: Added `title` as a fallback for sorting order in search API.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
