### PR TITLE
FW-4605 Add Related Media to Dictionary API

### DIFF
--- a/firstvoices/backend/serializers/dictionary_serializers.py
+++ b/firstvoices/backend/serializers/dictionary_serializers.py
@@ -392,4 +392,8 @@ class DictionaryEntryDetailWriteResponseSerializer(DictionaryEntryDetailSerializ
             "notes",
             "translations",
             "pronunciations",
+            "related_dictionary_entries",
+            "related_audio",
+            "related_images",
+            "related_videos",
         )

--- a/firstvoices/backend/serializers/media_serializers.py
+++ b/firstvoices/backend/serializers/media_serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from rest_framework.validators import UniqueValidator
 
 from backend.models import media
 
@@ -202,13 +203,22 @@ class RelatedMediaSerializerMixin(metaclass=serializers.SerializerMetaclass):
     """Mixin that provides standard related media fields"""
 
     related_audio = WriteableRelatedAudioSerializer(
-        required=False, many=True, queryset=media.Audio.objects.all()
+        required=False,
+        many=True,
+        queryset=media.Audio.objects.all(),
+        validators=[UniqueValidator(queryset=media.Audio.objects.all())],
     )
     related_images = WriteableRelatedImageSerializer(
-        required=False, many=True, queryset=media.Image.objects.all()
+        required=False,
+        many=True,
+        queryset=media.Image.objects.all(),
+        validators=[UniqueValidator(queryset=media.Image.objects.all())],
     )
     related_videos = WriteableRelatedVideoSerializer(
-        required=False, many=True, queryset=media.Video.objects.all()
+        required=False,
+        many=True,
+        queryset=media.Video.objects.all(),
+        validators=[UniqueValidator(queryset=media.Video.objects.all())],
     )
 
     class Meta:

