### PR TITLE
FW-4444 import stories

### DIFF
--- a/firstvoices/backend/management/commands/import_csv_data.py
+++ b/firstvoices/backend/management/commands/import_csv_data.py
@@ -39,6 +39,7 @@ from backend.resources.sites import (
     SiteMigrationResource,
     SiteResource,
 )
+from backend.resources.stories import StoryResource
 from backend.resources.users import UserResource
 from backend.resources.widgets import SiteWidgetResource, WidgetSettingsResource
 
@@ -116,6 +117,7 @@ def run_import():
             "character-dictionary-links",
             DictionaryEntryRelatedCharacterResource(),
         ),
+        ("stories", StoryResource()),
         ("site-widgets", SiteWidgetResource()),
         ("widget-settings", WidgetSettingsResource()),
         ("pages", SitePageResource()),

--- a/firstvoices/backend/resources/base.py
+++ b/firstvoices/backend/resources/base.py
@@ -1,7 +1,12 @@
 from import_export import fields, resources, widgets
 
+from backend.models.constants import Visibility
+from backend.models.media import Audio, Image, Video
 from backend.models.sites import Site
-from backend.resources.utils.import_export_widgets import UserForeignKeyWidget
+from backend.resources.utils.import_export_widgets import (
+    ChoicesWidget,
+    UserForeignKeyWidget,
+)
 
 
 class BaseResource(resources.ModelResource):
@@ -25,6 +30,41 @@ class SiteContentResource(BaseResource):
         column_name="site",
         attribute="site",
         widget=(widgets.ForeignKeyWidget(Site, "id")),
+    )
+
+    class Meta:
+        abstract = True
+
+
+class ControlledSiteContentResource(SiteContentResource):
+    visibility = fields.Field(
+        column_name="visibility",
+        widget=ChoicesWidget(Visibility.choices),
+        attribute="visibility",
+    )
+
+    class Meta:
+        abstract = True
+
+
+class RelatedMediaResourceMixin(resources.ModelResource):
+    related_audio = fields.Field(
+        column_name="related_audio",
+        attribute="related_audio",
+        m2m_add=True,
+        widget=widgets.ManyToManyWidget(Audio, field="id"),
+    )
+    related_images = fields.Field(
+        column_name="related_images",
+        attribute="related_images",
+        m2m_add=True,
+        widget=widgets.ManyToManyWidget(Image, "id"),
+    )
+    related_videos = fields.Field(
+        column_name="related_videos",
+        attribute="related_videos",
+        m2m_add=True,
+        widget=widgets.ManyToManyWidget(Video, "id"),
     )
 
     class Meta:

--- a/firstvoices/backend/resources/base.py
+++ b/firstvoices/backend/resources/base.py
@@ -52,19 +52,19 @@ class RelatedMediaResourceMixin(resources.ModelResource):
         column_name="related_audio",
         attribute="related_audio",
         m2m_add=True,
-        widget=widgets.ManyToManyWidget(Audio, field="id"),
+        widget=widgets.ManyToManyWidget(Audio, separator=",", field="id"),
     )
     related_images = fields.Field(
         column_name="related_images",
         attribute="related_images",
         m2m_add=True,
-        widget=widgets.ManyToManyWidget(Image, "id"),
+        widget=widgets.ManyToManyWidget(Image, separator=",", field="id"),
     )
     related_videos = fields.Field(
         column_name="related_videos",
         attribute="related_videos",
         m2m_add=True,
-        widget=widgets.ManyToManyWidget(Video, "id"),
+        widget=widgets.ManyToManyWidget(Video, separator=",", field="id"),
     )
 
     class Meta:

--- a/firstvoices/backend/resources/characters.py
+++ b/firstvoices/backend/resources/characters.py
@@ -1,5 +1,3 @@
-import logging
-
 from import_export import fields
 from import_export.widgets import ForeignKeyWidget, ManyToManyWidget
 
@@ -19,30 +17,11 @@ class CharacterResource(SiteContentResource):
         column_name="related_videos",
         attribute="related_videos",
         m2m_add=True,
