### PR TITLE
Remove widgets field in SiteWidgetList admin

### DIFF
--- a/firstvoices/backend/admin/base_admin.py
+++ b/firstvoices/backend/admin/base_admin.py
@@ -17,6 +17,13 @@ class BaseAdmin(admin.ModelAdmin):
         "last_modified_by",
         "last_modified",
     )
+    fields = (
+        "id",
+        "created",
+        "created_by",
+        "last_modified_by",
+        "last_modified",
+    )
     list_display = (
         "id",
         "created_by",

--- a/firstvoices/backend/admin/widget_admin.py
+++ b/firstvoices/backend/admin/widget_admin.py
@@ -72,6 +72,8 @@ class SiteWidgetListOrderInline(BaseInlineAdmin):
 class SiteWidgetListAdmin(BaseSiteContentAdmin):
     list_display = ("__str__",) + BaseSiteContentAdmin.list_display
     list_filter = ["site"]
+    fields = ("site",) + BaseSiteContentAdmin.fields
+    readonly_fields = BaseSiteContentAdmin.readonly_fields
     search_fields = (
         "widgets__title",
         "site__title",


### PR DESCRIPTION
### Description of Changes
This PR includes a fix for SiteWidgetList creation in the admin panel. Widgets should now be added to a SiteWidgetList using the order inline at the bottom of the page at `admin/backend/sitewidgetlist/add/`.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
