### PR TITLE
FW-4354 import memberships

### DIFF
--- a/firstvoices/backend/management/commands/import_csv_data.py
+++ b/firstvoices/backend/management/commands/import_csv_data.py
@@ -9,6 +9,7 @@ from scripts.utils.aws_download_utils import (
 )
 
 from backend.models.app import AppImportStatus
+from backend.resources.app import AppMembershipResource
 from backend.resources.categories import CategoryMigrationResource
 from backend.resources.characters import (
     CharacterResource,
@@ -22,7 +23,11 @@ from backend.resources.media import (
     PersonResource,
     VideoResource,
 )
-from backend.resources.sites import SiteMigrationResource, SiteResource
+from backend.resources.sites import (
+    MembershipResource,
+    SiteMigrationResource,
+    SiteResource,
+)
 from backend.resources.users import UserResource
 
 
@@ -71,7 +76,9 @@ def run_import():
     # List model resources in the correct order to import them
     import_resources = [
         ("users", UserResource()),
+        ("app-memberships", AppMembershipResource()),
         ("sites", SiteMigrationResource()),
+        ("site-memberships", MembershipResource()),
         ("categories", CategoryMigrationResource()),
         ("contributors", PersonResource()),
         ("audio-data", AudioResource()),

--- a/firstvoices/backend/resources/app.py
+++ b/firstvoices/backend/resources/app.py
@@ -1,0 +1,32 @@
+from import_export import fields
+
+from backend.models.app import AppMembership
+from backend.models.constants import AppRole
+from backend.resources.base import BaseResource
+from backend.resources.utils.import_export_widgets import (
+    ChoicesWidget,
+    UserForeignKeyWidget,
+)
+
+
+class AppMembershipResource(BaseResource):
+    role = fields.Field(
+        column_name="role",
+        widget=ChoicesWidget(AppRole.choices),
+        attribute="role",
+    )
+    user = fields.Field(
+        column_name="user",
+        attribute="user",
+        widget=UserForeignKeyWidget(create=False),
+    )
+
+    class Meta:
+        model = AppMembership
+
+    def skip_row(self, instance, original, row, import_validation_errors=None):
+        """Don't create/overwrite app-level roles for users that already have one."""
+        user_has_role = AppMembership.objects.filter(user=instance.user).exists()
+        if user_has_role:
+            return True
+        return super().skip_row(instance, original, row, import_validation_errors)

--- a/firstvoices/backend/resources/app.py
+++ b/firstvoices/backend/resources/app.py
@@ -18,7 +18,7 @@ class AppMembershipResource(BaseResource):
     user = fields.Field(
         column_name="user",
         attribute="user",
-        widget=UserForeignKeyWidget(create=False),
+        widget=UserForeignKeyWidget(),
     )
 
     class Meta:

--- a/firstvoices/backend/resources/base.py
+++ b/firstvoices/backend/resources/base.py
@@ -8,12 +8,12 @@ class BaseResource(resources.ModelResource):
     created_by = fields.Field(
         column_name="created_by",
         attribute="created_by",
-        widget=UserForeignKeyWidget(create=False),
+        widget=UserForeignKeyWidget(),
     )
     last_modified_by = fields.Field(
         column_name="last_modified_by",
         attribute="last_modified_by",
-        widget=UserForeignKeyWidget(create=False),
+        widget=UserForeignKeyWidget(),
     )
 
     class Meta:

--- a/firstvoices/backend/resources/sites.py
+++ b/firstvoices/backend/resources/sites.py
@@ -72,7 +72,7 @@ class MembershipResource(SiteContentResource):
     user = fields.Field(
         column_name="user",
         attribute="user",
-        widget=UserForeignKeyWidget(create=False),
+        widget=UserForeignKeyWidget(),
     )
 
     class Meta:

--- a/firstvoices/backend/resources/sites.py
+++ b/firstvoices/backend/resources/sites.py
@@ -2,11 +2,14 @@ from django.db import connection
 from import_export import fields
 from import_export.widgets import ForeignKeyWidget
 
-from backend.models.constants import Visibility
+from backend.models.constants import Role, Visibility
 from backend.models.media import File, ImageFile, VideoFile
-from backend.models.sites import Language, Site
-from backend.resources.base import BaseResource
-from backend.resources.utils.import_export_widgets import ChoicesWidget
+from backend.models.sites import Language, Membership, Site
+from backend.resources.base import BaseResource, SiteContentResource
+from backend.resources.utils.import_export_widgets import (
+    ChoicesWidget,
+    UserForeignKeyWidget,
+)
 
 
 class SiteResource(BaseResource):
@@ -58,3 +61,19 @@ class SiteMigrationResource(SiteResource):
                         [tuple(imagefile_ids_to_delete)],
                     )
             Site.objects.filter(id__in=dataset["id"]).delete()
+
+
+class MembershipResource(SiteContentResource):
+    role = fields.Field(
+        column_name="role",
+        widget=ChoicesWidget(Role.choices),
+        attribute="role",
+    )
+    user = fields.Field(
+        column_name="user",
+        attribute="user",
+        widget=UserForeignKeyWidget(create=False),
+    )
+
+    class Meta:
+        model = Membership

--- a/firstvoices/backend/resources/users.py
+++ b/firstvoices/backend/resources/users.py
@@ -5,3 +5,10 @@ from jwt_auth.models import User
 class UserResource(resources.ModelResource):
     class Meta:
         model = User
+
+    def skip_row(self, instance, original, row, import_validation_errors=None):
+        """Skip users that already exist."""
+        user_exists = User.objects.filter(email=instance.email).exists()
+        if user_exists:
+            return True
+        return super().skip_row(instance, original, row, import_validation_errors)

--- a/firstvoices/backend/resources/utils/import_export_widgets.py
+++ b/firstvoices/backend/resources/utils/import_export_widgets.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import get_user_model
 from import_export.widgets import ForeignKeyWidget, Widget
 
-DUMMY_USER_EMAIL = "test@test.com"
+DUMMY_USER_EMAIL = "support@fpcc.ca"
 
 
 class ChoicesWidget(Widget):

--- a/firstvoices/backend/tests/test_resources/test_membership_resource.py
+++ b/firstvoices/backend/tests/test_resources/test_membership_resource.py
@@ -1,0 +1,121 @@
+import uuid
+
+import pytest
+import tablib
+
+from backend.models.constants import AppRole, Role
+from backend.resources.app import AppMembership, AppMembershipResource
+from backend.resources.sites import Membership, MembershipResource
+from backend.tests.factories import AppMembershipFactory, SiteFactory, UserFactory
+
+
+class TestAppMembershipImport:
+    @staticmethod
+    def build_table(data: list[str]):
+        headers = [
+            # these headers should match what is produced by fv-nuxeo-export tool
+            "user,created,created_by,last_modified,last_modified_by,id,role",
+        ]
+        table = tablib.import_set("\n".join(headers + data), format="csv")
+        return table
+
+    @pytest.mark.django_db
+    def test_import_base_data(self):
+        """Import AppMembership object with basic fields"""
+        id_one = uuid.uuid4()
+        user = UserFactory.create()
+        data = [
+            f"{user.email},,,,,{id_one},Staff",
+        ]
+        table = self.build_table(data)
+        result = AppMembershipResource().import_data(dataset=table)
+
+        assert not result.has_errors()
+        assert not result.has_validation_errors()
+        assert result.totals["new"] == len(data)
+        new_membership = AppMembership.objects.filter(id=table["id"][0])
+        assert new_membership.exists()
+        assert new_membership.first().user == user
+        assert new_membership.first().role == AppRole.STAFF
+        assert new_membership.first().created_by is None
+
+    @pytest.mark.django_db
+    def test_no_overwrite(self):
+        """Only new roles should be added, existing should not be overwritten"""
+        user = UserFactory.create()
+        AppMembershipFactory.create(user=user, role=AppRole.SUPERADMIN)
+
+        id_one = uuid.uuid4()
+        data = [
+            f"{user.email},,,,,{id_one},Staff",
+        ]
+        table = self.build_table(data)
+        result = AppMembershipResource().import_data(dataset=table)
+
+        assert not result.has_errors()
+        assert not result.has_validation_errors()
+        assert result.totals["new"] == 0
+        old_membership = AppMembership.objects.get(user=user)
+        assert old_membership.role == AppRole.SUPERADMIN
+
+
+class TestSiteMembershipImport:
+    @staticmethod
+    def build_table(data: list[str]):
+        headers = [
+            # these headers should match what is produced by fv-nuxeo-export tool
+            "user,role,order,id,created,created_by,last_modified,last_modified_by,site",
+        ]
+        table = tablib.import_set("\n".join(headers + data), format="csv")
+        return table
+
+    @pytest.mark.django_db
+    def test_import_base_data(self):
+        """Import site-level Membership object with basic fields"""
+        site = SiteFactory.create()
+        user = UserFactory.create()
+        id_one = uuid.uuid4()
+        data = [
+            f"{user.email},Language Admin,0,{id_one},,,,,{site.id}",
+        ]
+        table = self.build_table(data)
+        result = MembershipResource().import_data(dataset=table)
+
+        assert not result.has_errors()
+        assert not result.has_validation_errors()
+        assert result.totals["new"] == len(data)
+        assert Membership.objects.filter(site=site.id).count() == len(data)
+
+        new_membership = Membership.objects.filter(id=table["id"][0])
+        assert new_membership.exists()
+        assert new_membership.first().user == user
+        assert new_membership.first().role == Role.LANGUAGE_ADMIN
+        assert new_membership.first().created_by is None
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        "exporter_label,django_choice",
+        [
+            ("Language Admin", Role.LANGUAGE_ADMIN),
+            ("Editor", Role.EDITOR),
+            ("Assistant", Role.ASSISTANT),
+            ("Member", Role.MEMBER),
+        ],
+    )
+    def test_import_all_roles(self, exporter_label, django_choice):
+        """Ensure that import works for all site membership roles"""
+        site = SiteFactory.create()
+        user = UserFactory.create()
+        id_one = uuid.uuid4()
+        data = [
+            f"{user.email},{exporter_label},0,{id_one},,,,,{site.id}",
+        ]
+        table = self.build_table(data)
+        result = MembershipResource().import_data(dataset=table)
+
+        assert not result.has_errors()
+        assert not result.has_validation_errors()
+        assert result.totals["new"] == len(data)
+        new_membership = Membership.objects.filter(id=table["id"][0])
+        assert new_membership.exists()
+        assert new_membership.first().role == django_choice