-        widget=ManyToManyWidget(Video, "id"),
+        widget=ManyToManyWidget(Video, field="id"),
     )
 
     class Meta:
         model = Character
-
-    def before_import_row(self, row, row_number=None, **kwargs):
-        logger = logging.getLogger(__name__)
-
-        if row["related_audio"] != "":
-            audio_obj_ids = row["related_audio"].split(",")
-            for audio_id in audio_obj_ids:
-                if not Audio.objects.filter(id=audio_id).exists():
-                    # Audio obj not found
-                    logger.warning(f"Missing audio obj for character {row['id']}.")
-                    row["related_audio"] = ""
-
-        if row["related_videos"] != "":
-            video_obj_ids = row["related_videos"].split(",")
-            for video_id in video_obj_ids:
-                if not Video.objects.filter(id=video_id).exists():
-                    # Video obj not found
-                    logger.warning(f"Missing video obj for character {row['id']}.")
-                    row["related_videos"] = ""
 
 
 class CharacterVariantResource(SiteContentResource):

--- a/firstvoices/backend/resources/dictionary.py
+++ b/firstvoices/backend/resources/dictionary.py
@@ -1,6 +1,6 @@
 from import_export import fields
 from import_export.results import RowResult
-from import_export.widgets import ForeignKeyWidget, ManyToManyWidget
+from import_export.widgets import ForeignKeyWidget
 
 from backend.models import (
     Acknowledgement,
@@ -20,12 +20,15 @@ from backend.models.dictionary import (
     DictionaryEntryRelatedCharacter,
     TypeOfDictionaryEntry,
 )
-from backend.models.media import Audio, Image, Video
-from backend.resources.base import BaseResource, SiteContentResource
+from backend.resources.base import (
+    BaseResource,
+    RelatedMediaResourceMixin,
+    SiteContentResource,
+)
 from backend.resources.utils.import_export_widgets import ChoicesWidget
 
 
-class DictionaryEntryResource(SiteContentResource):
+class DictionaryEntryResource(SiteContentResource, RelatedMediaResourceMixin):
     visibility = fields.Field(
         column_name="visibility",
         widget=ChoicesWidget(Visibility.choices),
@@ -40,24 +43,6 @@ class DictionaryEntryResource(SiteContentResource):
         column_name="part_of_speech",
         attribute="part_of_speech",
         widget=ForeignKeyWidget(PartOfSpeech, "title"),
-    )
-    related_images = fields.Field(
-        column_name="related_images",
-        attribute="related_images",
-        m2m_add=True,
-        widget=ManyToManyWidget(Image, field="id"),
-    )
-    related_audio = fields.Field(
-        column_name="related_audio",
-        attribute="related_audio",
-        m2m_add=True,
-        widget=ManyToManyWidget(Audio, field="id"),
-    )
-    related_videos = fields.Field(
-        column_name="related_videos",
-        attribute="related_videos",
-        m2m_add=True,
-        widget=ManyToManyWidget(Video, field="id"),
     )
 
     class Meta:

--- a/firstvoices/backend/resources/stories.py
+++ b/firstvoices/backend/resources/stories.py
@@ -1,0 +1,24 @@
+from import_export.fields import Field
+
+from backend.models.story import Story
+from backend.resources.base import (
+    ControlledSiteContentResource,
+    RelatedMediaResourceMixin,
+)
+from backend.resources.utils.import_export_widgets import ArrayOfStringsWidget
+
+
+class StoryResource(ControlledSiteContentResource, RelatedMediaResourceMixin):
+    acknowledgements = Field(
+        column_name="acknowledgements",
+        attribute="acknowledgements",
+        widget=ArrayOfStringsWidget(sep="|||"),
+    )
+    notes = Field(
+        column_name="notes",
+        attribute="notes",
+        widget=ArrayOfStringsWidget(sep="|||"),
+    )
+
+    class Meta:
+        model = Story

--- a/firstvoices/backend/resources/utils/import_export_widgets.py
+++ b/firstvoices/backend/resources/utils/import_export_widgets.py
@@ -29,6 +29,26 @@ class ChoicesWidget(Widget):
         return self.choice_labels.get(value)
 
 
+class ArrayOfStringsWidget(Widget):
+    """Import/export widget to split strings on custom separator."""
+
+    def __init__(self, sep: str = ",", *args, **kwargs) -> None:
+        super().__init__()
+        self.sep = sep
+
+    def clean(self, value: str, row=None, *args, **kwargs) -> list:
+        """Converts the display value (string with separator) into array on sep"""
+        if value:
+            return [string.strip() for string in value.split(sep=self.sep)]
+        return []
+
+    def render(self, value: list, obj=None) -> str:
+        """Converts the db value (array) into a single string for display, using separator"""
+        if value:
+            return self.sep.join(value)
+        return ""
+
+
 class UserForeignKeyWidget(ForeignKeyWidget):
     """Import/export widget to find/create users from their email.
 

--- a/firstvoices/backend/tests/test_resources/test_character_resource.py
+++ b/firstvoices/backend/tests/test_resources/test_character_resource.py
@@ -83,8 +83,9 @@ class TestCharacterImport:
     @pytest.mark.django_db
     def test_missing_related_media(self):
         site = SiteFactory.create()
+        audio = AudioFactory.create(site=site)
         data = [
-            f"{uuid.uuid4()},2023-02-02 21:21:10.713,user_one@test.com,2023-02-21 10:20:15.754,user_two@test.com,{site.id},ᐃ,2,,{uuid.uuid4()},{uuid.uuid4()}",  # noqa E501
+            f'{uuid.uuid4()},2023-02-02 21:21:10.713,user_one@test.com,2023-02-21 10:20:15.754,user_two@test.com,{site.id},ᐃ,2,,"{audio.id},{uuid.uuid4()}",{uuid.uuid4()}',  # noqa E501
         ]
         table = self.build_table(data)
 
@@ -94,7 +95,8 @@ class TestCharacterImport:
 
         new_char = Character.objects.get(id=table["id"][0])
         # Verifying missing audio and video are not present
-        assert new_char.related_audio.all().count() == 0
+        assert new_char.related_audio.all().count() == 1
+        assert audio in new_char.related_audio.all()
         assert new_char.related_videos.all().count() == 0
 
     @pytest.mark.django_db

--- a/firstvoices/backend/tests/test_resources/test_stories_resource.py
+++ b/firstvoices/backend/tests/test_resources/test_stories_resource.py
@@ -1,0 +1,101 @@
+import uuid
+
+import pytest
+import tablib
+
+from backend.models.constants import Visibility
+from backend.models.story import Story
+from backend.resources.stories import StoryResource
+from backend.tests.factories import SiteFactory
+
+sample_draftjs_text = "\"{'entityMap': {}, 'blocks': [{'key': '', 'text': 'Historia de los Tres Osos', 'type': 'unstyled', 'depth': 0, 'inlineStyleRanges': [], 'entityRanges': [], 'data': {}}]}\""  # noqa E501
+sample_draftjs_transl = "\"{'entityMap': {}, 'blocks': [{'key': '', 'text': 'History of the Three Bears', 'type': 'unstyled', 'depth': 0, 'inlineStyleRanges': [], 'entityRanges': [], 'data': {}}]}\""  # noqa E501
+
+
+class TestStoryImport:
+    @staticmethod
+    def build_table(data: list[str]):
+        headers = [
+            # these headers should match what is produced by fv-nuxeo-export tool
+            "id,created,created_by,last_modified,last_modified_by,visibility"
+            ",title,title_translation,introduction,introduction_translation"
+            ",for_games,for_kids_1,for_kids_2,hide_overlay,site,exclude_from_kids,exclude_from_games"
+            ",author,notes,acknowledgements,related_audio,related_images,related_videos"
+        ]
+        table = tablib.import_set("\n".join(headers + data), format="csv")
+        return table
+
+    @pytest.mark.django_db
+    def test_import_base_data(self):
+        """Import Story object with basic fields"""
+        site = SiteFactory.create()
+        data = [
+            f"{uuid.uuid4()},2022-04-06 14:08:27.693,one@test.com,2022-04-06 14:45:52.750,one@test.com,Members"
+            f",Testytest,Test story,{sample_draftjs_text},{sample_draftjs_transl}"
+            f",,,True,,{site.id},False,False"
+            ",By: The Author,,,,,",
+            f"{uuid.uuid4()},2022-04-06 14:08:27.693,one@test.com,2022-04-06 14:45:52.750,one@test.com,Members"
+            f",Testytest2,Test story two,{sample_draftjs_text},{sample_draftjs_transl}"
+            f",,,True,true,{site.id},False,False"
+            ",,,,,,",
+        ]
+        table = self.build_table(data)
+
+        result = StoryResource().import_data(dataset=table)
+
+        assert not result.has_errors()
+        assert not result.has_validation_errors()
+        assert result.totals["new"] == len(data)
+        assert Story.objects.filter(site=site.id).count() == len(data)
+
+        new_story = Story.objects.get(id=table["id"][0])
+        assert new_story.title == table["title"][0]
+        assert new_story.visibility == Visibility.MEMBERS
+        assert str(new_story.site.id) == table["site"][0]
+        assert new_story.title_translation == table["title_translation"][0]
+        assert new_story.introduction == table["introduction"][0]
+        assert (
+            new_story.introduction_translation == table["introduction_translation"][0]
+        )
+        assert new_story.hide_overlay is False  # csv is null
+        assert str(new_story.exclude_from_kids) == table["exclude_from_kids"][0]
+        assert str(new_story.exclude_from_games) == table["exclude_from_games"][0]
+        assert new_story.author == table["author"][0]
+
+        # other possible hide-overlay value
+        new_story = Story.objects.get(id=table["id"][1])
+        assert new_story.hide_overlay is True  # csv is "true"
+
+    @pytest.mark.parametrize(
+        "note_string,ack_string,expected_len",
+        [
+            ("Note about stuff", "Thanks Everyone", 1),
+            ("Note1|||Note2|||Note3", "Thanks Me|||Thanks You|||Thanks All", 3),
+            ('"Note, Comma|||  Note2"', '"Thanks, Comma|||Thanks2"', 2),
+        ],
+    )
+    @pytest.mark.django_db
+    def test_import_array_fields(self, note_string, ack_string, expected_len):
+        """Import Story object with array fields for notes, acks"""
+        site = SiteFactory.create()
+        data = [
+            f"{uuid.uuid4()},2022-04-06 14:08:27.693,one@test.com,2022-04-06 14:45:52.750,one@test.com,Members"
+            f",Testytest,Test story,,"
+            f",,,True,,{site.id},False,False"
+            f",Authorname,{note_string},{ack_string},,,"
+        ]
+        table = self.build_table(data)
+
+        result = StoryResource().import_data(dataset=table)
+
+        assert not result.has_errors()
+        assert not result.has_validation_errors()
+        assert result.totals["new"] == len(data)
+        assert Story.objects.filter(site=site.id).count() == len(data)
+
+        new_story = Story.objects.get(id=table["id"][0])
+        assert len(new_story.notes) == expected_len
+        assert len(new_story.acknowledgements) == expected_len
+
+        assert all(note.startswith("Note") for note in new_story.notes)
+        assert all(ack.startswith("Thanks") for ack in new_story.acknowledgements)


### PR DESCRIPTION
### Description of Changes
Adds an import for Story model. Adds reusable components for easily importing ArrayOfStrings and related media. I also figured out the issue with the M2M widget (it was an argument problem), fixed it and updated characters/dictionary.

Potential issues that I will get to later:
- add import for story pages
- fix length of text fields for songs/stories
- have to check if story/songs are limited to 1 cover image

### Checklist
- README / documentation has been updated if needed
- [X] PR title / commit messages contain Jira ticket number if applicable
- [X] Tests have been updated / created if applicable
- Admin Panel has been updated if models have been added or modified
- Migrations have been updated and committed if applicable
- Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
The M2M widget out of the box will silently skip invalid UIDs. If we want it to visibly log an issue with these rows, I can add it, but I don't think it is necessary in our case since it indicates data that was invalid anyway.