--- a/firstvoices/backend/tests/test_apis/test_characters_api.py
+++ b/firstvoices/backend/tests/test_apis/test_characters_api.py
@@ -21,6 +21,8 @@ class TestCharactersEndpoints(
     API_DETAIL_VIEW = "api:character-detail"
     CHARACTER_NOTE = "Test note"
 
+    model = Character
+
     def create_minimal_instance(self, site, visibility):
         return factories.CharacterFactory.create(
             site=site, note="a note", approximate_form="approx"

--- a/firstvoices/backend/tests/test_apis/test_story_api.py
+++ b/firstvoices/backend/tests/test_apis/test_story_api.py
@@ -4,9 +4,10 @@ import pytest
 
 from backend.models.constants import Role, Visibility
 from backend.tests import factories
+
+from ...models import Page, Story
 from .base_api_test import BaseControlledSiteContentApiTest
 from .base_media_test import RelatedMediaTestMixin
-from ...models import Page, Story
 
 
 class TestStoryEndpoint(RelatedMediaTestMixin, BaseControlledSiteContentApiTest):
@@ -26,7 +27,7 @@ class TestStoryEndpoint(RelatedMediaTestMixin, BaseControlledSiteContentApiTest)
         cover_image = factories.ImageFactory.create(site=site)
 
         generated_media = {}
-        for purpose in ('story', 'page1', 'page2'):
+        for purpose in ("story", "page1", "page2"):
             images = []
             videos = []
             audio = []
@@ -40,13 +41,19 @@ class TestStoryEndpoint(RelatedMediaTestMixin, BaseControlledSiteContentApiTest)
                 generated_media[purpose] = {
                     "related_images": images,
                     "related_videos": videos,
-                    "related_audio": audio
+                    "related_audio": audio,
                 }
 
         return {
-            "relatedAudio": list(map(lambda x: str(x.id), generated_media['story']['related_audio'])),
-            "relatedImages": list(map(lambda x: str(x.id), generated_media['story']['related_images'])),
-            "relatedVideos": list(map(lambda x: str(x.id), generated_media['story']['related_videos'])),
+            "relatedAudio": list(
+                map(lambda x: str(x.id), generated_media["story"]["related_audio"])
+            ),
+            "relatedImages": list(
+                map(lambda x: str(x.id), generated_media["story"]["related_images"])
+            ),
+            "relatedVideos": list(
+                map(lambda x: str(x.id), generated_media["story"]["related_videos"])
+            ),
             "coverImage": str(cover_image.id),
             "title": "Title",
             "titleTranslation": "A translation of the title",
@@ -57,16 +64,46 @@ class TestStoryEndpoint(RelatedMediaTestMixin, BaseControlledSiteContentApiTest)
                 {
                     "text": "First text page",
                     "translation": "Translated 1st",
-                    "relatedAudio": list(map(lambda x: str(x.id), generated_media['page1']['related_audio'])),
-                    "relatedImages": list(map(lambda x: str(x.id), generated_media['page1']['related_images'])),
-                    "relatedVideos": list(map(lambda x: str(x.id), generated_media['page1']['related_videos'])),
+                    "relatedAudio": list(
+                        map(
+                            lambda x: str(x.id),
+                            generated_media["page1"]["related_audio"],
+                        )
+                    ),
+                    "relatedImages": list(
+                        map(
+                            lambda x: str(x.id),
+                            generated_media["page1"]["related_images"],
+                        )
+                    ),
+                    "relatedVideos": list(
+                        map(
+                            lambda x: str(x.id),
+                            generated_media["page1"]["related_videos"],
+                        )
+                    ),
                 },
                 {
                     "text": "Second text page",
                     "translation": "Translated 2nd",
-                    "relatedAudio": list(map(lambda x: str(x.id), generated_media['page2']['related_audio'])),
-                    "relatedImages": list(map(lambda x: str(x.id), generated_media['page2']['related_images'])),
-                    "relatedVideos": list(map(lambda x: str(x.id), generated_media['page2']['related_videos'])),
+                    "relatedAudio": list(
+                        map(
+                            lambda x: str(x.id),
+                            generated_media["page2"]["related_audio"],
+                        )
+                    ),
+                    "relatedImages": list(
+                        map(
+                            lambda x: str(x.id),
+                            generated_media["page2"]["related_images"],
+                        )
+                    ),
+                    "relatedVideos": list(
+                        map(
+                            lambda x: str(x.id),
+                            generated_media["page2"]["related_videos"],
+                        )
+                    ),
                 },
             ],
             "acknowledgements": ["Test Authour", "Another Acknowledgement"],
@@ -101,10 +138,8 @@ class TestStoryEndpoint(RelatedMediaTestMixin, BaseControlledSiteContentApiTest)
 
     def assert_update_response(self, expected_data, actual_response):
         assert actual_response["title"] == expected_data["title"]
-        assert (
-            actual_response["pages"][0]["text"] == expected_data["pages"][0]["text"]
-        )
-        assert (len(actual_response["pages"][0]["relatedAudio"]) == 3)
+        assert actual_response["pages"][0]["text"] == expected_data["pages"][0]["text"]
+        assert len(actual_response["pages"][0]["relatedAudio"]) == 3
         assert (
             actual_response["relatedAudio"][0]["id"] == expected_data["relatedAudio"][0]
         )
@@ -117,6 +152,13 @@ class TestStoryEndpoint(RelatedMediaTestMixin, BaseControlledSiteContentApiTest)
             == expected_data["relatedImages"][0]
         )
         assert actual_response["coverImage"]["id"] == expected_data["coverImage"]
+
+    def add_related_objects(self, instance):
+        factories.PagesFactory.create(story=instance)
+
+    def assert_related_objects_deleted(self, instance):
+        for page in instance.pages.all():
+            self.assert_instance_deleted(page)
 
     def create_instance_with_media(
         self,
@@ -142,7 +184,7 @@ class TestStoryEndpoint(RelatedMediaTestMixin, BaseControlledSiteContentApiTest)
             "coverImage": None,
             "titleTranslation": story.title_translation,
             "excludeFromGames": False,
-            "excludeFromKids": False
+            "excludeFromKids": False,
         }
 
     def get_expected_response(self, story, site):


### PR DESCRIPTION
### Description of Changes
Add tests for related media in dictionary API as they were already enabled via the mixin.
Bonus change: added unique validators for related media per the request of Guy.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
I was going to change the dictionary entry an character's models to better fit the other write API tests (Rob's Story and Songs API) but it seemed like more of a halftime change so I will do it then. Additionally in that halftime PR I will add tests to validate the related media uniqueness validators (tested locally, just not in the unit tests)
