### PR TITLE
Fix media files not deleting from AWS using Admin

### DIFF
--- a/firstvoices/backend/admin/media_admin.py
+++ b/firstvoices/backend/admin/media_admin.py
@@ -22,6 +22,10 @@ class FileAdmin(HiddenBaseAdmin):
     search_fields = ("content",)
     readonly_fields = ("mimetype", "size") + HiddenBaseAdmin.readonly_fields
 
+    def delete_queryset(self, request, queryset):
+        for obj in queryset.all():
+            obj.delete()
+
 
 @admin.register(ImageFile)
 @admin.register(VideoFile)
@@ -37,6 +41,10 @@ class AudioAdmin(BaseSiteContentAdmin):
     list_display = ("title",) + BaseSiteContentAdmin.list_display
     search_fields = ("title",)
 
+    def delete_queryset(self, request, queryset):
+        for obj in queryset.all():
+            obj.delete()
+
 
 @admin.register(Image)
 @admin.register(Video)
@@ -48,6 +56,10 @@ class VisualMediaAdmin(BaseSiteContentAdmin):
     ) + BaseSiteContentAdmin.readonly_fields
     list_display = ("title",) + BaseSiteContentAdmin.list_display
     search_fields = ("title",)
+
+    def delete_queryset(self, request, queryset):
+        for obj in queryset.all():
+            obj.delete()
 
 
 @admin.register(EmbeddedVideo)


### PR DESCRIPTION
### Description of Changes
This PR fixes the media files not being removed from AWS when deleting from the admin list view (eg: from `/admin/backend/imagefile/`). When media is deleted this way `delete_queryset` is called which doesn't use the model `delete` method, leaving some orphaned media on AWS in certain cases.

Relates to [FW-4547](https://firstvoices.atlassian.net/browse/FW-4547), [FW-4352](https://firstvoices.atlassian.net/browse/FW-4352), and [FW-4676](https://firstvoices.atlassian.net/browse/FW-4676).

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A


[FW-4547]: https://firstvoices.atlassian.net/browse/FW-4547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FW-4352]: https://firstvoices.atlassian.net/browse/FW-4352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FW-4676]: https://firstvoices.atlassian.net/browse/FW-4676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