### PR TITLE
fw-4368, story page permissions (final.final.this_one)

### DIFF
--- a/firstvoices/backend/serializers/base_serializers.py
+++ b/firstvoices/backend/serializers/base_serializers.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import PermissionDenied
 from rest_framework import serializers
 from rest_framework_nested.relations import NestedHyperlinkedIdentityField
 
@@ -104,8 +105,8 @@ class CreateControlledSiteContentSerializerMixin(CreateSiteContentSerializerMixi
         site_membership = memberships.filter(site=site).first()
         if site_membership:
             if site_membership.role == Role.ASSISTANT and visibility > Visibility.TEAM:
-                raise serializers.ValidationError(
-                    "Assistants cannot change the visibility of controlled content."
+                raise PermissionDenied(
+                    "Assistants cannot create or edit published content."
                 )
 
         return super().validate(attrs)

--- a/firstvoices/backend/serializers/story_serializers.py
+++ b/firstvoices/backend/serializers/story_serializers.py
@@ -60,6 +60,12 @@ class StoryPageDetailSerializer(
     class Meta(StoryPageSummarySerializer.Meta):
         fields = StoryPageSummarySerializer.Meta.fields + ("story",)
 
+    def validate(self, attrs):
+        """use the visibility from the parent story for all permission checks"""
+        story = get_story_from_context(self)
+        attrs["visibility"] = story.visibility
+        return super().validate(attrs)
+
     def create(self, validated_data):
         return super().create(self.add_story_id(validated_data))
 

--- a/firstvoices/backend/tests/test_apis/base_api_test.py
+++ b/firstvoices/backend/tests/test_apis/base_api_test.py
@@ -513,7 +513,7 @@ class ControlledSiteContentCreateApiTestMixin:
             content_type=self.content_type,
         )
 
-        assert response.status_code == 400
+        assert response.status_code == 403
 
 
 class SiteContentUpdateApiTestMixin:
@@ -661,7 +661,7 @@ class ControlledSiteContentUpdateApiTestMixin:
             content_type=self.content_type,
         )
 
-        assert response.status_code == 400
+        assert response.status_code == 403
 
 
 class SiteContentDestroyApiTestMixin:


### PR DESCRIPTION
### Description of Changes
* switched the the right base test class (for controlled site content) and added the necessary test overrides
* minor: updated the create controlled content permission check for assistants to raise PermissionDenied instead of ValidationError

### Checklist
- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