--- a/firstvoices/backend/tests/test_resources/test_membership_resource.py
+++ b/firstvoices/backend/tests/test_resources/test_membership_resource.py
@@ -55,6 +55,7 @@ class TestAppMembershipImport:
         assert not result.has_errors()
         assert not result.has_validation_errors()
         assert result.totals["new"] == 0
+        assert result.totals["skip"] == 1
         old_membership = AppMembership.objects.get(user=user)
         assert old_membership.role == AppRole.SUPERADMIN
 

--- a/firstvoices/backend/tests/test_resources/test_site_resource.py
+++ b/firstvoices/backend/tests/test_resources/test_site_resource.py
@@ -100,7 +100,7 @@ class TestSiteImport:
         assert result.totals["new"] == 1
         new_site = Site.objects.get(id=table["id"][0])
         # for now: use dummy user details on migrated site - fix later to match actual data
-        assert new_site.created_by.email == "test@test.com"
+        assert new_site.created_by.email == "support@fpcc.ca"
 
 
 class TestSiteMigration:


### PR DESCRIPTION
### Description of Changes
Adds import for app-level and site-level memberships. Skips users with existing app-level memberships (e.g. don't overwrite existing superadmins). Also fixes a bug that appears when re-migrating users -- skip import for users already in the db.

### Checklist
- README / documentation has been updated if needed
- [X] PR title / commit messages contain Jira ticket number if applicable
- [X] Tests have been updated / created if applicable
- Admin Panel has been updated if models have been added or modified
- Migrations have been updated and committed if applicable
- Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
