### PR TITLE
FW-4329 Add SitePage read API

### DIFF
--- a/firstvoices/backend/serializers/page_serializers.py
+++ b/firstvoices/backend/serializers/page_serializers.py
@@ -23,12 +23,7 @@ class SitePageSerializer(SiteContentLinkedTitleSerializer):
         )
 
 
-class SitePageDetailSerializer(SiteContentLinkedTitleSerializer):
-    url = SiteHyperlinkedIdentityField(
-        view_name="api:sitepage-detail", lookup_field="slug"
-    )
-    slug = serializers.CharField(read_only=True)
-    visibility = serializers.CharField(read_only=True, source="get_visibility_display")
+class SitePageDetailSerializer(SitePageSerializer):
     widgets = SiteWidgetListSerializer()
     banner_image = ImageSerializer()
     banner_video = VideoSerializer()

--- a/firstvoices/backend/serializers/page_serializers.py
+++ b/firstvoices/backend/serializers/page_serializers.py
@@ -1,0 +1,45 @@
+from rest_framework import serializers
+
+from backend.models import SitePage
+from backend.serializers.base_serializers import SiteContentLinkedTitleSerializer
+from backend.serializers.fields import SiteHyperlinkedIdentityField
+from backend.serializers.media_serializers import ImageSerializer, VideoSerializer
+from backend.serializers.widget_serializers import SiteWidgetListSerializer
+
+
+class SitePageSerializer(SiteContentLinkedTitleSerializer):
+    url = SiteHyperlinkedIdentityField(
+        view_name="api:sitepage-detail", lookup_field="slug"
+    )
+    slug = serializers.CharField(read_only=True)
+    visibility = serializers.CharField(read_only=True, source="get_visibility_display")
+
+    class Meta(SiteContentLinkedTitleSerializer.Meta):
+        model = SitePage
+        fields = SiteContentLinkedTitleSerializer.Meta.fields + (
+            "visibility",
+            "subtitle",
+            "slug",
+        )
+
+
+class SitePageDetailSerializer(SiteContentLinkedTitleSerializer):
+    url = SiteHyperlinkedIdentityField(
+        view_name="api:sitepage-detail", lookup_field="slug"
+    )
+    slug = serializers.CharField(read_only=True)
+    visibility = serializers.CharField(read_only=True, source="get_visibility_display")
+    widgets = SiteWidgetListSerializer()
+    banner_image = ImageSerializer()
+    banner_video = VideoSerializer()
+
+    class Meta(SiteContentLinkedTitleSerializer.Meta):
+        model = SitePage
+        fields = SiteContentLinkedTitleSerializer.Meta.fields + (
+            "visibility",
+            "subtitle",
+            "slug",
+            "widgets",
+            "banner_image",
+            "banner_video",
+        )

--- a/firstvoices/backend/serializers/site_serializers.py
+++ b/firstvoices/backend/serializers/site_serializers.py
@@ -89,6 +89,7 @@ class SiteDetailSerializer(UpdateSerializerMixin, SiteSummarySerializer):
     )
     ignored_characters = SiteViewLinkField(view_name="api:ignoredcharacter-list")
     images = SiteViewLinkField(view_name="api:image-list")
+    pages = SiteViewLinkField(view_name="api:sitepage-list")
     people = SiteViewLinkField(view_name="api:person-list")
     songs = SiteViewLinkField(view_name="api:song-list")
     videos = SiteViewLinkField(view_name="api:video-list")
@@ -119,6 +120,7 @@ class SiteDetailSerializer(UpdateSerializerMixin, SiteSummarySerializer):
             "dictionary_cleanup_preview",
             "ignored_characters",
             "images",
+            "pages",
             "people",
             "songs",
             "videos",

--- a/firstvoices/backend/tests/factories/site_page_factories.py
+++ b/firstvoices/backend/tests/factories/site_page_factories.py
@@ -13,4 +13,4 @@ class SitePageFactory(DjangoModelFactory):
         model = SitePage
 
     title = factory.Sequence(lambda n: "SitePage-%03d" % n)
