### PR TITLE
Fw-4215, fix for media flag always false

### DIFF
--- a/firstvoices/backend/serializers/media_serializers.py
+++ b/firstvoices/backend/serializers/media_serializers.py
@@ -74,13 +74,22 @@ class VideoUploadSerializer(serializers.FileField):
 
 
 class MediaSerializer(ExternalSiteContentUrlMixin, serializers.ModelSerializer):
+    # Camel-case these explicitly so they work as inputs as well
+    excludeFromKids = serializers.BooleanField(
+        source="exclude_from_kids", default=False
+    )
+    excludeFromGames = serializers.BooleanField(
+        source="exclude_from_games", default=False
+    )
+    isShared = serializers.BooleanField(source="is_shared", default=False)
+
     class Meta:
         fields = base_id_fields + (
             "description",
             "acknowledgement",
-            "exclude_from_games",
-            "exclude_from_kids",
-            "is_shared",
+            "excludeFromKids",
+            "excludeFromGames",
+            "isShared",
             "original",
         )
 

--- a/firstvoices/backend/tests/test_apis/base_api_test.py
+++ b/firstvoices/backend/tests/test_apis/base_api_test.py
@@ -446,14 +446,27 @@ class SiteContentCreateApiTestMixin:
     @pytest.mark.django_db
     def test_create_success_201(self):
         site = self.create_site_with_app_admin(Visibility.PUBLIC)
+        data = self.get_valid_data(site)
 
         response = self.client.post(
             self.get_list_endpoint(site_slug=site.slug),
-            data=self.format_upload_data(self.get_valid_data(site)),
+            data=self.format_upload_data(data),
             content_type=self.content_type,
         )
 
         assert response.status_code == 201
+
+        response_data = json.loads(response.content)
+        pk = response_data["id"]
+
+        self.assert_created_instance(pk, data)
+        self.assert_created_response(data, response_data)
+
+    def assert_created_instance(self, pk, data):
+        raise NotImplementedError()
+
+    def assert_created_response(self, expected_data, actual_response):
+        raise NotImplementedError()
 
 
 class SiteContentUpdateApiTestMixin:

--- a/firstvoices/backend/tests/test_apis/base_media_test.py
+++ b/firstvoices/backend/tests/test_apis/base_media_test.py
@@ -203,6 +203,7 @@ class BaseMediaApiTest(
 
     sample_filename = "sample-image.jpg"
     sample_filetype = "image/jpeg"
+    model = None
 
     def get_valid_data(self, site=None):
         """Returns a valid data object suitable for create/update requests"""
@@ -217,6 +218,16 @@ class BaseMediaApiTest(
                 self.sample_filename, self.sample_filetype
             ),
         }
+
+    def assert_created_instance(self, pk, data):
+        instance = self.model.objects.get(pk=pk)
+        assert instance.title == data["title"]
+        assert instance.description == data["description"]
+        assert data["original"].name in instance.original.content.name
+        assert instance.acknowledgement == data["acknowledgement"]
+        assert instance.is_shared == data["isShared"]
+        assert instance.exclude_from_games == data["excludeFromGames"]
+        assert instance.exclude_from_kids == data["excludeFromKids"]
 
     def add_related_objects(self, instance):
         # related files are added as part of minimal instance; nothing extra to add here

--- a/firstvoices/backend/tests/test_apis/test_audio_api.py
+++ b/firstvoices/backend/tests/test_apis/test_audio_api.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from backend.models.constants import Visibility
+from backend.models.media import Audio
 from backend.tests import factories
 
 from .base_media_test import BaseMediaApiTest
@@ -17,6 +18,7 @@ class TestAudioEndpoint(BaseMediaApiTest):
     API_DETAIL_VIEW = "api:audio-detail"
     sample_filename = "sample-audio.mp3"
     sample_filetype = "audio/mpeg"
+    model = Audio
 
     def create_minimal_instance(self, site, visibility):
         return factories.AudioFactory.create(site=site)
@@ -41,6 +43,10 @@ class TestAudioEndpoint(BaseMediaApiTest):
 
     def assert_related_objects_deleted(self, instance):
         self.assert_instance_deleted(instance.original)
+
+    def assert_created_response(self, expected_data, actual_response):
+        instance = Audio.objects.get(pk=actual_response["id"])
+        assert actual_response == self.get_expected_audio_data(instance, None)
 
     @pytest.mark.django_db
     def test_create_with_speakers(self):

--- a/firstvoices/backend/tests/test_apis/test_category_api.py
+++ b/firstvoices/backend/tests/test_apis/test_category_api.py
@@ -66,6 +66,13 @@ class TestCategoryEndpoints(BaseUncontrolledSiteContentApiTest):
         assert actual_response["description"] == expected_data["description"]
         assert actual_response["parent"]["id"] == expected_data["parent_id"]
 
+    def assert_created_instance(self, pk, data):
+        instance = Category.objects.get(pk=pk)
+        return self.assert_updated_instance(data, instance)
+
+    def assert_created_response(self, expected_data, actual_response):
+        return self.assert_update_response(expected_data, actual_response)
+
     def add_related_objects(self, instance):
         # no related objects to add
         pass

