### PR TITLE
fw-4781, adjust site permissions

### DIFF
--- a/firstvoices/backend/models/sites.py
+++ b/firstvoices/backend/models/sites.py
@@ -95,7 +95,7 @@ class Site(BaseModel):
         verbose_name = _("site")
         verbose_name_plural = _("sites")
         rules_permissions = {
-            "view": predicates.can_view_site_model,
+            "view": predicates.can_view_site,
             "add": predicates.is_superadmin,
             "change": predicates.is_language_admin_or_super,
             "delete": predicates.is_superadmin,

--- a/firstvoices/backend/permissions/filters/base.py
+++ b/firstvoices/backend/permissions/filters/base.py
@@ -149,6 +149,14 @@ def has_team_access_to_site(user):
     return has_at_least_assistant_membership(user)
 
 
+def has_member_access_to_site_obj(user):
+    """Special case for getting the membership directly from a site model object"""
+    if user.is_anonymous:
+        return always_false(user)
+
+    return Q(membership_set__user=user) & Q(membership_set__role__gte=Role.MEMBER)
+
+
 def has_team_access_to_site_obj(user):
     """Special case for getting the membership directly from a site model object"""
     if user.is_anonymous:

--- a/firstvoices/backend/permissions/filters/view_models.py
+++ b/firstvoices/backend/permissions/filters/view_models.py
@@ -5,12 +5,12 @@ from . import base, view
 #
 
 
-# Site model is visible to all unless it has Team-only visibility
-def can_view_site_model(user):
+# Rule for who can see detailed site info including homepage, content APIs, etc
+def can_view_site(user):
     return (
         base.is_public_obj()
-        | base.is_members_obj()
         | base.is_at_least_staff_admin(user)
+        | base.has_member_access_to_site_obj(user)
         | base.has_team_access_to_site_obj(user)
     )
 

--- a/firstvoices/backend/permissions/predicates/view.py
+++ b/firstvoices/backend/permissions/predicates/view.py
@@ -25,13 +25,3 @@ has_visible_site = Predicate(
     ),
     name="has_visible_site",
 )
-
-is_visible_site_object = Predicate(
-    (
-        base.has_public_access_to_site_obj
-        | base.is_at_least_staff_admin
-        | base.has_member_access_to_site_obj
-        | base.has_team_access
-    ),
-    name="is_visible_site_object",
-)

--- a/firstvoices/backend/permissions/predicates/view_models.py
+++ b/firstvoices/backend/permissions/predicates/view_models.py
@@ -6,15 +6,15 @@ from . import base, view
 # model-specific view permission predicates
 #
 
-# Site model is visible to all unless it has Team-only visibility
-can_view_site_model = Predicate(
+# Rule for who can see detailed site info including homepage, content APIs, etc
+can_view_site = Predicate(
     (
         base.is_public_obj
-        | base.is_members_obj
         | base.is_at_least_staff_admin
+        | base.has_member_access_to_site_obj
         | base.has_team_access
     ),
-    name="can_view_site_model",
+    name="can_view_site",
 )
 
 # Membership model is visible to admins, and relevant user

--- a/firstvoices/backend/views/base_views.py
+++ b/firstvoices/backend/views/base_views.py
@@ -4,7 +4,6 @@ from rest_framework import mixins
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
-from backend import permissions
 from backend.models import Alphabet, Character, CharacterVariant, IgnoredCharacter, Site
 from backend.permissions import utils
 
@@ -148,10 +147,9 @@ class SiteContentViewSetMixin:
         if len(site) == 0:
             raise Http404
 
-        # Check if site content is visible. This uses a different permission rule than for viewing the fields on the
-        # Site model itself, which are mainly used in site listings. That's why we're checking is_visible_object
-        # rather than the model's view permission.
-        if permissions.predicates.is_visible_site_object(self.request.user, site[0]):
+        # Check permissions on the site first
+        perm = Site.get_perm("view")
+        if self.request.user.has_perm(perm, site[0]):
             return site
         else:
             raise PermissionDenied


### PR DESCRIPTION
### Description of Changes
- changed model permissions to match ability to access site details (e.g., members can see member site, team members can see team site)
- site list api has custom handling to show summary info for member + public sites

### Checklist
- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
