### PR TITLE
fw-4607, de-duplicate results

### DIFF
--- a/firstvoices/backend/permissions/managers.py
+++ b/firstvoices/backend/permissions/managers.py
@@ -18,11 +18,12 @@ class PermissionsManager(models.Manager):
         Returns a queryset containing only objects that the given user has permission to view. This
         does not filter related objects.
         """
-        return self.get_queryset().filter(self.visible_as_filter(user))
+        return self.get_queryset().filter(self.visible_as_filter(user)).distinct()
 
     def visible_as_filter(self, user=AnonymousUser()):
         """
-        Returns a Q object representing the visible permissions. This does not filter related objects.
+        Returns a Q object representing the visible permissions. This does not filter related objects. Note that this
+        can result in duplicate results and should be used with a distinct() clause.
         """
         if hasattr(self.model, "view_permission_filter"):
             return self.model.view_permission_filter(user)

--- a/firstvoices/backend/permissions/utils.py
+++ b/firstvoices/backend/permissions/utils.py
@@ -34,4 +34,4 @@ def filter_by_viewable(user, queryset):
     Returns a new queryset containing items from queryset that the user has permission to view
     """
     view_permission_filter = queryset.model.objects.visible_as_filter(user)
-    return queryset.filter(view_permission_filter)
+    return queryset.filter(view_permission_filter).distinct()

--- a/firstvoices/backend/tests/test_permissions/test_permission_settings.py
+++ b/firstvoices/backend/tests/test_permissions/test_permission_settings.py
@@ -9,6 +9,11 @@ from backend.models.constants import AppRole, Role, Visibility
 from backend.models.dictionary import BaseDictionaryContentModel
 from backend.tests import factories
 
+"""
+This class generates tests for all models (with a few exclusions), to verify that the different forms of view
+permissions all have the same effect. (Direct use of predicates, permission rules on the models, and query filters.)
+"""
+
 
 class BaseModelFactory(DjangoModelFactory):
     created_by = factory.SubFactory(factories.UserFactory)
@@ -20,7 +25,15 @@ class SiteContentFactory(BaseModelFactory):
 
 
 def get_permitted_ids(user, queryset):
-    return {obj.id for obj in queryset if user.has_perm(obj.get_perm("view"), obj)}
+    return [obj.id for obj in queryset if user.has_perm(obj.get_perm("view"), obj)]
+
+
+def assert_unordered_lists_have_same_items(list1, list2):
+    assert len(list1) == len(list2)
+
+    list1_sorted = sorted(list1)
+    list2_sorted = sorted(list2)
+    assert list1_sorted == list2_sorted
 
 
 class TestPermissionManager:
@@ -75,18 +88,29 @@ class TestPermissionManager:
 
         self.generate_test_data(model_cls, model_factory, user, user_role)
 
+        # get list via has_perm()
         visible_by_permission_rules = get_permitted_ids(user, model_cls.objects.all())
-        visible_by_permission_manager = {
+
+        # get list via Model.objects.visible()
+        visible_by_permission_manager = [
             obj.id for obj in model_cls.objects.visible(user)
-        }
-        assert visible_by_permission_manager == visible_by_permission_rules
-        visible_by_permission_filter = {
+        ]
+
+        assert_unordered_lists_have_same_items(
+            visible_by_permission_manager, visible_by_permission_rules
+        )
+
+        # get list via Model.objects.visible_as_filter()
+        visible_by_permission_filter = [
             obj.id
             for obj in model_cls.objects.filter(
                 model_cls.objects.visible_as_filter(user)
-            )
-        }
-        assert visible_by_permission_filter == visible_by_permission_rules
+            ).distinct()
+        ]
+
+        assert_unordered_lists_have_same_items(
+            visible_by_permission_manager, visible_by_permission_filter
+        )
 
     def generate_test_data(self, model_cls, model_factory, user, user_role):
         """

--- a/firstvoices/backend/views/base_views.py
+++ b/firstvoices/backend/views/base_views.py
@@ -123,9 +123,7 @@ class FVPermissionViewSetMixin:
 
     def list(self, request, *args, **kwargs):
         # permissions
-        queryset = utils.filter_by_viewable(
-            request.user, self.get_queryset()
-        ).distinct()
+        queryset = utils.filter_by_viewable(request.user, self.get_queryset())
 
         # pagination
         page = self.paginate_queryset(queryset)


### PR DESCRIPTION
### Description of Changes
- updated permission tests to compare lists instead of sets, to reveal duplicated results
- added distinct() for all direct uses of the visibility filters (very few-- we mostly use a utility function)
- added a comment in the visible_as_filter function about using distinct()

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