-    slug = factory.Sequence(lambda n: "site-%03d" % n)
+    slug = factory.Sequence(lambda n: "site-page-%03d" % n)

--- a/firstvoices/backend/tests/test_apis/base_api_test.py
+++ b/firstvoices/backend/tests/test_apis/base_api_test.py
@@ -5,6 +5,7 @@ from django.utils.http import urlencode
 from rest_framework.reverse import reverse
 from rest_framework.test import APIClient
 
+from backend.models import SitePage
 from backend.models.constants import AppRole, Role, Visibility
 from backend.tests import factories
 
@@ -252,7 +253,9 @@ class SiteContentDetailApiTestMixin:
         instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
 
         response = self.client.get(
-            self.get_detail_endpoint(key=instance.id, site_slug="invalid")
+            self.get_detail_endpoint(key=instance.slug, site_slug="invalid")
+            if instance.__class__ == SitePage
+            else self.get_detail_endpoint(key=instance.id, site_slug="invalid")
         )
 
         assert response.status_code == 404
@@ -264,7 +267,9 @@ class SiteContentDetailApiTestMixin:
         instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
 
         response = self.client.get(
-            self.get_detail_endpoint(key=instance.id, site_slug=site.slug)
+            self.get_detail_endpoint(key=instance.slug, site_slug=site.slug)
+            if instance.__class__ == SitePage
+            else self.get_detail_endpoint(key=instance.id, site_slug=site.slug)
         )
 
         assert response.status_code == 403
@@ -282,7 +287,9 @@ class SiteContentDetailApiTestMixin:
         )
 
         response = self.client.get(
-            self.get_detail_endpoint(key=instance.id, site_slug=site.slug)
+            self.get_detail_endpoint(key=instance.slug, site_slug=site.slug)
+            if instance.__class__ == SitePage
+            else self.get_detail_endpoint(key=instance.id, site_slug=site.slug)
         )
 
         assert response.status_code == 200
@@ -297,7 +304,9 @@ class SiteContentDetailApiTestMixin:
         instance = self.create_minimal_instance(site=site, visibility=Visibility.TEAM)
 
         response = self.client.get(
-            self.get_detail_endpoint(key=instance.id, site_slug=site.slug)
+            self.get_detail_endpoint(key=instance.slug, site_slug=site.slug)
+            if instance.__class__ == SitePage
+            else self.get_detail_endpoint(key=instance.id, site_slug=site.slug)
         )
 
         assert response.status_code == 200
@@ -308,7 +317,9 @@ class SiteContentDetailApiTestMixin:
         instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
 
         response = self.client.get(
-            self.get_detail_endpoint(key=instance.id, site_slug=site.slug)
+            self.get_detail_endpoint(key=instance.slug, site_slug=site.slug)
+            if instance.__class__ == SitePage
+            else self.get_detail_endpoint(key=instance.id, site_slug=site.slug)
         )
 
         assert response.status_code == 200
@@ -357,7 +368,9 @@ class ControlledDetailApiTestMixin:
         instance = self.create_minimal_instance(site=site, visibility=Visibility.TEAM)
 
         response = self.client.get(
-            self.get_detail_endpoint(key=instance.id, site_slug=site.slug)
+            self.get_detail_endpoint(key=instance.slug, site_slug=site.slug)
+            if instance.__class__ == SitePage
+            else self.get_detail_endpoint(key=instance.id, site_slug=site.slug)
         )
 
         assert response.status_code == 403

