### PR TITLE
FW-4648 Add PATCH support to Site content APIs

### DIFF
--- a/firstvoices/backend/serializers/dictionary_serializers.py
+++ b/firstvoices/backend/serializers/dictionary_serializers.py
@@ -210,44 +210,47 @@ class DictionaryEntryDetailSerializer(
         return created
 
     def update(self, instance, validated_data):
-        dictionary.Acknowledgement.objects.filter(dictionary_entry=instance).delete()
-        dictionary.AlternateSpelling.objects.filter(dictionary_entry=instance).delete()
-        dictionary.Note.objects.filter(dictionary_entry=instance).delete()
-        dictionary.Pronunciation.objects.filter(dictionary_entry=instance).delete()
-        dictionary.Translation.objects.filter(dictionary_entry=instance).delete()
-
-        try:
+        if "acknowledgement_set" in validated_data:
+            dictionary.Acknowledgement.objects.filter(
+                dictionary_entry=instance
+            ).delete()
             acknowledgements = validated_data.pop("acknowledgement_set", [])
-            alternate_spellings = validated_data.pop("alternatespelling_set", [])
-            notes = validated_data.pop("note_set", [])
-            pronunciations = validated_data.pop("pronunciation_set", [])
-            translations = validated_data.pop("translation_set", [])
-
             for acknowledgement in acknowledgements:
                 dictionary.Acknowledgement.objects.create(
                     dictionary_entry=instance, **acknowledgement
                 )
 
+        if "alternatespelling_set" in validated_data:
+            dictionary.AlternateSpelling.objects.filter(
+                dictionary_entry=instance
+            ).delete()
+            alternate_spellings = validated_data.pop("alternatespelling_set", [])
             for alternate_spelling in alternate_spellings:
                 dictionary.AlternateSpelling.objects.create(
                     dictionary_entry=instance, **alternate_spelling
                 )
 
+        if "note_set" in validated_data:
+            dictionary.Note.objects.filter(dictionary_entry=instance).delete()
+            notes = validated_data.pop("note_set", [])
             for note in notes:
                 dictionary.Note.objects.create(dictionary_entry=instance, **note)
 
+        if "pronunciation_set" in validated_data:
+            dictionary.Pronunciation.objects.filter(dictionary_entry=instance).delete()
+            pronunciations = validated_data.pop("pronunciation_set", [])
             for pronunciation in pronunciations:
                 dictionary.Pronunciation.objects.create(
                     dictionary_entry=instance, **pronunciation
                 )
 
+        if "translation_set" in validated_data:
+            dictionary.Translation.objects.filter(dictionary_entry=instance).delete()
+            translations = validated_data.pop("translation_set", [])
             for translation in translations:
                 dictionary.Translation.objects.create(
                     dictionary_entry=instance, **translation
                 )
-
-        except KeyError:
-            pass
 
         return super().update(instance, validated_data)
 

--- a/firstvoices/backend/serializers/song_serializers.py
+++ b/firstvoices/backend/serializers/song_serializers.py
@@ -51,13 +51,11 @@ class SongSerializer(
         return created
 
     def update(self, instance, validated_data):
-        Lyric.objects.filter(song__id=instance.id).delete()
-        try:
+        if "lyrics" in validated_data:
+            Lyric.objects.filter(song__id=instance.id).delete()
             lyrics = validated_data.pop("lyrics")
             for index, lyric_data in enumerate(lyrics):
                 Lyric.objects.create(song=instance, ordering=index, **lyric_data)
-        except KeyError:
-            pass
 
         return super().update(instance, validated_data)
 

--- a/firstvoices/backend/serializers/widget_serializers.py
+++ b/firstvoices/backend/serializers/widget_serializers.py
@@ -76,15 +76,19 @@ class SiteWidgetDetailSerializer(
         return created
 
     def update(self, instance, validated_data):
-        WidgetSettings.objects.filter(widget__id=instance.id).delete()
-        settings = validated_data.pop("widgetsettings_set")
-        validated_data["format"] = WidgetFormats[
-            str.upper(validated_data.pop("get_format_display"))
-        ]
-        for setting in settings:
-            WidgetSettings.objects.create(
-                widget=instance, key=setting["key"], value=setting["value"]
-            )
+        if "widgetsettings_set" in validated_data:
+            WidgetSettings.objects.filter(widget__id=instance.id).delete()
+            settings = validated_data.pop("widgetsettings_set")
+
+            for setting in settings:
+                WidgetSettings.objects.create(
+                    widget=instance, key=setting["key"], value=setting["value"]
+                )
+
+        if "get_format_display" in validated_data:
+            validated_data["format"] = WidgetFormats[
+                str.upper(validated_data.pop("get_format_display"))
+            ]
 
         return super().update(instance, validated_data)
 

--- a/firstvoices/backend/tests/test_apis/base_api_test.py
+++ b/firstvoices/backend/tests/test_apis/base_api_test.py
@@ -735,7 +735,7 @@ class SiteContentDestroyApiTestMixin:
         assert response.status_code == 404
 
 
-class SiteContentPatchApiTestMixin:
+class SiteContentPatchApiTestMixin(WriteApiTestMixin):
     """
     For use with BaseSiteContentApiTest
     """

--- a/firstvoices/backend/tests/test_apis/base_api_test.py
+++ b/firstvoices/backend/tests/test_apis/base_api_test.py
@@ -735,9 +735,9 @@ class SiteContentDestroyApiTestMixin:
         assert response.status_code == 404
 
 
-class SiteContentPatchApiTestMixin(WriteApiTestMixin):
+class SiteContentPatchApiTestMixin:
     """
-    For use with BaseSiteContentApiTest
+    For use with BaseSiteContentApiTest and WriteApiTestMixin
     """
 
     model = None
@@ -857,6 +857,7 @@ class BaseUncontrolledSiteContentApiTest(
     WriteApiTestMixin,
     SiteContentCreateApiTestMixin,
     SiteContentUpdateApiTestMixin,
+    SiteContentPatchApiTestMixin,
     SiteContentDestroyApiTestMixin,
     BaseReadOnlyUncontrolledSiteContentApiTest,
 ):

--- a/firstvoices/backend/tests/test_apis/base_media_test.py
+++ b/firstvoices/backend/tests/test_apis/base_media_test.py
@@ -136,6 +136,26 @@ class RelatedMediaTestMixin(MediaTestMixin):
     ):
         raise NotImplementedError
 
+    def assert_patch_instance_original_fields_related_media(
+        self, original_instance, updated_instance
+    ):
+        assert updated_instance.related_audio == original_instance.related_audio
+        assert updated_instance.related_images == original_instance.related_images
+        assert updated_instance.related_videos == original_instance.related_videos
+
+    def assert_update_patch_response_related_media(
+        self, original_instance, actual_response
+    ):
+        assert actual_response["relatedAudio"][0]["id"] == str(
+            original_instance.related_audio.first().id
+        )
+        assert actual_response["relatedImages"][0]["id"] == str(
+            original_instance.related_images.first().id
+        )
+        assert actual_response["relatedVideos"][0]["id"] == str(
+            original_instance.related_videos.first().id
+        )
+
     @pytest.mark.django_db
     def test_detail_related_audio_with_speaker(self):
         site = self.create_site_with_non_member(Visibility.PUBLIC)

--- a/firstvoices/backend/tests/test_apis/test_category_api.py
+++ b/firstvoices/backend/tests/test_apis/test_category_api.py
@@ -17,16 +17,11 @@ from backend.tests.factories import (
     get_app_admin,
     get_non_member_user,
 )
-from backend.tests.test_apis.base_api_test import (
-    BaseUncontrolledSiteContentApiTest,
-    SiteContentPatchApiTestMixin,
-)
+from backend.tests.test_apis.base_api_test import BaseUncontrolledSiteContentApiTest
 from backend.tests.utils import find_object_by_id
 
 
-class TestCategoryEndpoints(
-    SiteContentPatchApiTestMixin, BaseUncontrolledSiteContentApiTest
-):
+class TestCategoryEndpoints(BaseUncontrolledSiteContentApiTest):
     """
     End-to-end tests that the category endpoints have the expected behaviour.
     """

--- a/firstvoices/backend/tests/test_apis/test_characters_api.py
+++ b/firstvoices/backend/tests/test_apis/test_characters_api.py
@@ -94,22 +94,16 @@ class TestCharactersEndpoints(
         assert updated_instance.title == original_instance.title
         assert updated_instance.sort_order == original_instance.sort_order
         assert updated_instance.approximate_form == original_instance.approximate_form
-        assert updated_instance.related_audio == original_instance.related_audio
-        assert updated_instance.related_images == original_instance.related_images
-        assert updated_instance.related_videos == original_instance.related_videos
+        self.assert_patch_instance_original_fields_related_media(
+            original_instance, updated_instance
+        )
 
     def assert_patch_instance_updated_fields(self, data, updated_instance: Character):
         assert updated_instance.note == data["note"]
 
     def assert_update_patch_response(self, original_instance, data, actual_response):
-        assert actual_response["relatedAudio"][0]["id"] == str(
-            original_instance.related_audio.first().id
-        )
-        assert actual_response["relatedImages"][0]["id"] == str(
-            original_instance.related_images.first().id
-        )
-        assert actual_response["relatedVideos"][0]["id"] == str(
-            original_instance.related_videos.first().id
+        self.assert_update_patch_response_related_media(
+            original_instance, actual_response
         )
         assert actual_response["id"] == str(original_instance.id)
         assert actual_response["title"] == original_instance.title

--- a/firstvoices/backend/tests/test_apis/test_characters_api.py
+++ b/firstvoices/backend/tests/test_apis/test_characters_api.py
@@ -6,12 +6,17 @@ from backend.models.constants import Role, Visibility
 from backend.tests import factories
 
 from ...models import Character
-from .base_api_test import BaseReadOnlyUncontrolledSiteContentApiTest
+from .base_api_test import (
+    BaseReadOnlyUncontrolledSiteContentApiTest,
+    SiteContentPatchApiTestMixin,
+)
 from .base_media_test import RelatedMediaTestMixin
 
 
 class TestCharactersEndpoints(
-    RelatedMediaTestMixin, BaseReadOnlyUncontrolledSiteContentApiTest
+    RelatedMediaTestMixin,
+    SiteContentPatchApiTestMixin,
+    BaseReadOnlyUncontrolledSiteContentApiTest,
 ):
     """
     End-to-end tests that the characters endpoints have the expected behaviour.
@@ -57,6 +62,63 @@ class TestCharactersEndpoints(
             "relatedImages": [],
             "relatedVideos": [],
         }
+
+    def create_original_instance_for_patch(self, site):
+        audio = factories.AudioFactory.create(site=site)
+        image = factories.ImageFactory.create(site=site)
+        video = factories.VideoFactory.create(site=site)
+        character = factories.CharacterFactory.create(
+            site=site,
+            title="Title",
+            sort_order=2,
+            approximate_form="test",
+            note="Note",
+            related_audio=(audio,),
+            related_images=(image,),
+            related_videos=(video,),
+        )
+        dictionary_entry = factories.DictionaryEntryFactory.create(site=site)
+        factories.DictionaryEntryRelatedCharacterFactory.create(
+            character=character, dictionary_entry=dictionary_entry
+        )
+
+        return character
+
+    def get_valid_patch_data(self, site=None):
+        return {"note": "Note Updated"}
+
+    def assert_patch_instance_original_fields(
+        self, original_instance, updated_instance: Character
+    ):
+        assert updated_instance.id == original_instance.id
+        assert updated_instance.title == original_instance.title
+        assert updated_instance.sort_order == original_instance.sort_order
+        assert updated_instance.approximate_form == original_instance.approximate_form
+        assert updated_instance.related_audio == original_instance.related_audio
+        assert updated_instance.related_images == original_instance.related_images
+        assert updated_instance.related_videos == original_instance.related_videos
+
+    def assert_patch_instance_updated_fields(self, data, updated_instance: Character):
+        assert updated_instance.note == data["note"]
+
+    def assert_update_patch_response(self, original_instance, data, actual_response):
+        assert actual_response["relatedAudio"][0]["id"] == str(
+            original_instance.related_audio.first().id
+        )
+        assert actual_response["relatedImages"][0]["id"] == str(
+            original_instance.related_images.first().id
+        )
+        assert actual_response["relatedVideos"][0]["id"] == str(
+            original_instance.related_videos.first().id
+        )
+        assert actual_response["id"] == str(original_instance.id)
+        assert actual_response["title"] == original_instance.title
+        assert actual_response["sortOrder"] == original_instance.sort_order
+        assert actual_response["approximateForm"] == original_instance.approximate_form
+        assert actual_response["note"] == data["note"]
+        assert actual_response["relatedDictionaryEntries"][0]["id"] == str(
+            original_instance.related_dictionary_entries.first().id
+        )
 
     @pytest.mark.django_db
     def test_detail_variants(self):

--- a/firstvoices/backend/tests/test_apis/test_characters_api.py
+++ b/firstvoices/backend/tests/test_apis/test_characters_api.py
@@ -9,12 +9,14 @@ from ...models import Character
 from .base_api_test import (
     BaseReadOnlyUncontrolledSiteContentApiTest,
     SiteContentPatchApiTestMixin,
+    WriteApiTestMixin,
 )
 from .base_media_test import RelatedMediaTestMixin
 
 
 class TestCharactersEndpoints(
     RelatedMediaTestMixin,
+    WriteApiTestMixin,
     SiteContentPatchApiTestMixin,
     BaseReadOnlyUncontrolledSiteContentApiTest,
 ):

--- a/firstvoices/backend/tests/test_apis/test_dictionary_api.py
+++ b/firstvoices/backend/tests/test_apis/test_dictionary_api.py
@@ -258,9 +258,9 @@ class TestDictionaryEndpoint(
             updated_instance.exclude_from_games == original_instance.exclude_from_games
         )
         assert updated_instance.exclude_from_kids == original_instance.exclude_from_kids
-        assert updated_instance.related_audio == original_instance.related_audio
-        assert updated_instance.related_images == original_instance.related_images
-        assert updated_instance.related_videos == original_instance.related_videos
+        self.assert_patch_instance_original_fields_related_media(
+            original_instance, updated_instance
+        )
 
     def assert_patch_instance_updated_fields(
         self, data, updated_instance: DictionaryEntry
@@ -280,14 +280,8 @@ class TestDictionaryEndpoint(
         assert actual_response["relatedDictionaryEntries"][0]["id"] == str(
             original_instance.related_dictionary_entries.first().id
         )
-        assert actual_response["relatedAudio"][0]["id"] == str(
-            original_instance.related_audio.first().id
-        )
-        assert actual_response["relatedImages"][0]["id"] == str(
-            original_instance.related_images.first().id
-        )
-        assert actual_response["relatedVideos"][0]["id"] == str(
-            original_instance.related_videos.first().id
+        self.assert_update_patch_response_related_media(
+            original_instance, actual_response
         )
 
     @pytest.mark.django_db

--- a/firstvoices/backend/tests/test_apis/test_dictionary_api.py
+++ b/firstvoices/backend/tests/test_apis/test_dictionary_api.py
@@ -14,16 +14,12 @@ from backend.models.dictionary import (
 )
 from backend.tests import factories
 
-from .base_api_test import (
-    BaseControlledSiteContentApiTest,
-    SiteContentPatchApiTestMixin,
-)
+from .base_api_test import BaseControlledSiteContentApiTest
 from .base_media_test import RelatedMediaTestMixin
 
 
 class TestDictionaryEndpoint(
     RelatedMediaTestMixin,
-    SiteContentPatchApiTestMixin,
     BaseControlledSiteContentApiTest,
 ):
     """

--- a/firstvoices/backend/tests/test_apis/test_pages_api.py
+++ b/firstvoices/backend/tests/test_apis/test_pages_api.py
@@ -8,7 +8,6 @@ from backend.models.widget import SiteWidget, SiteWidgetList, SiteWidgetListOrde
 from backend.tests import factories
 from backend.tests.test_apis.base_api_test import (
     BaseControlledLanguageAdminOnlySiteContentAPITest,
-    SiteContentPatchApiTestMixin,
 )
 from backend.tests.utils import (
     setup_widget_list,
@@ -17,9 +16,7 @@ from backend.tests.utils import (
 )
 
 
-class TestSitePageEndpoint(
-    SiteContentPatchApiTestMixin, BaseControlledLanguageAdminOnlySiteContentAPITest
-):
+class TestSitePageEndpoint(BaseControlledLanguageAdminOnlySiteContentAPITest):
     API_LIST_VIEW = "api:sitepage-list"
     API_DETAIL_VIEW = "api:sitepage-detail"
 

--- a/firstvoices/backend/tests/test_apis/test_person_api.py
+++ b/firstvoices/backend/tests/test_apis/test_person_api.py
@@ -1,15 +1,10 @@
 from backend.models.media import Person
 from backend.tests import factories
 from backend.tests.factories import PersonFactory
-from backend.tests.test_apis.base_api_test import (
-    BaseUncontrolledSiteContentApiTest,
-    SiteContentPatchApiTestMixin,
-)
+from backend.tests.test_apis.base_api_test import BaseUncontrolledSiteContentApiTest
 
 
-class TestPeopleEndpoints(
-    SiteContentPatchApiTestMixin, BaseUncontrolledSiteContentApiTest
-):
+class TestPeopleEndpoints(BaseUncontrolledSiteContentApiTest):
     """
     End-to-end tests that the /people endpoints have the expected behaviour.
     """

--- a/firstvoices/backend/tests/test_apis/test_person_api.py
+++ b/firstvoices/backend/tests/test_apis/test_person_api.py
@@ -1,9 +1,15 @@
 from backend.models.media import Person
+from backend.tests import factories
 from backend.tests.factories import PersonFactory
-from backend.tests.test_apis.base_api_test import BaseUncontrolledSiteContentApiTest
+from backend.tests.test_apis.base_api_test import (
+    BaseUncontrolledSiteContentApiTest,
+    SiteContentPatchApiTestMixin,
+)
 
 
-class TestPeopleEndpoints(BaseUncontrolledSiteContentApiTest):
+class TestPeopleEndpoints(
+    SiteContentPatchApiTestMixin, BaseUncontrolledSiteContentApiTest
+):
     """
     End-to-end tests that the /people endpoints have the expected behaviour.
     """
@@ -51,3 +57,24 @@ class TestPeopleEndpoints(BaseUncontrolledSiteContentApiTest):
     def assert_related_objects_deleted(self, instance):
         # no related objects to delete
         pass
+
+    def create_original_instance_for_patch(self, site):
+        return factories.PersonFactory.create(site=site, name="Name", bio="Bio")
+
+    def get_valid_patch_data(self, site=None):
+        return {"name": "Name Updated"}
+
+    def assert_patch_instance_original_fields(
+        self, original_instance, updated_instance: Person
+    ):
+        assert updated_instance.id == original_instance.id
+        assert updated_instance.bio == original_instance.bio
+        assert updated_instance.site == original_instance.site
+
+    def assert_patch_instance_updated_fields(self, data, updated_instance: Person):
+        assert updated_instance.name == data["name"]
+
+    def assert_update_patch_response(self, original_instance, data, actual_response):
+        assert actual_response["id"] == str(original_instance.id)
+        assert actual_response["name"] == data["name"]
+        assert actual_response["bio"] == original_instance.bio

--- a/firstvoices/backend/tests/test_apis/test_song_api.py
+++ b/firstvoices/backend/tests/test_apis/test_song_api.py
@@ -6,16 +6,12 @@ from backend.models.constants import Role, Visibility
 from backend.tests import factories
 
 from ...models import Lyric, Song
-from .base_api_test import (
-    BaseControlledSiteContentApiTest,
-    SiteContentPatchApiTestMixin,
-)
+from .base_api_test import BaseControlledSiteContentApiTest
 from .base_media_test import RelatedMediaTestMixin
 
 
 class TestSongEndpoint(
     RelatedMediaTestMixin,
-    SiteContentPatchApiTestMixin,
     BaseControlledSiteContentApiTest,
 ):
     """

--- a/firstvoices/backend/tests/test_apis/test_song_api.py
+++ b/firstvoices/backend/tests/test_apis/test_song_api.py
@@ -6,11 +6,18 @@ from backend.models.constants import Role, Visibility
 from backend.tests import factories
 
 from ...models import Lyric, Song
-from .base_api_test import BaseControlledSiteContentApiTest
+from .base_api_test import (
+    BaseControlledSiteContentApiTest,
+    SiteContentPatchApiTestMixin,
+)
 from .base_media_test import RelatedMediaTestMixin
 
 
-class TestSongEndpoint(RelatedMediaTestMixin, BaseControlledSiteContentApiTest):
+class TestSongEndpoint(
+    RelatedMediaTestMixin,
+    SiteContentPatchApiTestMixin,
+    BaseControlledSiteContentApiTest,
+):
     """
     End-to-end tests that the song endpoints have the expected behaviour.
     """
@@ -181,6 +188,100 @@ class TestSongEndpoint(RelatedMediaTestMixin, BaseControlledSiteContentApiTest):
             "excludeFromGames": False,
             "excludeFromKids": False,
         }
+
+    def create_original_instance_for_patch(self, site):
+        audio = factories.AudioFactory.create(site=site)
+        image = factories.ImageFactory.create(site=site)
+        video = factories.VideoFactory.create(site=site)
+        cover_image = factories.ImageFactory.create(site=site)
+        song = factories.SongFactory.create(
+            site=site,
+            title="Title",
+            title_translation="Title Translation",
+            introduction="Introduction",
+            introduction_translation="Introduction Translation",
+            acknowledgements=["Acknowledgement"],
+            notes=["Note"],
+            hide_overlay=True,
+            cover_image=cover_image,
+            exclude_from_games=True,
+            exclude_from_kids=True,
+            related_audio=(audio,),
+            related_images=(image,),
+            related_videos=(video,),
+        )
+        factories.LyricsFactory.create(song=song)
+        return song
+
+    def get_valid_patch_data(self, site=None):
+        return {"title": "Title Updated"}
+
+    def assert_patch_instance_original_fields(
+        self, original_instance, updated_instance: Song
+    ):
+        assert updated_instance.id == original_instance.id
+        assert updated_instance.title_translation == original_instance.title_translation
+        assert updated_instance.introduction == original_instance.introduction
+        assert (
+            updated_instance.introduction_translation
+            == original_instance.introduction_translation
+        )
+        assert updated_instance.acknowledgements == original_instance.acknowledgements
+        assert updated_instance.notes == original_instance.notes
+        assert updated_instance.hide_overlay == original_instance.hide_overlay
+        assert updated_instance.cover_image == original_instance.cover_image
+        assert (
+            updated_instance.exclude_from_games == original_instance.exclude_from_games
+        )
+        assert updated_instance.exclude_from_kids == original_instance.exclude_from_kids
+        assert updated_instance.related_audio == original_instance.related_audio
+        assert updated_instance.related_images == original_instance.related_images
+        assert updated_instance.related_videos == original_instance.related_videos
+        assert updated_instance.lyrics.first() == original_instance.lyrics.first()
+
+    def assert_patch_instance_updated_fields(self, data, updated_instance: Song):
+        assert updated_instance.title == data["title"]
+
+    def assert_update_patch_response(self, original_instance, data, actual_response):
+        assert actual_response["id"] == str(original_instance.id)
+        assert actual_response["title"] == data["title"]
+        assert actual_response["relatedAudio"][0]["id"] == str(
+            original_instance.related_audio.first().id
+        )
+        assert actual_response["relatedImages"][0]["id"] == str(
+            original_instance.related_images.first().id
+        )
+        assert actual_response["relatedVideos"][0]["id"] == str(
+            original_instance.related_videos.first().id
+        )
+        assert actual_response["hideOverlay"] == original_instance.hide_overlay
+        assert actual_response["coverImage"]["id"] == str(
+            original_instance.cover_image.id
+        )
+        assert (
+            actual_response["visibility"] == original_instance.get_visibility_display()
+        )
+        assert (
+            actual_response["titleTranslation"] == original_instance.title_translation
+        )
+        assert actual_response["introduction"] == original_instance.introduction
+        assert (
+            actual_response["introductionTranslation"]
+            == original_instance.introduction_translation
+        )
+        assert actual_response["notes"][0] == original_instance.notes[0]
+        assert (
+            actual_response["lyrics"][0]["text"]
+            == original_instance.lyrics.first().text
+        )
+        assert (
+            actual_response["acknowledgements"][0]
+            == original_instance.acknowledgements[0]
+        )
+        assert (
+            actual_response["excludeFromGames"] == original_instance.exclude_from_games
+        )
+        assert actual_response["excludeFromKids"] == original_instance.exclude_from_kids
 
     @pytest.mark.django_db
     def test_lyrics_order(self):

--- a/firstvoices/backend/tests/test_apis/test_song_api.py
+++ b/firstvoices/backend/tests/test_apis/test_song_api.py
@@ -219,55 +219,53 @@ class TestSongEndpoint(
     def assert_patch_instance_original_fields(
         self, original_instance, updated_instance: Song
     ):
+        self.assert_patch_instance_original_fields_related_media(
+            original_instance, updated_instance
+        )
         assert updated_instance.id == original_instance.id
+        assert (
+            updated_instance.exclude_from_games == original_instance.exclude_from_games
+        )
+        assert updated_instance.acknowledgements == original_instance.acknowledgements
+        assert updated_instance.hide_overlay == original_instance.hide_overlay
+        assert updated_instance.cover_image == original_instance.cover_image
         assert updated_instance.title_translation == original_instance.title_translation
+        assert updated_instance.exclude_from_kids == original_instance.exclude_from_kids
+        assert updated_instance.notes == original_instance.notes
         assert updated_instance.introduction == original_instance.introduction
         assert (
             updated_instance.introduction_translation
             == original_instance.introduction_translation
         )
-        assert updated_instance.acknowledgements == original_instance.acknowledgements
-        assert updated_instance.notes == original_instance.notes
-        assert updated_instance.hide_overlay == original_instance.hide_overlay
-        assert updated_instance.cover_image == original_instance.cover_image
-        assert (
-            updated_instance.exclude_from_games == original_instance.exclude_from_games
-        )
-        assert updated_instance.exclude_from_kids == original_instance.exclude_from_kids
-        assert updated_instance.related_audio == original_instance.related_audio
-        assert updated_instance.related_images == original_instance.related_images
-        assert updated_instance.related_videos == original_instance.related_videos
         assert updated_instance.lyrics.first() == original_instance.lyrics.first()
 
     def assert_patch_instance_updated_fields(self, data, updated_instance: Song):
         assert updated_instance.title == data["title"]
 
     def assert_update_patch_response(self, original_instance, data, actual_response):
-        assert actual_response["id"] == str(original_instance.id)
         assert actual_response["title"] == data["title"]
-        assert actual_response["relatedAudio"][0]["id"] == str(
-            original_instance.related_audio.first().id
+        assert (
+            actual_response["titleTranslation"] == original_instance.title_translation
         )
-        assert actual_response["relatedImages"][0]["id"] == str(
-            original_instance.related_images.first().id
+        assert (
+            actual_response["excludeFromGames"] == original_instance.exclude_from_games
         )
-        assert actual_response["relatedVideos"][0]["id"] == str(
-            original_instance.related_videos.first().id
+        assert actual_response["excludeFromKids"] == original_instance.exclude_from_kids
+        self.assert_update_patch_response_related_media(
+            original_instance, actual_response
         )
+        assert actual_response["introduction"] == original_instance.introduction
+        assert (
+            actual_response["introductionTranslation"]
+            == original_instance.introduction_translation
+        )
+        assert actual_response["id"] == str(original_instance.id)
         assert actual_response["hideOverlay"] == original_instance.hide_overlay
         assert actual_response["coverImage"]["id"] == str(
             original_instance.cover_image.id
         )
         assert (
             actual_response["visibility"] == original_instance.get_visibility_display()
-        )
-        assert (
-            actual_response["titleTranslation"] == original_instance.title_translation
-        )
-        assert actual_response["introduction"] == original_instance.introduction
-        assert (
-            actual_response["introductionTranslation"]
-            == original_instance.introduction_translation
         )
         assert actual_response["notes"][0] == original_instance.notes[0]
         assert (
@@ -278,10 +276,6 @@ class TestSongEndpoint(
             actual_response["acknowledgements"][0]
             == original_instance.acknowledgements[0]
         )
-        assert (
-            actual_response["excludeFromGames"] == original_instance.exclude_from_games
-        )
-        assert actual_response["excludeFromKids"] == original_instance.exclude_from_kids
 
     @pytest.mark.django_db
     def test_lyrics_order(self):

--- a/firstvoices/backend/tests/test_apis/test_story_api.py
+++ b/firstvoices/backend/tests/test_apis/test_story_api.py
@@ -218,9 +218,9 @@ class TestStoryEndpoint(
             updated_instance.exclude_from_games == original_instance.exclude_from_games
         )
         assert updated_instance.exclude_from_kids == original_instance.exclude_from_kids
-        assert updated_instance.related_audio == original_instance.related_audio
-        assert updated_instance.related_images == original_instance.related_images
-        assert updated_instance.related_videos == original_instance.related_videos
+        self.assert_patch_instance_original_fields_related_media(
+            original_instance, updated_instance
+        )
         assert updated_instance.pages.first() == original_instance.pages.first()
 
     def assert_patch_instance_updated_fields(self, data, updated_instance: Story):
@@ -229,14 +229,8 @@ class TestStoryEndpoint(
     def assert_update_patch_response(self, original_instance, data, actual_response):
         assert actual_response["id"] == str(original_instance.id)
         assert actual_response["title"] == data["title"]
-        assert actual_response["relatedAudio"][0]["id"] == str(
-            original_instance.related_audio.first().id
-        )
-        assert actual_response["relatedImages"][0]["id"] == str(
-            original_instance.related_images.first().id
-        )
-        assert actual_response["relatedVideos"][0]["id"] == str(
-            original_instance.related_videos.first().id
+        self.assert_update_patch_response_related_media(
+            original_instance, actual_response
         )
         assert actual_response["hideOverlay"] == original_instance.hide_overlay
         assert actual_response["coverImage"]["id"] == str(

--- a/firstvoices/backend/tests/test_apis/test_story_api.py
+++ b/firstvoices/backend/tests/test_apis/test_story_api.py
@@ -6,16 +6,12 @@ from backend.models.constants import Role, Visibility
 from backend.models.story import Story
 from backend.tests import factories
 
-from .base_api_test import (
-    BaseControlledSiteContentApiTest,
-    SiteContentPatchApiTestMixin,
-)
+from .base_api_test import BaseControlledSiteContentApiTest
 from .base_media_test import RelatedMediaTestMixin
 
 
 class TestStoryEndpoint(
     RelatedMediaTestMixin,
-    SiteContentPatchApiTestMixin,
     BaseControlledSiteContentApiTest,
 ):
     """

--- a/firstvoices/backend/tests/test_apis/test_story_api.py
+++ b/firstvoices/backend/tests/test_apis/test_story_api.py
@@ -6,11 +6,18 @@ from backend.models.constants import Role, Visibility
 from backend.models.story import Story
 from backend.tests import factories
 
-from .base_api_test import BaseControlledSiteContentApiTest
+from .base_api_test import (
+    BaseControlledSiteContentApiTest,
+    SiteContentPatchApiTestMixin,
+)
 from .base_media_test import RelatedMediaTestMixin
 
 
-class TestStoryEndpoint(RelatedMediaTestMixin, BaseControlledSiteContentApiTest):
+class TestStoryEndpoint(
+    RelatedMediaTestMixin,
+    SiteContentPatchApiTestMixin,
+    BaseControlledSiteContentApiTest,
+):
     """
     End-to-end tests that the story endpoints have the expected behaviour.
     """
@@ -164,6 +171,100 @@ class TestStoryEndpoint(RelatedMediaTestMixin, BaseControlledSiteContentApiTest)
             "author": story.author,
             "hideOverlay": story.hide_overlay,
         }
+
+    def create_original_instance_for_patch(self, site):
+        audio = factories.AudioFactory.create(site=site)
+        image = factories.ImageFactory.create(site=site)
+        video = factories.VideoFactory.create(site=site)
+        cover_image = factories.ImageFactory.create(site=site)
+        story = factories.StoryFactory.create(
+            site=site,
+            author="Author",
+            title="Title",
+            title_translation="Title Translation",
+            introduction="Introduction",
+            introduction_translation="Introduction Translation",
+            acknowledgements=["Acknowledgement"],
+            notes=["Note"],
+            hide_overlay=True,
+            cover_image=cover_image,
+            exclude_from_games=True,
+            exclude_from_kids=True,
+            related_audio=(audio,),
+            related_images=(image,),
+            related_videos=(video,),
+        )
+        factories.StoryPageFactory.create(site=site, story=story)
+        return story
+
+    def get_valid_patch_data(self, site=None):
+        return {"title": "Title Updated"}
+
+    def assert_patch_instance_original_fields(
+        self, original_instance, updated_instance: Story
+    ):
+        assert updated_instance.id == original_instance.id
+        assert updated_instance.title_translation == original_instance.title_translation
+        assert updated_instance.introduction == original_instance.introduction
+        assert (
+            updated_instance.introduction_translation
+            == original_instance.introduction_translation
+        )
+        assert updated_instance.acknowledgements == original_instance.acknowledgements
+        assert updated_instance.notes == original_instance.notes
+        assert updated_instance.hide_overlay == original_instance.hide_overlay
+        assert updated_instance.cover_image == original_instance.cover_image
+        assert (
+            updated_instance.exclude_from_games == original_instance.exclude_from_games
+        )
+        assert updated_instance.exclude_from_kids == original_instance.exclude_from_kids
+        assert updated_instance.related_audio == original_instance.related_audio
+        assert updated_instance.related_images == original_instance.related_images
+        assert updated_instance.related_videos == original_instance.related_videos
+        assert updated_instance.pages.first() == original_instance.pages.first()
+
+    def assert_patch_instance_updated_fields(self, data, updated_instance: Story):
+        assert updated_instance.title == data["title"]
+
+    def assert_update_patch_response(self, original_instance, data, actual_response):
+        assert actual_response["id"] == str(original_instance.id)
+        assert actual_response["title"] == data["title"]
+        assert actual_response["relatedAudio"][0]["id"] == str(
+            original_instance.related_audio.first().id
+        )
+        assert actual_response["relatedImages"][0]["id"] == str(
+            original_instance.related_images.first().id
+        )
+        assert actual_response["relatedVideos"][0]["id"] == str(
+            original_instance.related_videos.first().id
+        )
+        assert actual_response["hideOverlay"] == original_instance.hide_overlay
+        assert actual_response["coverImage"]["id"] == str(
+            original_instance.cover_image.id
+        )
+        assert (
+            actual_response["visibility"] == original_instance.get_visibility_display()
+        )
+        assert (
+            actual_response["titleTranslation"] == original_instance.title_translation
+        )
+        assert actual_response["introduction"] == original_instance.introduction
+        assert (
+            actual_response["introductionTranslation"]
+            == original_instance.introduction_translation
+        )
+        assert actual_response["notes"][0] == original_instance.notes[0]
+        assert (
+            actual_response["pages"][0]["text"] == original_instance.pages.first().text
+        )
+        assert (
+            actual_response["acknowledgements"][0]
+            == original_instance.acknowledgements[0]
+        )
+        assert (
+            actual_response["excludeFromGames"] == original_instance.exclude_from_games
+        )
+        assert actual_response["excludeFromKids"] == original_instance.exclude_from_kids
 
     @pytest.mark.django_db
     def test_pages_order(self):

--- a/firstvoices/backend/tests/test_apis/test_storypage_api.py
+++ b/firstvoices/backend/tests/test_apis/test_storypage_api.py
@@ -111,23 +111,17 @@ class TestStoryPageEndpoint(
         assert updated_instance.translation == original_instance.translation
         assert updated_instance.ordering == original_instance.ordering
         assert updated_instance.notes == original_instance.notes
-        assert updated_instance.related_audio == original_instance.related_audio
-        assert updated_instance.related_images == original_instance.related_images
-        assert updated_instance.related_videos == original_instance.related_videos
+        self.assert_patch_instance_original_fields_related_media(
+            original_instance, updated_instance
+        )
         assert updated_instance.story == original_instance.story
 
     def assert_patch_instance_updated_fields(self, data, updated_instance: StoryPage):
         assert updated_instance.text == data["text"]
 
     def assert_update_patch_response(self, original_instance, data, actual_response):
-        assert actual_response["relatedAudio"][0]["id"] == str(
-            original_instance.related_audio.first().id
-        )
-        assert actual_response["relatedImages"][0]["id"] == str(
-            original_instance.related_images.first().id
-        )
-        assert actual_response["relatedVideos"][0]["id"] == str(
-            original_instance.related_videos.first().id
+        self.assert_update_patch_response_related_media(
+            original_instance, actual_response
         )
         assert actual_response["text"] == data["text"]
         assert actual_response["translation"] == original_instance.translation

--- a/firstvoices/backend/tests/test_apis/test_storypage_api.py
+++ b/firstvoices/backend/tests/test_apis/test_storypage_api.py
@@ -7,16 +7,12 @@ from backend.models.constants import Role, Visibility
 from backend.models.story import StoryPage
 from backend.tests import factories
 
-from .base_api_test import (
-    BaseUncontrolledSiteContentApiTest,
-    SiteContentPatchApiTestMixin,
-)
+from .base_api_test import BaseUncontrolledSiteContentApiTest
 from .base_media_test import RelatedMediaTestMixin
 
 
 class TestStoryPageEndpoint(
     RelatedMediaTestMixin,
-    SiteContentPatchApiTestMixin,
     BaseUncontrolledSiteContentApiTest,
 ):
     """

--- a/firstvoices/backend/tests/test_apis/test_widgets_api.py
+++ b/firstvoices/backend/tests/test_apis/test_widgets_api.py
@@ -7,13 +7,10 @@ from backend.models.widget import SiteWidget, WidgetFormats, WidgetSettings
 from backend.tests import factories
 from backend.tests.test_apis.base_api_test import (
     BaseControlledLanguageAdminOnlySiteContentAPITest,
-    SiteContentPatchApiTestMixin,
 )
 
 
-class TestSiteWidgetEndpoint(
-    SiteContentPatchApiTestMixin, BaseControlledLanguageAdminOnlySiteContentAPITest
-):
+class TestSiteWidgetEndpoint(BaseControlledLanguageAdminOnlySiteContentAPITest):
     API_LIST_VIEW = "api:sitewidget-list"
     API_DETAIL_VIEW = "api:sitewidget-detail"
 

--- a/firstvoices/backend/tests/test_apis/test_widgets_api.py
+++ b/firstvoices/backend/tests/test_apis/test_widgets_api.py
@@ -3,14 +3,17 @@ import json
 import pytest
 
 from backend.models.constants import AppRole, Visibility
-from backend.models.widget import SiteWidget, WidgetSettings
+from backend.models.widget import SiteWidget, WidgetFormats, WidgetSettings
 from backend.tests import factories
 from backend.tests.test_apis.base_api_test import (
     BaseControlledLanguageAdminOnlySiteContentAPITest,
+    SiteContentPatchApiTestMixin,
 )
 
 
-class TestSiteWidgetEndpoint(BaseControlledLanguageAdminOnlySiteContentAPITest):
+class TestSiteWidgetEndpoint(
+    SiteContentPatchApiTestMixin, BaseControlledLanguageAdminOnlySiteContentAPITest
+):
     API_LIST_VIEW = "api:sitewidget-list"
     API_DETAIL_VIEW = "api:sitewidget-detail"
 
@@ -77,6 +80,49 @@ class TestSiteWidgetEndpoint(BaseControlledLanguageAdminOnlySiteContentAPITest):
             "format": "Default",
             "settings": [],
         }
+
+    def create_original_instance_for_patch(self, site):
+        widget = factories.SiteWidgetFactory.create(
+            site=site, title="Title", widget_type="Type", format=WidgetFormats.LEFT
+        )
+        factories.WidgetSettingsFactory.create(widget=widget)
+
+        return widget
+
+    def get_valid_patch_data(self, site=None):
+        return {"title": "Title Updated"}
+
+    def assert_patch_instance_original_fields(
+        self, original_instance, updated_instance: SiteWidget
+    ):
+        assert updated_instance.id == original_instance.id
+        assert updated_instance.site == original_instance.site
+        assert updated_instance.visibility == original_instance.visibility
+        assert updated_instance.widget_type == original_instance.widget_type
+        assert updated_instance.format == original_instance.format
+        assert (
+            updated_instance.widgetsettings_set.first()
+            == original_instance.widgetsettings_set.first()
+        )
+
+    def assert_patch_instance_updated_fields(self, data, updated_instance: SiteWidget):
+        assert updated_instance.title == data["title"]
+
+    def assert_update_patch_response(self, original_instance, data, actual_response):
+        assert actual_response["title"] == data["title"]
+        assert (
+            actual_response["visibility"] == original_instance.get_visibility_display()
+        )
+        assert actual_response["type"] == original_instance.widget_type
+        assert actual_response["format"] == original_instance.get_format_display()
+        assert (
+            actual_response["settings"][0]["key"]
+            == original_instance.widgetsettings_set.first().key
+        )
+        assert (
+            actual_response["settings"][0]["value"]
+            == original_instance.widgetsettings_set.first().value
+        )
 
     @pytest.mark.django_db
     def test_widget_permissions(self):

--- a/firstvoices/backend/views/base_views.py
+++ b/firstvoices/backend/views/base_views.py
@@ -8,16 +8,6 @@ from backend import permissions
 from backend.models import Alphabet, Character, CharacterVariant, IgnoredCharacter, Site
 from backend.permissions import utils
 
-http_methods_except_patch = [
-    "get",
-    "post",
-    "put",
-    "delete",
-    "head",
-    "options",
-    "trace",
-]
-
 
 class FVPermissionViewSetMixin:
     """

--- a/firstvoices/backend/views/category_views.py
+++ b/firstvoices/backend/views/category_views.py
@@ -19,11 +19,7 @@ from backend.serializers.category_serializers import (
     ParentCategoryFlatListSerializer,
     ParentCategoryListSerializer,
 )
-from backend.views.base_views import (
-    FVPermissionViewSetMixin,
-    SiteContentViewSetMixin,
-    http_methods_except_patch,
-)
+from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSetMixin
 
 from . import doc_strings
 from .api_doc_variables import id_parameter, site_slug_parameter
@@ -119,6 +115,22 @@ from .api_doc_variables import id_parameter, site_slug_parameter
             id_parameter,
         ],
     ),
+    partial_update=extend_schema(
+        description=_("Edit a category. Any omitted fields will be unchanged."),
+        responses={
+            200: OpenApiResponse(
+                description=doc_strings.success_200_edit,
+                response=CategoryDetailSerializer,
+            ),
+            400: OpenApiResponse(description=doc_strings.error_400_validation),
+            403: OpenApiResponse(description=doc_strings.error_403),
+            404: OpenApiResponse(description=doc_strings.error_404),
+        },
+        parameters=[
+            site_slug_parameter,
+            id_parameter,
+        ],
+    ),
     destroy=extend_schema(
         description=_("Delete a category."),
         responses={
@@ -136,7 +148,6 @@ from .api_doc_variables import id_parameter, site_slug_parameter
     ),
 )
 class CategoryViewSet(SiteContentViewSetMixin, FVPermissionViewSetMixin, ModelViewSet):
-    http_method_names = http_methods_except_patch
     valid_inputs = TypeOfDictionaryEntry.values
 
     def get_detail_queryset(self):

--- a/firstvoices/backend/views/character_views.py
+++ b/firstvoices/backend/views/character_views.py
@@ -16,7 +16,7 @@ from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSe
 
 @extend_schema_view(
     list=extend_schema(
-        description="A list of all characters available on the specified site",
+        description="A list of all characters available on the specified site.",
         responses={
             200: CharacterDetailSerializer,
             403: OpenApiResponse(description=doc_strings.error_403),
@@ -25,7 +25,7 @@ from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSe
         parameters=[site_slug_parameter],
     ),
     retrieve=extend_schema(
-        description="Details about a specific character in the specified site",
+        description="Details about a specific character in the specified site.",
         responses={
             200: CharacterDetailSerializer,
             403: OpenApiResponse(description=doc_strings.error_403),
@@ -37,7 +37,7 @@ from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSe
         ],
     ),
     update=extend_schema(
-        description="Edit a character in the specified site",
+        description="Edit a character in the specified site.",
         responses={
             200: OpenApiResponse(
                 description=doc_strings.success_200_edit,
@@ -47,6 +47,26 @@ from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSe
             403: OpenApiResponse(description=doc_strings.error_403),
             404: OpenApiResponse(description=doc_strings.error_404),
         },
+        parameters=[
+            site_slug_parameter,
+            id_parameter,
+        ],
+    ),
+    partial_update=extend_schema(
+        description="Edit a character in the specified site. Any omitted fields will be unchanged.",
+        responses={
+            200: OpenApiResponse(
+                description=doc_strings.success_200_edit,
+                response=CharacterDetailSerializer,
+            ),
+            400: OpenApiResponse(description=doc_strings.error_400_validation),
+            403: OpenApiResponse(description=doc_strings.error_403),
+            404: OpenApiResponse(description=doc_strings.error_404),
+        },
+        parameters=[
+            site_slug_parameter,
+            id_parameter,
+        ],
     ),
 )
 class CharactersViewSet(
@@ -56,7 +76,7 @@ class CharactersViewSet(
     Character information.
     """
 
-    http_method_names = ["get", "put"]
+    http_method_names = ["get", "put", "patch"]
     serializer_class = CharacterDetailSerializer
 
     def get_queryset(self):

--- a/firstvoices/backend/views/dictionary_views.py
+++ b/firstvoices/backend/views/dictionary_views.py
@@ -72,6 +72,19 @@ from . import doc_strings
         },
         parameters=[site_slug_parameter, id_parameter],
     ),
+    partial_update=extend_schema(
+        description="Update a dictionary entry on the specified site. Any omitted fields will be unchanged.",
+        responses={
+            200: OpenApiResponse(
+                description=doc_strings.success_200_detail,
+                response=DictionaryEntryDetailWriteResponseSerializer,
+            ),
+            400: OpenApiResponse(description=doc_strings.error_400_validation),
+            403: OpenApiResponse(description=doc_strings.error_403),
+            404: OpenApiResponse(description=doc_strings.error_404),
+        },
+        parameters=[site_slug_parameter, id_parameter],
+    ),
     destroy=extend_schema(
         description="Delete a dictionary entry from the specified site.",
         responses={
@@ -92,7 +105,7 @@ class DictionaryViewSet(
     Dictionary entry information.
     """
 
-    http_method_names = ["get", "post", "put", "delete"]
+    http_method_names = ["get", "post", "put", "delete", "patch"]
     serializer_class = DictionaryEntryDetailSerializer
 
     def get_queryset(self):

--- a/firstvoices/backend/views/dictionary_views.py
+++ b/firstvoices/backend/views/dictionary_views.py
@@ -105,7 +105,6 @@ class DictionaryViewSet(
     Dictionary entry information.
     """
 
-    http_method_names = ["get", "post", "put", "delete", "patch"]
     serializer_class = DictionaryEntryDetailSerializer
 
     def get_queryset(self):

--- a/firstvoices/backend/views/person_views.py
+++ b/firstvoices/backend/views/person_views.py
@@ -4,11 +4,7 @@ from rest_framework.viewsets import ModelViewSet
 
 from backend.models.media import Person
 from backend.serializers.media_serializers import PersonSerializer
-from backend.views.base_views import (
-    FVPermissionViewSetMixin,
-    SiteContentViewSetMixin,
-    http_methods_except_patch,
-)
+from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSetMixin
 
 from . import doc_strings
 from .api_doc_variables import id_parameter, site_slug_parameter
@@ -73,6 +69,22 @@ from .api_doc_variables import id_parameter, site_slug_parameter
             id_parameter,
         ],
     ),
+    partial_update=extend_schema(
+        description=_("Edit a person. Any omitted fields will be unchanged."),
+        responses={
+            200: OpenApiResponse(
+                description=doc_strings.success_200_edit,
+                response=PersonSerializer,
+            ),
+            400: OpenApiResponse(description=doc_strings.error_400_validation),
+            403: OpenApiResponse(description=doc_strings.error_403),
+            404: OpenApiResponse(description=doc_strings.error_404),
+        },
+        parameters=[
+            site_slug_parameter,
+            id_parameter,
+        ],
+    ),
     destroy=extend_schema(
         description=_("Delete a person."),
         responses={
@@ -90,7 +102,6 @@ from .api_doc_variables import id_parameter, site_slug_parameter
     ),
 )
 class PersonViewSet(SiteContentViewSetMixin, FVPermissionViewSetMixin, ModelViewSet):
-    http_method_names = http_methods_except_patch
     serializer_class = PersonSerializer
 
     def get_queryset(self):

--- a/firstvoices/backend/views/song_views.py
+++ b/firstvoices/backend/views/song_views.py
@@ -10,11 +10,7 @@ from rest_framework.viewsets import ModelViewSet
 
 from backend.models import Song
 from backend.serializers.song_serializers import SongListSerializer, SongSerializer
-from backend.views.base_views import (
-    FVPermissionViewSetMixin,
-    SiteContentViewSetMixin,
-    http_methods_except_patch,
-)
+from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSetMixin
 
 from . import doc_strings
 from .api_doc_variables import id_parameter, site_slug_parameter
@@ -81,6 +77,22 @@ from .api_doc_variables import id_parameter, site_slug_parameter
             id_parameter,
         ],
     ),
+    partial_update=extend_schema(
+        description=_("Edit a song. Any omitted fields will be unchanged."),
+        responses={
+            200: OpenApiResponse(
+                description=doc_strings.success_200_edit,
+                response=SongSerializer,
+            ),
+            400: OpenApiResponse(description=doc_strings.error_400_validation),
+            403: OpenApiResponse(description=doc_strings.error_403),
+            404: OpenApiResponse(description=doc_strings.error_404),
+        },
+        parameters=[
+            site_slug_parameter,
+            id_parameter,
+        ],
+    ),
     destroy=extend_schema(
         description=_("Delete a song."),
         responses={
@@ -98,8 +110,6 @@ from .api_doc_variables import id_parameter, site_slug_parameter
     ),
 )
 class SongViewSet(SiteContentViewSetMixin, FVPermissionViewSetMixin, ModelViewSet):
-    http_method_names = http_methods_except_patch
-
     def get_detail_queryset(self):
         site = self.get_validated_site()
         return Song.objects.filter(site__slug=site[0].slug).all()

--- a/firstvoices/backend/views/story_views.py
+++ b/firstvoices/backend/views/story_views.py
@@ -7,7 +7,6 @@ from backend.serializers.story_serializers import StoryListSerializer, StorySeri
 from backend.views.base_views import (
     FVPermissionViewSetMixin,
     SiteContentViewSetMixin,
-    http_methods_except_patch,
 )
 
 from . import doc_strings
@@ -70,6 +69,22 @@ from .api_doc_variables import id_parameter, site_slug_parameter
             id_parameter,
         ],
     ),
+    partial_update=extend_schema(
+        description=_("Edit a story. Any omitted fields will be unchanged."),
+        responses={
+            200: OpenApiResponse(
+                description=doc_strings.success_200_edit,
+                response=StorySerializer,
+            ),
+            400: OpenApiResponse(description=doc_strings.error_400_validation),
+            403: OpenApiResponse(description=doc_strings.error_403),
+            404: OpenApiResponse(description=doc_strings.error_404),
+        },
+        parameters=[
+            site_slug_parameter,
+            id_parameter,
+        ],
+    ),
     destroy=extend_schema(
         description=_("Delete a story."),
         responses={
@@ -87,8 +102,6 @@ from .api_doc_variables import id_parameter, site_slug_parameter
     ),
 )
 class StoryViewSet(SiteContentViewSetMixin, FVPermissionViewSetMixin, ModelViewSet):
-    http_method_names = http_methods_except_patch
-
     def get_detail_queryset(self):
         site = self.get_validated_site()
         return Story.objects.filter(site__slug=site[0].slug).all()

--- a/firstvoices/backend/views/storypage_views.py
+++ b/firstvoices/backend/views/storypage_views.py
@@ -6,11 +6,7 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.viewsets import ModelViewSet
 
 from backend.models import Story, StoryPage
-from backend.views.base_views import (
-    FVPermissionViewSetMixin,
-    SiteContentViewSetMixin,
-    http_methods_except_patch,
-)
+from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSetMixin
 
 from ..serializers.story_serializers import StoryPageDetailSerializer
 from . import doc_strings
@@ -73,6 +69,22 @@ from .api_doc_variables import id_parameter, site_slug_parameter
             id_parameter,
         ],
     ),
+    partial_update=extend_schema(
+        description=_("Edit a story page. Any omitted fields will be unchanged."),
+        responses={
+            200: OpenApiResponse(
+                description=doc_strings.success_200_edit,
+                response=StoryPageDetailSerializer,
+            ),
+            400: OpenApiResponse(description=doc_strings.error_400_validation),
+            403: OpenApiResponse(description=doc_strings.error_403),
+            404: OpenApiResponse(description=doc_strings.error_404),
+        },
+        parameters=[
+            site_slug_parameter,
+            id_parameter,
+        ],
+    ),
     destroy=extend_schema(
         description=_("Delete a story page."),
         responses={
@@ -90,8 +102,6 @@ from .api_doc_variables import id_parameter, site_slug_parameter
     ),
 )
 class StoryPageViewSet(SiteContentViewSetMixin, FVPermissionViewSetMixin, ModelViewSet):
-    http_method_names = http_methods_except_patch
-
     def get_detail_queryset(self):
         site = self.get_validated_site().first()
         story = self.get_validated_story(site)

--- a/firstvoices/backend/views/widget_views.py
+++ b/firstvoices/backend/views/widget_views.py
@@ -7,11 +7,7 @@ from backend.models.widget import SiteWidget, WidgetSettings
 from backend.serializers.widget_serializers import SiteWidgetDetailSerializer
 from backend.views import doc_strings
 from backend.views.api_doc_variables import id_parameter, site_slug_parameter
-from backend.views.base_views import (
-    FVPermissionViewSetMixin,
-    SiteContentViewSetMixin,
-    http_methods_except_patch,
-)
+from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSetMixin
 
 
 @extend_schema_view(
@@ -64,6 +60,22 @@ from backend.views.base_views import (
             id_parameter,
         ],
     ),
+    partial_update=extend_schema(
+        description=_("Edit a site widget. Any omitted fields will be unchanged."),
+        responses={
+            200: OpenApiResponse(
+                description=doc_strings.success_200_edit,
+                response=SiteWidgetDetailSerializer,
+            ),
+            400: OpenApiResponse(description=doc_strings.error_400_validation),
+            403: OpenApiResponse(description=doc_strings.error_403),
+            404: OpenApiResponse(description=doc_strings.error_404),
+        },
+        parameters=[
+            site_slug_parameter,
+            id_parameter,
+        ],
+    ),
     destroy=extend_schema(
         description=_("Delete a site widget."),
         responses={
@@ -83,7 +95,6 @@ from backend.views.base_views import (
 class SiteWidgetViewSet(
     SiteContentViewSetMixin, FVPermissionViewSetMixin, ModelViewSet
 ):
-    http_method_names = http_methods_except_patch
     serializer_class = SiteWidgetDetailSerializer
 
     def get_queryset(self):


### PR DESCRIPTION
### Description of Changes
This PR enables PATCH for the following site content APIs:
- Categories at `/api/1.0/sites/{site_slug}/categories/{id}/`
- Characters at `/api/1.0/sites/{site_slug}/characters/{id}/`
- Dictionary at `/api/1.0/sites/{site_slug}/dictionary/{id}/`
- People at `/api/1.0/sites/{site_slug}/people/{id}/`
- Songs at `/api/1.0/sites/{site_slug}/songs/{id}/`
- Stories at `/api/1.0/sites/{site_slug}/stories/{id}/`
- Story Pages at `/api/1.0/sites/{site_slug}/stories/{story_pk}/pages/{id}/`
- Widgets at `/api/1.0/sites/{site_slug}/widgets/{id}/`

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
For reviewers, it would be good to test at least one of the PATCH API locally.
