### PR TITLE
fw-4658, allow a list of URLs in allowed_origin

### DIFF
--- a/firstvoices/firstvoices/settings.py
+++ b/firstvoices/firstvoices/settings.py
@@ -182,8 +182,9 @@ JWT = jwt.config()
 CORS_ALLOWED_ORIGINS = [
     "http://localhost:3000",
     "https://localhost:3000",
-    os.getenv("ALLOWED_ORIGIN"),
-]
+] + os.getenv(
+    "ALLOWED_ORIGIN"
+).split(",")
 
 LANGUAGE_CODE = "en-ca"
 


### PR DESCRIPTION
### Description of Changes
* allow a comma-separated list of values in the ALLOWED_ORIGIN environment variable, so we can support multiple sites accessing our server (currently FirstVoices dev and the dev version of the app)
* (single value still works)

### Checklist
- [ ] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
