### PR TITLE
FW-4612-search-api-returning-words-and-phrases-for-word-searches

### DIFF
--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -54,10 +54,10 @@ def get_types_query(types):
     # Adding type filters
     # If only one of the "words" or "phrases" is present, we need to filter out the other one
     # no action required if both are present
-    if "words" in types and "phrases" not in types:
-        return Q(~Q("match", type=TypeOfDictionaryEntry.PHRASE))
-    elif "phrases" in types and "words" not in types:
-        return Q(~Q("match", type=TypeOfDictionaryEntry.WORD))
+    if "word" in types and "phrase" not in types:
+        return Q(~Q("match", type=TypeOfDictionaryEntry.PHRASE.value))
+    elif "phrase" in types and "word" not in types:
+        return Q(~Q("match", type=TypeOfDictionaryEntry.WORD.value))
     else:
         return None
 

--- a/firstvoices/backend/tests/test_search/test_filters.py
+++ b/firstvoices/backend/tests/test_search/test_filters.py
@@ -28,28 +28,24 @@ class TestSearchFilters:
 
 @pytest.mark.django_db
 class TestTypesFilter:
-    expected_phrases_filter = (
-        "'must_not': [{'match': {'type': TypeOfDictionaryEntry.PHRASE}}]}"
-    )
-    expected_word_filter = (
-        "'must_not': [{'match': {'type': TypeOfDictionaryEntry.WORD}}]}"
-    )
+    expected_phrases_filter = "'must_not': [{'match': {'type': 'phrase'}}]}"
+    expected_word_filter = "'must_not': [{'match': {'type': 'word'}}]}"
 
     def test_words(self):
-        search_query = get_search_query(types=["words"])
+        search_query = get_search_query(types=["word"])
         search_query = search_query.to_dict()
 
         assert self.expected_phrases_filter in str(search_query)
         assert self.expected_word_filter not in str(search_query)
 
     def test_phrases(self):
-        search_query = get_search_query(types=["phrases"])
+        search_query = get_search_query(types=["phrase"])
         search_query = search_query.to_dict()
 
         assert self.expected_phrases_filter not in str(search_query)
         assert self.expected_word_filter in str(search_query)
 
-    @pytest.mark.parametrize("types", [["phrases", "words"], ["words", "phrases"]])
+    @pytest.mark.parametrize("types", [["phrase", "word"], ["word", "phrase"]])
     def test_words_and_phrases(self, types):
         search_query = get_search_query(types=types)
         search_query = search_query.to_dict()


### PR DESCRIPTION
### Description of Changes
Fixed a typo which was causing bug not filtering on `types` parameter properly.

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
