### PR TITLE
fw-4735, prefetching for banners + widget lists in admin

### DIFF
--- a/firstvoices/backend/admin/page_admin.py
+++ b/firstvoices/backend/admin/page_admin.py
@@ -1,7 +1,9 @@
 from django.contrib import admin
 
 from backend.admin.base_admin import BaseControlledSiteContentAdmin
+from backend.models.media import Image, Video
 from backend.models.page import SitePage
+from backend.models.widget import SiteWidgetList
 
 
 @admin.register(SitePage)
@@ -13,3 +15,13 @@ class SitePageAdmin(BaseControlledSiteContentAdmin):
         "widgets__widgets__title",
         "site__title",
     ) + BaseControlledSiteContentAdmin.search_fields
+
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        # prefetch the media models' site info (it is used for their display name)
+        if db_field.name == "banner_image":
+            kwargs["queryset"] = Image.objects.select_related("site")
+        if db_field.name == "banner_video":
+            kwargs["queryset"] = Video.objects.select_related("site")
+        if db_field.name == "widgets":
+            kwargs["queryset"] = SiteWidgetList.objects.select_related("site")
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)


### PR DESCRIPTION
### Description of Changes
- admin site speed improvements: eliminate n+1 queries related to the display names for the options in the banner_image, banner_video, logo, homepage, and widgets dropdowns

### Checklist
- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