--- a/firstvoices/backend/tests/test_apis/test_pages_api.py
+++ b/firstvoices/backend/tests/test_apis/test_pages_api.py
@@ -1,0 +1,231 @@
+import json
+
+import pytest
+
+from backend.models.constants import Role, Visibility
+from backend.models.widget import SiteWidgetListOrder
+from backend.tests import factories
+from backend.tests.test_apis.base_api_test import (
+    BaseReadOnlyControlledSiteContentApiTest,
+)
+
+
+class TestSitePageEndpoint(BaseReadOnlyControlledSiteContentApiTest):
+    API_LIST_VIEW = "api:sitepage-list"
+    API_DETAIL_VIEW = "api:sitepage-detail"
+
+    def create_minimal_instance(self, site, visibility):
+        return factories.SitePageFactory.create(site=site, visibility=visibility)
+
+    def get_expected_response(self, page, site):
+        return {
+            "id": str(page.id),
+            "title": page.title,
+            "url": f"http://testserver{self.get_detail_endpoint(key=page.slug, site_slug=site.slug)}",
+            "visibility": "Public",
+            "subtitle": "",
+            "slug": page.slug,
+        }
+
+    def get_expected_detail_response(self, page, site):
+        return {
+            "id": str(page.id),
+            "title": page.title,
+            "url": f"http://testserver{self.get_detail_endpoint(key=page.slug, site_slug=site.slug)}",
+            "visibility": "Public",
+            "subtitle": "",
+            "slug": page.slug,
+            "widgets": [],
+            "bannerImage": None,
+            "bannerVideo": None,
+        }
+
+    @pytest.mark.parametrize(
+        "user_role, expected_visible_pages",
+        [
+            (None, 1),
+            (Role.MEMBER, 2),
+            (Role.ASSISTANT, 3),
+            (Role.EDITOR, 3),
+            (Role.LANGUAGE_ADMIN, 3),
+        ],
+    )
+    @pytest.mark.django_db
+    def test_page_permissions(self, user_role, expected_visible_pages):
+        user = factories.UserFactory.create(id=1)
+        self.client.force_authenticate(user=user)
+
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+        if user_role is not None:
+            factories.MembershipFactory.create(user=user, site=site, role=user_role)
+
+        factories.SitePageFactory.create(site=site, visibility=Visibility.PUBLIC)
+        factories.SitePageFactory.create(site=site, visibility=Visibility.MEMBERS)
+        factories.SitePageFactory.create(site=site, visibility=Visibility.TEAM)
+
+        response = self.client.get(f"{self.get_list_endpoint(site.slug)}")
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+
+        assert len(response_data["results"]) == expected_visible_pages
+
+    def update_widget_sites(self, site, widgets):
+        for widget in widgets:
+            widget.site = site
+            widget.save()
+
+    @pytest.mark.django_db
+    def test_detail_widget_order(self):
+        user = factories.get_non_member_user()
+        self.client.force_authenticate(user=user)
+
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+        factories.SiteWidgetListOrderFactory.reset_sequence()
+        widget_list = factories.SiteWidgetListWithThreeWidgetsFactory.create(site=site)
+
+        # Get the widgets from the widget list
+        widget_one = widget_list.widgets.all()[0]
+        widget_two = widget_list.widgets.all()[1]
+        widget_three = widget_list.widgets.all()[2]
+        self.update_widget_sites(site, [widget_one, widget_two, widget_three])
+
+        site_page = factories.SitePageFactory.create(
+            site=site, visibility=Visibility.PUBLIC, widgets=widget_list
+        )
+
+        # Get the order field for each widget from the through model
+        list_order_one = (
+            SiteWidgetListOrder.objects.filter(site_widget=widget_one).first().order
+        )
+        list_order_two = (
+            SiteWidgetListOrder.objects.filter(site_widget=widget_two).first().order
+        )
+        list_order_three = (
+            SiteWidgetListOrder.objects.filter(site_widget=widget_three).first().order
+        )
+
+        # Check the order of the widgets as they were created.
+        assert list_order_one == 2
+        assert list_order_two == 0
+        assert list_order_three == 1
+
+        response = self.client.get(
+            f"{self.get_detail_endpoint(key=site_page.slug, site_slug=site.slug)}"
+        )
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+
+        assert len(response_data["widgets"]) == 3
+
+        # Check that the widgets have been re-arranged based on the order field in the API response.
+        assert response_data["widgets"][0]["id"] == str(widget_two.id)
+        assert response_data["widgets"][1]["id"] == str(widget_three.id)
+        assert response_data["widgets"][2]["id"] == str(widget_one.id)
+
+    @pytest.mark.django_db
+    def test_detail_widget_order_in_multiple_lists(self):
+        user = factories.get_non_member_user()
+        self.client.force_authenticate(user=user)
+
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+        factories.SiteWidgetListOrderFactory.reset_sequence()
+        widget_list_one = factories.SiteWidgetListWithThreeWidgetsFactory.create(
+            site=site
+        )
+
+        widget_list_two = factories.SiteWidgetListWithThreeWidgetsFactory.create(
+            site=site
+        )
+
+        # Get the widgets from each of the factories.
+        widget_one = widget_list_one.widgets.all()[0]
+        widget_two = widget_list_one.widgets.all()[1]
+        widget_three = widget_list_one.widgets.all()[2]
+        widget_four = widget_list_two.widgets.all()[0]
+        widget_five = widget_list_two.widgets.all()[1]
+        widget_six = widget_list_two.widgets.all()[2]
+
+        # Set the widgets to all belong to the same site.
+        self.update_widget_sites(
+            site,
+            [
+                widget_one,
+                widget_two,
+                widget_three,
+                widget_four,
+                widget_five,
+                widget_six,
+            ],
+        )
+
+        # Create a site page with the widget list
+        site_page = factories.SitePageFactory.create(
+            site=site, visibility=Visibility.PUBLIC, widgets=widget_list_two
+        )
+
+        # Get the order of the widgets.
+        widget_one_list_one_order = SiteWidgetListOrder.objects.filter(
+            site_widget=widget_one
+        ).first()
+        widget_two_list_one_order = SiteWidgetListOrder.objects.filter(
+            site_widget=widget_two
+        ).first()
+        widget_three_list_one_order = SiteWidgetListOrder.objects.filter(
+            site_widget=widget_three
+        ).first()
+        widget_four_list_two_order = SiteWidgetListOrder.objects.filter(
+            site_widget=widget_four
+        ).first()
+        widget_five_list_two_order = SiteWidgetListOrder.objects.filter(
+            site_widget=widget_five
+        ).first()
+        widget_six_list_two_order = SiteWidgetListOrder.objects.filter(
+            site_widget=widget_six
+        ).first()
+
+        # Update one of the existing widgets order (to free up order 0 in the list)
+        widget_five_list_two_order.order = 3
+        widget_five_list_two_order.save()
+
+        assert widget_one_list_one_order.order == 2
+        assert widget_two_list_one_order.order == 0
+        assert widget_three_list_one_order.order == 1
+        assert widget_four_list_two_order.order == 2
+        assert widget_five_list_two_order.order == 3
+        assert widget_six_list_two_order.order == 1
+
+        # Add a widget from widget_list_one to widget_list_two with a different order
+        SiteWidgetListOrder.objects.create(
+            site_widget=widget_one, site_widget_list=widget_list_two, order=0
+        )
+
+        response = self.client.get(
+            f"{self.get_detail_endpoint(key=site_page.slug, site_slug=site.slug)}"
+        )
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+
+        assert len(response_data["widgets"]) == 4
+
+        # Check that the homepage uses the order in widget_list_two for widget_one
+        assert response_data["widgets"][0]["id"] == str(widget_one.id)
+        assert response_data["widgets"][1]["id"] == str(widget_six.id)
+        assert response_data["widgets"][2]["id"] == str(widget_four.id)
+        assert response_data["widgets"][3]["id"] == str(widget_five.id)
+
+        # Update the homepage to widget_list_one
+        site_page.widgets = widget_list_one
+        site_page.save()
+
+        response = self.client.get(
+            f"{self.get_detail_endpoint(key=site_page.slug, site_slug=site.slug)}"
+        )
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+
+        assert len(response_data["widgets"]) == 3
+
+        # Check that the homepage uses the order in widget_list_one for widget_one
+        assert response_data["widgets"][0]["id"] == str(widget_two.id)
+        assert response_data["widgets"][1]["id"] == str(widget_three.id)
+        assert response_data["widgets"][2]["id"] == str(widget_one.id)

--- a/firstvoices/backend/tests/test_apis/test_pages_api.py
+++ b/firstvoices/backend/tests/test_apis/test_pages_api.py
@@ -8,6 +8,7 @@ from backend.tests import factories
 from backend.tests.test_apis.base_api_test import (
     BaseReadOnlyControlledSiteContentApiTest,
 )
+from backend.tests.utils import setup_widget_list, update_widget_list_order
 
 
 class TestSitePageEndpoint(BaseReadOnlyControlledSiteContentApiTest):
@@ -127,77 +128,15 @@ class TestSitePageEndpoint(BaseReadOnlyControlledSiteContentApiTest):
         user = factories.get_non_member_user()
         self.client.force_authenticate(user=user)
 
-        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
-        factories.SiteWidgetListOrderFactory.reset_sequence()
-        widget_list_one = factories.SiteWidgetListWithThreeWidgetsFactory.create(
-            site=site
-        )
-
-        widget_list_two = factories.SiteWidgetListWithThreeWidgetsFactory.create(
-            site=site
-        )
-
-        # Get the widgets from each of the factories.
-        widget_one = widget_list_one.widgets.all()[0]
-        widget_two = widget_list_one.widgets.all()[1]
-        widget_three = widget_list_one.widgets.all()[2]
-        widget_four = widget_list_two.widgets.all()[0]
-        widget_five = widget_list_two.widgets.all()[1]
-        widget_six = widget_list_two.widgets.all()[2]
-
-        # Set the widgets to all belong to the same site.
-        self.update_widget_sites(
-            site,
-            [
-                widget_one,
-                widget_two,
-                widget_three,
-                widget_four,
-                widget_five,
-                widget_six,
-            ],
-        )
+        site, widget_list_one, widget_list_two, widgets = setup_widget_list()
 
         # Create a site page with the widget list
         site_page = factories.SitePageFactory.create(
             site=site, visibility=Visibility.PUBLIC, widgets=widget_list_two
         )
 
-        # Get the order of the widgets.
-        widget_one_list_one_order = SiteWidgetListOrder.objects.filter(
-            site_widget=widget_one
-        ).first()
-        widget_two_list_one_order = SiteWidgetListOrder.objects.filter(
-            site_widget=widget_two
-        ).first()
-        widget_three_list_one_order = SiteWidgetListOrder.objects.filter(
-            site_widget=widget_three
-        ).first()
-        widget_four_list_two_order = SiteWidgetListOrder.objects.filter(
-            site_widget=widget_four
-        ).first()
-        widget_five_list_two_order = SiteWidgetListOrder.objects.filter(
-            site_widget=widget_five
-        ).first()
-        widget_six_list_two_order = SiteWidgetListOrder.objects.filter(
-            site_widget=widget_six
-        ).first()
-
-        # Update one of the existing widgets order (to free up order 0 in the list)
-        widget_five_list_two_order.order = 3
-        widget_five_list_two_order.save()
-
-        assert widget_one_list_one_order.order == 2
-        assert widget_two_list_one_order.order == 0
-        assert widget_three_list_one_order.order == 1
-        assert widget_four_list_two_order.order == 2
-        assert widget_five_list_two_order.order == 3
-        assert widget_six_list_two_order.order == 1
-
-        # Add a widget from widget_list_one to widget_list_two with a different order
-        SiteWidgetListOrder.objects.create(
-            site_widget=widget_one, site_widget_list=widget_list_two, order=0
-        )
+        # Check the widget list orders and add a widget from widget_list_one to widget_list_two with a different order
+        update_widget_list_order(widgets, widget_list_two)
 
         response = self.client.get(
             f"{self.get_detail_endpoint(key=site_page.slug, site_slug=site.slug)}"
@@ -208,10 +147,10 @@ class TestSitePageEndpoint(BaseReadOnlyControlledSiteContentApiTest):
         assert len(response_data["widgets"]) == 4
 
         # Check that the homepage uses the order in widget_list_two for widget_one
-        assert response_data["widgets"][0]["id"] == str(widget_one.id)
-        assert response_data["widgets"][1]["id"] == str(widget_six.id)
-        assert response_data["widgets"][2]["id"] == str(widget_four.id)
-        assert response_data["widgets"][3]["id"] == str(widget_five.id)
+        assert response_data["widgets"][0]["id"] == str(widgets[0].id)
+        assert response_data["widgets"][1]["id"] == str(widgets[5].id)
+        assert response_data["widgets"][2]["id"] == str(widgets[3].id)
+        assert response_data["widgets"][3]["id"] == str(widgets[4].id)
 
         # Update the homepage to widget_list_one
         site_page.widgets = widget_list_one
@@ -226,6 +165,6 @@ class TestSitePageEndpoint(BaseReadOnlyControlledSiteContentApiTest):
         assert len(response_data["widgets"]) == 3
 
         # Check that the homepage uses the order in widget_list_one for widget_one
-        assert response_data["widgets"][0]["id"] == str(widget_two.id)
-        assert response_data["widgets"][1]["id"] == str(widget_three.id)
-        assert response_data["widgets"][2]["id"] == str(widget_one.id)
+        assert response_data["widgets"][0]["id"] == str(widgets[1].id)
+        assert response_data["widgets"][1]["id"] == str(widgets[2].id)
+        assert response_data["widgets"][2]["id"] == str(widgets[0].id)

--- a/firstvoices/backend/tests/test_apis/test_pages_api.py
+++ b/firstvoices/backend/tests/test_apis/test_pages_api.py
@@ -8,7 +8,11 @@ from backend.tests import factories
 from backend.tests.test_apis.base_api_test import (
     BaseReadOnlyControlledSiteContentApiTest,
 )
-from backend.tests.utils import setup_widget_list, update_widget_list_order
+from backend.tests.utils import (
+    setup_widget_list,
+    update_widget_list_order,
+    update_widget_sites,
+)
 
 
 class TestSitePageEndpoint(BaseReadOnlyControlledSiteContentApiTest):
@@ -70,11 +74,6 @@ class TestSitePageEndpoint(BaseReadOnlyControlledSiteContentApiTest):
 
         assert len(response_data["results"]) == expected_visible_pages
 
-    def update_widget_sites(self, site, widgets):
-        for widget in widgets:
-            widget.site = site
-            widget.save()
-
     @pytest.mark.django_db
     def test_detail_widget_order(self):
         user = factories.get_non_member_user()
@@ -88,7 +87,7 @@ class TestSitePageEndpoint(BaseReadOnlyControlledSiteContentApiTest):
         widget_one = widget_list.widgets.all()[0]
         widget_two = widget_list.widgets.all()[1]
         widget_three = widget_list.widgets.all()[2]
-        self.update_widget_sites(site, [widget_one, widget_two, widget_three])
+        update_widget_sites(site, [widget_one, widget_two, widget_three])
 
         site_page = factories.SitePageFactory.create(
             site=site, visibility=Visibility.PUBLIC, widgets=widget_list

--- a/firstvoices/backend/tests/test_apis/test_sites_api.py
+++ b/firstvoices/backend/tests/test_apis/test_sites_api.py
@@ -172,6 +172,7 @@ class TestSitesEndpoints(MediaTestMixin, BaseApiTest):
             "dictionaryCleanupPreview": f"{site_url}/dictionary-cleanup/preview",
             "ignoredCharacters": f"{site_url}/ignored-characters",
             "images": f"{site_url}/images",
+            "pages": f"{site_url}/pages",
             "people": f"{site_url}/people",
             "songs": f"{site_url}/songs",
             "videos": f"{site_url}/videos",

--- a/firstvoices/backend/tests/utils.py
+++ b/firstvoices/backend/tests/utils.py
@@ -1,8 +1,88 @@
 import random
 import string
 
+from backend.models.constants import Visibility
+from backend.models.widget import SiteWidgetListOrder
+from backend.tests import factories
+
 
 def generate_string(length):
     """Function to generate string of ascii characters (both upper and lower case) for the given length."""
     letters = string.ascii_letters
     return "".join(random.choices(letters, k=length))  # NOSONAR
+
+
+def update_widget_sites(site, widgets):
+    for widget in widgets:
+        widget.site = site
+        widget.save()
+
+
+def setup_widget_list():
+    site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+    factories.SiteWidgetListOrderFactory.reset_sequence()
+    widget_list_one = factories.SiteWidgetListWithThreeWidgetsFactory.create(site=site)
+
+    widget_list_two = factories.SiteWidgetListWithThreeWidgetsFactory.create(site=site)
+
+    # Get the widgets from each of the factories.
+    widget_one = widget_list_one.widgets.all()[0]
+    widget_two = widget_list_one.widgets.all()[1]
+    widget_three = widget_list_one.widgets.all()[2]
+    widget_four = widget_list_two.widgets.all()[0]
+    widget_five = widget_list_two.widgets.all()[1]
+    widget_six = widget_list_two.widgets.all()[2]
+
+    widgets = [
+        widget_one,
+        widget_two,
+        widget_three,
+        widget_four,
+        widget_five,
+        widget_six,
+    ]
+    # Set the widgets to all belong to the same site.
+    update_widget_sites(
+        site,
+        widgets,
+    )
+
+    return site, widget_list_one, widget_list_two, widgets
+
+
+def update_widget_list_order(widgets, widget_list_two):
+    # Get the order of the widgets.
+    widget_one_list_one_order = SiteWidgetListOrder.objects.filter(
+        site_widget=widgets[0]
+    ).first()
+    widget_two_list_one_order = SiteWidgetListOrder.objects.filter(
+        site_widget=widgets[1]
+    ).first()
+    widget_three_list_one_order = SiteWidgetListOrder.objects.filter(
+        site_widget=widgets[2]
+    ).first()
+    widget_four_list_two_order = SiteWidgetListOrder.objects.filter(
+        site_widget=widgets[3]
+    ).first()
+    widget_five_list_two_order = SiteWidgetListOrder.objects.filter(
+        site_widget=widgets[4]
+    ).first()
+    widget_six_list_two_order = SiteWidgetListOrder.objects.filter(
+        site_widget=widgets[5]
+    ).first()
+
+    # Update one of the existing widgets order (to free up order 0 in the list)
+    widget_five_list_two_order.order = 3
+    widget_five_list_two_order.save()
+
+    assert widget_one_list_one_order.order == 2
+    assert widget_two_list_one_order.order == 0
+    assert widget_three_list_one_order.order == 1
+    assert widget_four_list_two_order.order == 2
+    assert widget_five_list_two_order.order == 3
+    assert widget_six_list_two_order.order == 1
+
+    # Add a widget from widget_list_one to widget_list_two with a different order
+    SiteWidgetListOrder.objects.create(
+        site_widget=widgets[0], site_widget_list=widget_list_two, order=0
+    )

--- a/firstvoices/backend/urls.py
+++ b/firstvoices/backend/urls.py
@@ -11,6 +11,7 @@ from backend.views.custom_order_recalculate_views import (
 from backend.views.data_views import SitesDataViewSet
 from backend.views.dictionary_views import DictionaryViewSet
 from backend.views.image_views import ImageViewSet
+from backend.views.page_views import SitePageViewSet
 from backend.views.parts_of_speech_views import PartsOfSpeechViewSet
 from backend.views.person_views import PersonViewSet
 from backend.views.search.base_search_views import BaseSearchViewSet
@@ -56,6 +57,7 @@ sites_router.register(r"images", ImageViewSet, basename="image")
 sites_router.register(r"people", PersonViewSet, basename="person")
 sites_router.register(r"search", SiteSearchViewsSet, basename="site-search")
 sites_router.register(r"word-of-the-day", WordOfTheDayView, basename="word-of-the-day")
+sites_router.register(r"pages", SitePageViewSet, basename="sitepage")
 sites_router.register(r"songs", SongViewSet, basename="song")
 sites_router.register(r"videos", VideoViewSet, basename="video")
 sites_router.register(r"widgets", SiteWidgetViewSet, basename="sitewidget")

--- a/firstvoices/backend/views/api_doc_variables.py
+++ b/firstvoices/backend/views/api_doc_variables.py
@@ -2,8 +2,17 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter
 
 site_slug_parameter = OpenApiParameter(
-    name="site_slug", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+    name="site_slug",
+    type=OpenApiTypes.STR,
+    location=OpenApiParameter.PATH,
+    description="site-slug",
 )
 id_parameter = OpenApiParameter(
     name="id", type=OpenApiTypes.STR, location=OpenApiParameter.PATH
+)
+site_page_slug_parameter = OpenApiParameter(
+    name="slug",
+    type=OpenApiTypes.STR,
+    location=OpenApiParameter.PATH,
+    description="page-slug",
 )

--- a/firstvoices/backend/views/page_views.py
+++ b/firstvoices/backend/views/page_views.py
@@ -1,0 +1,97 @@
+from django.db.models import Prefetch
+from drf_spectacular.utils import (
+    OpenApiResponse,
+    extend_schema,
+    extend_schema_view,
+    inline_serializer,
+)
+from rest_framework import serializers
+from rest_framework.viewsets import ModelViewSet
+
+from backend.models import SitePage
+from backend.models.widget import SiteWidget
+from backend.serializers.media_serializers import ImageSerializer, VideoSerializer
+from backend.serializers.page_serializers import (
+    SitePageDetailSerializer,
+    SitePageSerializer,
+)
+from backend.serializers.widget_serializers import SiteWidgetDetailSerializer
+from backend.views import doc_strings
+from backend.views.api_doc_variables import (
+    site_page_slug_parameter,
+    site_slug_parameter,
+)
+from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSetMixin
+
+
+@extend_schema_view(
+    list=extend_schema(
+        description="A list of available pages for the specified site.",
+        responses={
+            200: SitePageSerializer,
+            403: OpenApiResponse(description=doc_strings.error_403_site_access_denied),
+            404: OpenApiResponse(description=doc_strings.error_404_missing_site),
+        },
+        parameters=[site_slug_parameter],
+    ),
+    retrieve=extend_schema(
+        description="A page from the specified site.",
+        responses={
+            200: inline_serializer(
+                name="InlinePageDetailSerializer",
+                fields={
+                    "id": serializers.UUIDField(),
+                    "title": serializers.CharField(),
+                    "url": serializers.URLField(),
+                    "visibility": serializers.CharField(),
+                    "subtitle": serializers.CharField(),
+                    "slug": serializers.SlugField(),
+                    "widgets": SiteWidgetDetailSerializer(many=True),
+                    "banner_image": ImageSerializer(),
+                    "banner_video": VideoSerializer(),
+                },
+            ),
+            403: OpenApiResponse(description=doc_strings.error_403),
+            404: OpenApiResponse(description=doc_strings.error_404),
+        },
+        parameters=[
+            site_slug_parameter,
+            site_page_slug_parameter,
+        ],
+    ),
+)
+class SitePageViewSet(FVPermissionViewSetMixin, SiteContentViewSetMixin, ModelViewSet):
+    http_method_names = ["get"]
+    lookup_field = "slug"
+
+    def get_queryset(self):
+        if self.action == "retrieve":
+            return self.get_detail_queryset()
+
+        site = self.get_validated_site()
+        return (
+            SitePage.objects.filter(site__slug=site[0].slug)
+            .select_related("widgets", "banner_image", "banner_video")
+            .prefetch_related()
+        )
+
+    def get_detail_queryset(self):
+        site = self.get_validated_site()
+        return (
+            SitePage.objects.filter(site__slug=site[0].slug)
+            .select_related("widgets", "banner_image", "banner_video")
+            .prefetch_related(
+                Prefetch(
+                    "widgets__widgets",
+                    queryset=SiteWidget.objects.visible(self.request.user).order_by(
+                        "sitewidgetlistorder_set__order"
+                    ),
+                ),
+            )
+        )
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return SitePageSerializer
+        else:
+            return SitePageDetailSerializer


### PR DESCRIPTION
### Description of Changes
These changes adds the SitePage model list and detail read API at `/api/1.0/sites/{site-slug}/pages` and `/api/1.0/sites/{site-slug}/pages/{page-slug}`.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [x] Pull the branch and test locally

### Additional Notes
When reviewing, please check that the widget list order is correct even when a widget belongs to multiple lists with different orders. QA details can be found in [FW-4329](https://firstvoices.atlassian.net/browse/FW-4329).


[FW-4329]: https://firstvoices.atlassian.net/browse/FW-4329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