--- a/firstvoices/backend/tests/test_apis/test_images_api.py
+++ b/firstvoices/backend/tests/test_apis/test_images_api.py
@@ -1,3 +1,4 @@
+from backend.models.media import Image
 from backend.tests import factories
 
 from .base_media_test import BaseMediaApiTest
@@ -10,9 +11,14 @@ class TestImagesEndpoint(BaseMediaApiTest):
 
     API_LIST_VIEW = "api:image-list"
     API_DETAIL_VIEW = "api:image-detail"
+    model = Image
 
     def create_minimal_instance(self, site, visibility):
         return factories.ImageFactory.create(site=site)
 
     def get_expected_response(self, instance, site):
         return self.get_expected_image_data(instance)
+
+    def assert_created_response(self, expected_data, actual_response):
+        instance = Image.objects.get(pk=actual_response["id"])
+        assert actual_response == self.get_expected_image_data(instance)

--- a/firstvoices/backend/tests/test_apis/test_person_api.py
+++ b/firstvoices/backend/tests/test_apis/test_person_api.py
@@ -37,6 +37,13 @@ class TestPeopleEndpoints(BaseUncontrolledSiteContentApiTest):
         assert actual_response["name"] == expected_data["name"]
         assert actual_response["bio"] == expected_data["bio"]
 
+    def assert_created_instance(self, pk, data):
+        instance = Person.objects.get(pk=pk)
+        return self.assert_updated_instance(data, instance)
+
+    def assert_created_response(self, expected_data, actual_response):
+        return self.assert_update_response(expected_data, actual_response)
+
     def add_related_objects(self, instance):
         # no related objects to add
         pass

--- a/firstvoices/backend/tests/test_apis/test_song_api.py
+++ b/firstvoices/backend/tests/test_apis/test_song_api.py
@@ -108,6 +108,13 @@ class TestSongEndpoint(RelatedMediaTestMixin, BaseControlledSiteContentApiTest):
         )
         assert actual_response["coverImage"]["id"] == expected_data["coverImage"]
 
+    def assert_created_instance(self, pk, data):
+        instance = Song.objects.get(pk=pk)
+        return self.assert_updated_instance(data, instance)
+
+    def assert_created_response(self, expected_data, actual_response):
+        return self.assert_update_response(expected_data, actual_response)
+
     def add_related_objects(self, instance):
         factories.LyricsFactory.create(song=instance)
         factories.LyricsFactory.create(song=instance)

--- a/firstvoices/backend/tests/test_apis/test_story_api.py
+++ b/firstvoices/backend/tests/test_apis/test_story_api.py
@@ -153,6 +153,13 @@ class TestStoryEndpoint(RelatedMediaTestMixin, BaseControlledSiteContentApiTest)
         )
         assert actual_response["coverImage"]["id"] == expected_data["coverImage"]
 
+    def assert_created_instance(self, pk, data):
+        instance = Story.objects.get(pk=pk)
+        return self.assert_updated_instance(data, instance)
+
+    def assert_created_response(self, expected_data, actual_response):
+        return self.assert_update_response(expected_data, actual_response)
+
     def add_related_objects(self, instance):
         factories.PagesFactory.create(story=instance)
         factories.PagesFactory.create(story=instance)

--- a/firstvoices/backend/tests/test_apis/test_videos_api.py
+++ b/firstvoices/backend/tests/test_apis/test_videos_api.py
@@ -1,3 +1,4 @@
+from backend.models.media import Video
 from backend.tests import factories
 
 from .base_media_test import BaseMediaApiTest
@@ -12,9 +13,14 @@ class TestVideosEndpoint(BaseMediaApiTest):
     API_DETAIL_VIEW = "api:video-detail"
     sample_filename = "video_example_small.mp4"
     sample_filetype = "video/mp4"
+    model = Video
 
     def create_minimal_instance(self, site, visibility):
         return factories.VideoFactory.create(site=site)
 
     def get_expected_response(self, instance, site):
         return self.get_expected_video_data(instance)
+
+    def assert_created_response(self, expected_data, actual_response):
+        instance = Video.objects.get(pk=actual_response["id"])
+        assert actual_response == self.get_expected_video_data(instance)

--- a/firstvoices/backend/tests/test_apis/test_widgets_api.py
+++ b/firstvoices/backend/tests/test_apis/test_widgets_api.py
@@ -55,6 +55,13 @@ class TestSiteWidgetEndpoint(BaseControlledSiteContentApiTest):
     def assert_update_response(self, expected_data, actual_response):
         assert actual_response["title"] == expected_data["title"]
 
+    def assert_created_instance(self, pk, data):
+        instance = self.model.objects.get(pk=pk)
+        return self.get_expected_response(instance, instance.site)
+
+    def assert_created_response(self, expected_data, actual_response):
+        return self.assert_update_response(expected_data, actual_response)
+
     def get_expected_list_response_item(self, widget, site):
         return self.get_expected_response(widget, site)
 


### PR DESCRIPTION
### Description of Changes
- Added some new assertions in the base tests for create APIs, to check the created instances have the right properties
- Fixed the media property names (underscore vs camel case issue)

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
