### PR TITLE
Fw 4750 fix import dictionary type

### DIFF
--- a/firstvoices/backend/models/characters.py
+++ b/firstvoices/backend/models/characters.py
@@ -285,7 +285,7 @@ class Alphabet(BaseSiteContentModel):
                 )
             )
         else:
-            self.logger.warning("Empty confusable map for site %s", self.site)
+            self.logger.debug("Empty confusable map for site %s", self.site)
             return None
 
     def presort_transducer(self, base_characters=None, character_variants=None):

--- a/firstvoices/backend/resources/dictionary.py
+++ b/firstvoices/backend/resources/dictionary.py
@@ -18,6 +18,7 @@ from backend.models.constants import Visibility
 from backend.models.dictionary import (
     DictionaryEntryCategory,
     DictionaryEntryRelatedCharacter,
+    TypeOfDictionaryEntry,
 )
 from backend.resources.base import BaseResource, SiteContentResource
 from backend.resources.utils.import_export_widgets import ChoicesWidget
@@ -29,7 +30,11 @@ class DictionaryEntryResource(SiteContentResource):
         widget=ChoicesWidget(Visibility.choices),
         attribute="visibility",
     )
-
+    type = fields.Field(
+        column_name="type",
+        widget=ChoicesWidget(TypeOfDictionaryEntry.choices),
+        attribute="type",
+    )
     part_of_speech = fields.Field(
         column_name="part_of_speech",
         attribute="part_of_speech",

--- a/firstvoices/backend/tests/test_resources/test_dictionary_resources.py
+++ b/firstvoices/backend/tests/test_resources/test_dictionary_resources.py
@@ -62,7 +62,7 @@ class TestDictionaryEntryImport:
         assert table["title"][0] == test_word.title
         assert table["site"][0] == str(test_word.site.id)
         assert Visibility.PUBLIC == test_word.visibility
-        assert str(TypeOfDictionaryEntry.WORD).lower() == str(test_word.type).lower()
+        assert TypeOfDictionaryEntry.WORD == test_word.type
         assert table["batch_id"][0] == test_word.batch_id
         assert not test_word.exclude_from_kids
         assert not test_word.exclude_from_games
@@ -72,9 +72,7 @@ class TestDictionaryEntryImport:
         assert table["title"][1] == test_phrase.title
         assert table["site"][1] == str(test_phrase.site.id)
         assert Visibility.TEAM == test_phrase.visibility
-        assert (
-            str(TypeOfDictionaryEntry.PHRASE).lower() == str(test_phrase.type).lower()
-        )
+        assert TypeOfDictionaryEntry.PHRASE == test_phrase.type
         assert table["batch_id"][1] == test_phrase.batch_id
         assert test_phrase.exclude_from_kids
         assert test_phrase.exclude_from_games


### PR DESCRIPTION
### Description of Changes
Fix an issue with migrating dictionary entry type as unrecognized. Plus a misc fix for more appropriate warning level on confusables issue.

### Checklist
- README / documentation has been updated if needed
- [X] PR title / commit messages contain Jira ticket number if applicable
- [X] Tests have been updated / created if applicable
- Admin Panel has been updated if models have been added or modified
- Migrations have been updated and committed if applicable
- Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
