### PR TITLE
FW-4598 Handle invalid page and pageSize values in search Pagination

### DIFF
--- a/firstvoices/backend/pagination.py
+++ b/firstvoices/backend/pagination.py
@@ -98,3 +98,20 @@ class SearchPageNumberPagination(PageNumberPagination):
 
         self.request = request
         return list(self.page)
+
+    @staticmethod
+    def override_invalid_number(number, override_value=1):
+        """
+        A modified version the Django Paginator validate_number method to set invalid page numbers to 1.
+        This allows the pagination parameters to be used and the invalid page number to be caught by the
+        paginator.
+        """
+        try:
+            if isinstance(number, float) and not number.is_integer():
+                return override_value
+            number = int(number)
+        except (TypeError, ValueError):
+            return override_value
+        if number < 1:
+            return override_value
+        return number

--- a/firstvoices/backend/views/search/base_search_views.py
+++ b/firstvoices/backend/views/search/base_search_views.py
@@ -263,15 +263,11 @@ class BaseSearchViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         """
         default_page_size = self.paginator.get_page_size(self.request)
 
-        valid_page_number = self.paginator.override_invalid_number(
-            self.request.GET.get("page", 1)
-        )
-        page = valid_page_number
+        page = self.paginator.override_invalid_number(self.request.GET.get("page", 1))
 
-        valid_page_size = self.paginator.override_invalid_number(
+        page_size = self.paginator.override_invalid_number(
             self.request.GET.get("pageSize", default_page_size), default_page_size
         )
-        page_size = valid_page_size
 
         start = (page - 1) * page_size
 

--- a/firstvoices/backend/views/search/base_search_views.py
+++ b/firstvoices/backend/views/search/base_search_views.py
@@ -263,8 +263,16 @@ class BaseSearchViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         """
         default_page_size = self.paginator.get_page_size(self.request)
 
-        page = int(self.request.GET.get("page", 1))
-        page_size = int(self.request.GET.get("pageSize", default_page_size))
+        valid_page_number = self.paginator.override_invalid_number(
+            self.request.GET.get("page", 1)
+        )
+        page = valid_page_number
+
+        valid_page_size = self.paginator.override_invalid_number(
+            self.request.GET.get("pageSize", default_page_size), default_page_size
+        )
+        page_size = valid_page_size
+
         start = (page - 1) * page_size
 
         pagination_params = {


### PR DESCRIPTION
### Description of Changes
Adds an `override_invalid_number` method to handle invalid page and pageSize values in search pagination parameters. This lets the search proceed, during which the invalid values are handled by the paginator.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
