### PR TITLE
FW-4676 import audio model and audiospeakers

### DIFF
--- a/firstvoices/backend/resources/media.py
+++ b/firstvoices/backend/resources/media.py
@@ -1,7 +1,26 @@
-from backend.models.media import Person
+from backend.models.media import Audio, AudioSpeaker, Person
 from backend.resources.base import SiteContentResource
 
 
 class PersonResource(SiteContentResource):
     class Meta:
         model = Person
+
+
+class AudioResource(SiteContentResource):
+    class Meta:
+        model = Audio
+
+
+class AudioSpeakerResource(SiteContentResource):
+    class Meta:
+        model = AudioSpeaker
+
+
+class AudioSpeakerMigrationResource(AudioSpeakerResource):
+    def before_import(self, dataset, using_transactions, dry_run, **kwargs):
+        """Delete unused persons that are not used as AudioSpeakers."""
+        if not dry_run:
+            Person.objects.filter(site__in=dataset["site"]).exclude(
+                id__in=dataset["speaker"]
+            ).delete()

--- a/firstvoices/scripts/import_csv_data.py
+++ b/firstvoices/scripts/import_csv_data.py
@@ -14,7 +14,11 @@ from backend.resources.characters import (
     CharacterVariantResource,
     IgnoredCharacterResource,
 )
-from backend.resources.media import PersonResource
+from backend.resources.media import (
+    AudioResource,
+    AudioSpeakerMigrationResource,
+    PersonResource,
+)
 from backend.resources.sites import SiteMigrationResource  # , SiteResource
 
 """Script to import CSV files of site content into the fv-be database.
@@ -57,6 +61,8 @@ import_resources = [
     ("sites", SiteMigrationResource()),
     ("categories", CategoryMigrationResource()),
     ("contributors", PersonResource()),
+    ("audio-data", AudioResource()),
+    ("audio-speakers", AudioSpeakerMigrationResource()),
     # ("site_media", SiteResource()) # waiting on media import
     ("base-characters", CharacterResource()),
     ("variant-characters", CharacterVariantResource()),


### PR DESCRIPTION
### Description of Changes
Adds import resources for Audio models and AudioSpeaker relations. Updates the import script to include them and adds tests. The AudioSpeaker importer also deletes all Persons from the site that are not part of any AudioSpeaker relation.

### Checklist
- README / documentation has been updated if needed
- [X] PR title / commit messages contain Jira ticket number if applicable
- [X] Tests have been updated / created if applicable
- Admin Panel has been updated if models have been added or modified
- Migrations have been updated and committed if applicable
- Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
Audio objects are migrated with no related file - `original` is left as null.
