### PR TITLE
fw-4803, add arbitrary uid for notes in story + story page APIs

### DIFF
--- a/firstvoices/backend/serializers/story_serializers.py
+++ b/firstvoices/backend/serializers/story_serializers.py
@@ -1,3 +1,5 @@
+import uuid
+
 from rest_framework import serializers
 from rest_framework_nested.relations import NestedHyperlinkedIdentityField
 from rest_framework_nested.serializers import NestedHyperlinkedModelSerializer
@@ -19,6 +21,14 @@ from backend.serializers.site_serializers import LinkedSiteSerializer
 from backend.serializers.utils import get_story_from_context
 
 
+class ArbitraryIdSerializer(serializers.CharField):
+    def to_representation(self, value):
+        return {
+            "id": str(uuid.uuid4()),  # better for frontend
+            "text": str(value),
+        }
+
+
 class LinkedStorySerializer(SiteContentLinkedTitleSerializer):
     class Meta(SiteContentLinkedTitleSerializer.Meta):
         model = Story
@@ -35,6 +45,7 @@ class StoryPageSummarySerializer(
     }
 
     id = serializers.UUIDField(read_only=True)
+    notes = serializers.ListField(child=ArbitraryIdSerializer(), required=False)
 
     class Meta:
         model = StoryPage
@@ -92,6 +103,10 @@ class StorySerializer(
     site = LinkedSiteSerializer(required=False, read_only=True)
     pages = StoryPageSummarySerializer(many=True, read_only=True)
     visibility = WritableVisibilityField(required=True)
+    notes = serializers.ListField(child=ArbitraryIdSerializer(), required=False)
+    acknowledgements = serializers.ListField(
+        child=ArbitraryIdSerializer(), required=False
+    )
 
     class Meta(SiteContentLinkedTitleSerializer.Meta):
         model = Story

--- a/firstvoices/backend/tests/test_apis/test_story_api.py
+++ b/firstvoices/backend/tests/test_apis/test_story_api.py
@@ -219,12 +219,12 @@ class TestStoryEndpoint(
             actual_response["introductionTranslation"]
             == original_instance.introduction_translation
         )
-        assert actual_response["notes"][0] == original_instance.notes[0]
+        assert actual_response["notes"][0]["text"] == original_instance.notes[0]
         assert (
             actual_response["pages"][0]["text"] == original_instance.pages.first().text
         )
         assert (
-            actual_response["acknowledgements"][0]
+            actual_response["acknowledgements"][0]["text"]
             == original_instance.acknowledgements[0]
         )
         assert (

--- a/firstvoices/backend/tests/test_apis/test_storypage_api.py
+++ b/firstvoices/backend/tests/test_apis/test_storypage_api.py
@@ -118,7 +118,7 @@ class TestStoryPageEndpoint(RelatedMediaTestMixin, BaseControlledSiteContentApiT
         )
         assert actual_response["text"] == data["text"]
         assert actual_response["translation"] == original_instance.translation
-        assert actual_response["notes"][0] == original_instance.notes[0]
+        assert actual_response["notes"][0]["text"] == original_instance.notes[0]
         assert actual_response["ordering"] == original_instance.ordering
         assert actual_response["story"]["id"] == str(original_instance.story.id)
 
@@ -351,7 +351,10 @@ class TestStoryPageEndpoint(RelatedMediaTestMixin, BaseControlledSiteContentApiT
     def assert_update_response(self, expected_data, actual_response):
         assert actual_response["text"] == expected_data["text"]
         assert actual_response["translation"] == expected_data["translation"]
-        assert actual_response["notes"] == expected_data["notes"]
+
+        for i, note in enumerate(expected_data["notes"]):
+            assert actual_response["notes"][i]["text"] == note
+
         assert (
             actual_response["relatedAudio"][0]["id"] == expected_data["relatedAudio"][0]
         )


### PR DESCRIPTION
### Description of Changes
- it helps the frontend to have consistent formats for notes and acknowledgements, and for their purposes it is better to have an id for each item in the list rather than just strings
- rather than change the models at this moment (would impact the data migration), i added arbitrary uids in the serializer
- this means we can change the data models later on without impacting the frontend

### Checklist
- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
