### PR TITLE
FW-4412 import site model

### DIFF
--- a/firstvoices/backend/fixtures/languages.json
+++ b/firstvoices/backend/fixtures/languages.json
@@ -30,7 +30,7 @@
     "model": "backend.language",
     "fields": {
       "title": "Dane-Ẕaa",
-      "alternate_names": "Dane-zaa Ẕáágéʔ, Beaver, Dunne-za, ᑕᓀ ᖚ",
+      "alternate_names": "Dane-ẕaa Ẕáágéʔ, Beaver, Dunne-ẕa, ᑕᓀ ᖚ",
       "language_family": ["Na-Dene"],
       "language_code": "bea"
     }
@@ -38,7 +38,7 @@
   {
     "model": "backend.language",
     "fields": {
-      "title": "Danezāgé’",
+      "title": "Danezāgéʼ",
       "alternate_names": "Kaska, Kaska Dena",
       "language_family": ["Na-Dene"],
       "language_code": "kkz"
@@ -47,8 +47,8 @@
   {
     "model": "backend.language",
     "fields": {
-      "title": "Dene K’e",
-      "alternate_names": "Slavey, Slave, Dene K’eh, Dene, Dené, Dené Tha’, Dené Dháh, Dene Zhatıé, Acha'otinne",
+      "title": "Dene Kʼe",
+      "alternate_names": "Slavey, Slave, Dene Kʼeh, Dene, Dené, Dené Thaʼ, Dené Dháh, Dene Zhatıé, Achaʼotinne",
       "language_family": ["Na-Dene"],
       "language_code": "den"
     }
@@ -57,7 +57,7 @@
     "model": "backend.language",
     "fields": {
       "title": "Lingít",
-      "alternate_names": "Tlingit",
+      "alternate_names": "Łingít, Tlingit",
       "language_family": ["Na-Dene"],
       "language_code": "tli"
     }
@@ -65,8 +65,8 @@
   {
     "model": "backend.language",
     "fields": {
-      "title": "Nedut’en / Witsuwit’en",
-      "alternate_names": "Nedut’en, Nadot’en, Witsuwit’en, Babine, Nat’oot’en, Wet'suwet'en",
+      "title": "Nedutʼen / Witsuwitʼen",
+      "alternate_names": "Nedutʼen, Nadotʼen, Witsuwitʼen, Babine, Natʼootʼen, Wetʼsuwetʼen, Babine-Witsuwitʼen, Bulkley Valley Language, Lakes District Language",
       "language_family": ["Na-Dene"],
       "language_code": "bcr"
     }
@@ -75,7 +75,7 @@
     "model": "backend.language",
     "fields": {
       "title": "Southern Tutchone",
-      "alternate_names": "",
+      "alternate_names": "Tutchone",
       "language_family": ["Na-Dene"],
       "language_code": "tce"
     }
@@ -84,7 +84,7 @@
     "model": "backend.language",
     "fields": {
       "title": "Tāłtān",
-      "alternate_names": "Tahltan, Didene k’eh, Nahanni",
+      "alternate_names": "Tahltan, Didene kʼeh, Nahanni",
       "language_family": ["Na-Dene"],
       "language_code": "tht"
     }
@@ -92,8 +92,8 @@
   {
     "model": "backend.language",
     "fields": {
-      "title": "Tse’khene",
-      "alternate_names": "Sekani, Tsek’ene, Tsek’ehne, Sékanais",
+      "title": "Tseʼkhene",
+      "alternate_names": "Sekani, Tsekʼene, Tsekʼehne, Sékanais",
       "language_family": ["Na-Dene"],
       "language_code": "sek"
     }
@@ -101,8 +101,8 @@
   {
     "model": "backend.language",
     "fields": {
-      "title": "Tsilhqot’in",
-      "alternate_names": "Chilcotin, Tsilhqut’in, Tzilkotin",
+      "title": "Tsilhqotʼin",
+      "alternate_names": "Chilcotin, Tsilhqutʼin, Tzilkotin",
       "language_family": ["Na-Dene"],
       "language_code": "clc"
     }
@@ -128,8 +128,8 @@
   {
     "model": "backend.language",
     "fields": {
-      "title": "Hul’q’umi’num’ / Halq’eméylem / hən̓q̓əmin̓əm",
-      "alternate_names": "Hul’q’umi’num’, Halq’eméylem, hən̓q̓əmin̓əm, Halkomelem, Island Hul’q’umi’num’, Upriver Halq’eméylem, Downriver hən̓q̓əmin̓əm",
+      "title": "Hulʼqʼumiʼnumʼ / Halqʼeméylem / hən̓q̓əmin̓əm̓",
+      "alternate_names": "Hulʼqʼumiʼnumʼ, Halqʼeméylem, hən̓q̓əmin̓əm̓, Halkomelem, Island Hulʼqʼumiʼnumʼ, Upriver Halqʼeméylem, Downriver hən̓q̓əmin̓əm̓",
       "language_family": ["Salishan"],
       "language_code": "hur"
     }
@@ -138,7 +138,7 @@
     "model": "backend.language",
     "fields": {
       "title": "Nłeʔkepmxcín",
-      "alternate_names": "Nlaka’pamux, Nlha7kápmx, Thompson Salish",
+      "alternate_names": "Nlakaʼpamux, Nlha7kápmx, Thompson Salish",
       "language_family": ["Salishan"],
       "language_code": "thp"
     }
@@ -156,7 +156,7 @@
     "model": "backend.language",
     "fields": {
       "title": "Nuxalk",
-      "alternate_names": "Bella Coola",
+      "alternate_names": "Bella Coola, Nass",
       "language_family": ["Salishan"],
       "language_code": "blc"
     }
@@ -173,8 +173,8 @@
   {
     "model": "backend.language",
     "fields": {
-      "title": "SENĆOŦEN / Malchosen / Lekwungen / Semiahmoo / T’Sou-ke",
-      "alternate_names": "SENĆOŦEN, Malchosen, Lekwungen, Semiahmoo, T’Sou-ke, Straits Salish, Northern Straits Salish, Saanich, Tah-tu-lo, Sooke, Songhees",
+      "title": "SENĆOŦEN / Malchosen / Lekwungen / Semiahmoo / TʼSou-ke",
+      "alternate_names": "SENĆOŦEN, Malchosen, Lekwungen, Semiahmoo, TʼSou-ke, Straits Salish, Northern Straits Salish, Saanich, Tah-tu-lo, Sooke, Songhees",
       "language_family": ["Salishan"],
       "language_code": "str"
     }
@@ -201,7 +201,7 @@
     "model": "backend.language",
     "fields": {
       "title": "St̓át̓imcets",
-      "alternate_names": "Sƛ̓aƛ̓imxǝc, Ucwalmícwts, Lillooet, St̓át̓imc, Statimc, Stl’atl’imx, Stl’atl’imc, Sƛ’aƛ’imxǝc, Stlatliumh, Slatlemuk",
+      "alternate_names": "Sƛ̓aƛ̓imxǝc, Ucwalmícwts, Lillooet, St̓át̓imc, Statimc, Stlʼatlʼimx, Stlʼatlʼimc, Sƛʼaƛʼimxǝc, Stlatliumh, Slatlemuk",
       "language_family": ["Salishan"],
       "language_code": "lil"
     }
@@ -218,8 +218,8 @@
   {
     "model": "backend.language",
     "fields": {
-      "title": "Nisg̱a’a",
-      "alternate_names": "Niska, Nass, Nisga’a, Nishga, Niska’, Nisk’a’",
+      "title": "Nisg̱aʼa",
+      "alternate_names": "Niska, Nass, Nisgaʼa, Nishga, Niskaʼ, Niskʼaʼ",
       "language_family": ["Tsimshianic"],
       "language_code": "ncg"
     }
@@ -236,7 +236,7 @@
   {
     "model": "backend.language",
     "fields": {
-      "title": "Sm'algyax",
+      "title": "Sm'algya̱x",
       "alternate_names": "Tsimshian, Coast Tsimshian",
       "language_family": ["Tsimshianic"],
       "language_code": "tsi"
@@ -264,7 +264,7 @@
     "model": "backend.language",
     "fields": {
       "title": "Kwak̕wala",
-      "alternate_names": "Kwakiutl, Kwakwaka’wakw",
+      "alternate_names": "Kwakiutl, Kwakwakaʼwakw",
       "language_family": ["Wakashan"],
       "language_code": "kwk"
     }
@@ -273,7 +273,7 @@
     "model": "backend.language",
     "fields": {
       "title": "nuučaan̓uɫ",
-      "alternate_names": "Nuu-chah-nulth, Nootka",
+      "alternate_names": "Nuu-chah-nulth, Nootka, Nootkans, Tahkaht",
       "language_family": ["Wakashan"],
       "language_code": "nuk"
     }
@@ -281,8 +281,8 @@
   {
     "model": "backend.language",
     "fields": {
-      "title": "’Wuik̓ala",
-      "alternate_names": "Oowekyala, Wuikyala, ’Uik̓ala, Oowekyala, Oweek’ala, Owekeeno",
+      "title": "ʼWuik̓ala",
+      "alternate_names": "Oowekyala, Wuikyala, ʼUik̓ala, Oowekyala, Oweekʼala, Owekeeno, Owekeno",
       "language_family": ["Wakashan"],
       "language_code": "hei-wui"
     }
@@ -290,7 +290,7 @@
   {
     "model": "backend.language",
     "fields": {
-      "title": "X̄enaksialak̓ala / X̄a’islak̓ala",
+      "title": "X̄enaksialak̓ala / X̄aʼislak̓ala",
       "alternate_names": "Haisla, Kitimat, Kitlope, Northern Kwakiutl",
       "language_family": ["Wakashan"],
       "language_code": "has"
@@ -299,7 +299,7 @@
   {
     "model": "backend.language",
     "fields": {
-      "title": "X̱aad Kil / X̱aaydaa Kil",
+      "title": "X̱aad Kil / X̱aayda Kil",
       "alternate_names": "Haida",
       "language_family": ["Haida"],
       "language_code": "hai"

--- a/firstvoices/backend/resources/base.py
+++ b/firstvoices/backend/resources/base.py
@@ -1,0 +1,19 @@
+from import_export import fields, resources
+
+from backend.resources.utils.import_export_widgets import UserForeignKeyWidget
+
+
+class BaseResource(resources.ModelResource):
+    created_by = fields.Field(
+        column_name="created_by",
+        attribute="created_by",
+        widget=UserForeignKeyWidget(create=False),
+    )
+    last_modified_by = fields.Field(
+        column_name="last_modified_by",
+        attribute="last_modified_by",
+        widget=UserForeignKeyWidget(create=False),
+    )
+
+    class Meta:
+        abstract = True

--- a/firstvoices/backend/resources/sites.py
+++ b/firstvoices/backend/resources/sites.py
@@ -1,27 +1,10 @@
-from import_export import fields, resources
+from import_export import fields
+from import_export.widgets import ForeignKeyWidget
 
 from backend.models.constants import Visibility
-from backend.models.sites import Site
-from backend.resources.utils.import_export_widgets import (
-    ChoicesWidget,
-    UserForeignKeyWidget,
-)
-
-
-class BaseResource(resources.ModelResource):
-    created_by = fields.Field(
-        column_name="created_by",
-        attribute="created_by",
-        widget=UserForeignKeyWidget(create=False),
-    )
-    last_modified_by = fields.Field(
-        column_name="last_modified_by",
-        attribute="last_modified_by",
-        widget=UserForeignKeyWidget(create=False),
-    )
-
-    class Meta:
-        abstract = True
+from backend.models.sites import Language, Site
+from backend.resources.base import BaseResource
+from backend.resources.utils.import_export_widgets import ChoicesWidget
 
 
 class SiteResource(BaseResource):
@@ -31,9 +14,17 @@ class SiteResource(BaseResource):
         attribute="visibility",
     )
 
+    language = fields.Field(
+        column_name="language",
+        attribute="language",
+        widget=ForeignKeyWidget(Language, "title"),
+    )
+
     class Meta:
         model = Site
 
+
+class SiteMigrationResource(SiteResource):
     def before_import(self, dataset, using_transactions, dry_run, **kwargs):
         """Before importing sites that already exist, delete and import fresh."""
         if not dry_run:

--- a/firstvoices/scripts/import_csv_data.py
+++ b/firstvoices/scripts/import_csv_data.py
@@ -8,7 +8,7 @@ from scripts.utils.aws_download_utils import (
 )
 
 from backend.models.app import AppImportStatus
-from backend.resources.sites import SiteResource
+from backend.resources.sites import SiteMigrationResource  # , SiteResource
 
 """Script to import CSV files of site content into the fv-be database.
 
@@ -41,8 +41,9 @@ status = AppImportStatus.objects.create(label=f"nuxeo_import_{available_exports[
 
 # List model resources in the correct order to import them
 import_resources = [
-    ("sites", SiteResource()),
+    ("sites", SiteMigrationResource()),
     # more to be added
+    # ("site_media", SiteResource()) # waiting on media import
 ]
 
 


### PR DESCRIPTION
### Description of Changes
Updates languages fixture with some name fixes.

Add language and contact email fields to import tests. Split around some of the import resources so we have a separate SiteResource (creates/updates site fields) and SiteMigrationResource (deletes previous instances and rebuilds site) -- in preparation for a second round site import to update related media fields.

### Checklist
- README / documentation has been updated if needed
- [X] PR title / commit messages contain Jira ticket number if applicable
- [X] Tests have been updated / created if applicable
- Admin Panel has been updated if models have been added or modified
- Migrations have been updated and committed if applicable
- Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- Pull the branch and test locally

### Additional Notes
Includes some updates to the languages fixture. These changes were done manually on dev so everything should match. If you want to update your local, especially if you are going to test the migration locally, you can delete the existing BC languages and reload the fixture.
