### PR TITLE
FW-4775 Add site homepage widget data migration

### DIFF
--- a/firstvoices/backend/management/commands/import_csv_data.py
+++ b/firstvoices/backend/management/commands/import_csv_data.py
@@ -133,14 +133,8 @@ def run_import():
 
     for key, resource in import_resources:
         # Parse files to import with this resource
-        if resource.__class__ == SiteHomepageWidgetsResource:
-            logger.info("Importing Site homepage widget lists...")
-            matched_files = [
-                f for f in os.listdir(current_export_dir) if f.startswith(key)
-            ]
-        else:
-            logger.info(f"Importing {key} models...")
-            matched_files = [f for f in unmatched_files if f.startswith(key)]
+        logger.info(f"Importing from [{key}] CSV with {type(resource).__name__}...")
+        matched_files = [f for f in unmatched_files if f.startswith(key)]
         unmatched_files = [f for f in unmatched_files if f not in matched_files]
 
         if not matched_files:

--- a/firstvoices/backend/management/commands/import_csv_data.py
+++ b/firstvoices/backend/management/commands/import_csv_data.py
@@ -35,6 +35,7 @@ from backend.resources.media import (
     VideoResource,
 )
 from backend.resources.pages import SitePageResource
+from backend.resources.site_homepage_widgets import SiteHomepageWidgetsResource
 from backend.resources.sites import (
     MembershipResource,
     SiteMigrationResource,
@@ -121,6 +122,7 @@ def run_import():
         ("dict-entrylinks", DictionaryEntryLinkResource()),
         ("site-widgets", SiteWidgetResource()),
         ("widget-settings", WidgetSettingsResource()),
+        ("sites", SiteHomepageWidgetsResource()),
         ("pages", SitePageResource()),
         ("stories", StoryResource()),
         # more to be added
@@ -133,7 +135,12 @@ def run_import():
         logger.info(f"Importing {key} models...")
 
         # Parse files to import with this resource
-        matched_files = [f for f in unmatched_files if f.startswith(key)]
+        if resource.__class__ == SiteHomepageWidgetsResource:
+            matched_files = [
+                f for f in os.listdir(current_export_dir) if f.startswith(key)
+            ]
+        else:
+            matched_files = [f for f in unmatched_files if f.startswith(key)]
         unmatched_files = [f for f in unmatched_files if f not in matched_files]
 
         if not matched_files:

--- a/firstvoices/backend/management/commands/import_csv_data.py
+++ b/firstvoices/backend/management/commands/import_csv_data.py
@@ -132,14 +132,14 @@ def run_import():
     unmatched_files = os.listdir(current_export_dir)
 
     for key, resource in import_resources:
-        logger.info(f"Importing {key} models...")
-
         # Parse files to import with this resource
         if resource.__class__ == SiteHomepageWidgetsResource:
+            logger.info("Importing Site homepage widget lists...")
             matched_files = [
                 f for f in os.listdir(current_export_dir) if f.startswith(key)
             ]
         else:
+            logger.info(f"Importing {key} models...")
             matched_files = [f for f in unmatched_files if f.startswith(key)]
         unmatched_files = [f for f in unmatched_files if f not in matched_files]
 

--- a/firstvoices/backend/resources/pages.py
+++ b/firstvoices/backend/resources/pages.py
@@ -40,7 +40,13 @@ class SitePageResource(SiteContentResource):
             created_by_user = self.get_user_or_none(row["created_by"])
             site = Site.objects.get(id=row["site"])
             widgets_list = row["widgets"].split(",")
-            site_widget_list = SiteWidgetList.objects.create(site=site)
+            site_widget_list = SiteWidgetList.objects.create(
+                site=site,
+                last_modified_by=last_modified_by_user,
+                last_modified=row["last_modified"],
+                created_by=created_by_user,
+                created=row["created"],
+            )
             for index, widget_id in enumerate(widgets_list):
                 widget = SiteWidget.objects.get(id=widget_id)
                 SiteWidgetListOrder.objects.create(
@@ -48,7 +54,9 @@ class SitePageResource(SiteContentResource):
                     site_widget_list=site_widget_list,
                     order=index,
                     last_modified_by=last_modified_by_user,
+                    last_modified=row["last_modified"],
                     created_by=created_by_user,
+                    created=row["created"],
                 )
             row["widgets"] = site_widget_list.id
 

--- a/firstvoices/backend/resources/pages.py
+++ b/firstvoices/backend/resources/pages.py
@@ -1,14 +1,16 @@
 import logging
 
 from import_export import fields
-from jwt_auth.models import User
 
 from backend.models import Image, Site, SitePage
 from backend.models.constants import Visibility
 from backend.models.media import Video
 from backend.models.widget import SiteWidget, SiteWidgetList, SiteWidgetListOrder
 from backend.resources.base import SiteContentResource
-from backend.resources.utils.import_export_widgets import ChoicesWidget
+from backend.resources.utils.import_export_widgets import (
+    ChoicesWidget,
+    UserForeignKeyWidget,
+)
 
 
 class SitePageResource(SiteContentResource):
@@ -21,13 +23,6 @@ class SitePageResource(SiteContentResource):
     class Meta:
         model = SitePage
 
-    @staticmethod
-    def get_user_or_none(email):
-        try:
-            return User.objects.get(email=email)
-        except User.DoesNotExist:
-            return None
-
     def before_import_row(self, row, **kwargs):
         logger = logging.getLogger(__name__)
 
@@ -36,16 +31,16 @@ class SitePageResource(SiteContentResource):
         if row["widgets"] == "":
             row["widgets"] = None
         else:
-            last_modified_by_user = self.get_user_or_none(row["last_modified_by"])
-            created_by_user = self.get_user_or_none(row["created_by"])
+            user_widget = UserForeignKeyWidget()
+            last_modified_by_user = user_widget.clean(value=row["last_modified_by"])
+            created_by_user = user_widget.clean(value=row["created_by"])
+
             site = Site.objects.get(id=row["site"])
             widgets_list = row["widgets"].split(",")
             site_widget_list = SiteWidgetList.objects.create(
                 site=site,
                 last_modified_by=last_modified_by_user,
-                last_modified=row["last_modified"],
                 created_by=created_by_user,
-                created=row["created"],
             )
             for index, widget_id in enumerate(widgets_list):
                 widget = SiteWidget.objects.get(id=widget_id)
@@ -54,9 +49,7 @@ class SitePageResource(SiteContentResource):
                     site_widget_list=site_widget_list,
                     order=index,
                     last_modified_by=last_modified_by_user,
-                    last_modified=row["last_modified"],
                     created_by=created_by_user,
-                    created=row["created"],
                 )
             row["widgets"] = site_widget_list.id
 

--- a/firstvoices/backend/resources/site_homepage_widgets.py
+++ b/firstvoices/backend/resources/site_homepage_widgets.py
@@ -1,8 +1,8 @@
 from import_export import resources
-from jwt_auth.models import User
 
 from backend.models import Site
 from backend.models.widget import SiteWidget, SiteWidgetList, SiteWidgetListOrder
+from backend.resources.utils.import_export_widgets import UserForeignKeyWidget
 
 
 class SiteHomepageWidgetsResource(resources.ModelResource):
@@ -10,25 +10,18 @@ class SiteHomepageWidgetsResource(resources.ModelResource):
         model = Site
         fields = ("id",)
 
-    @staticmethod
-    def get_user_or_none(email):
-        try:
-            return User.objects.get(email=email)
-        except User.DoesNotExist:
-            return None
-
     def before_import_row(self, row, row_number=None, **kwargs):
         if row["homepage_widgets"] != "":
-            last_modified_by_user = self.get_user_or_none(row["last_modified_by"])
-            created_by_user = self.get_user_or_none(row["created_by"])
+            user_widget = UserForeignKeyWidget()
+            last_modified_by_user = user_widget.clean(value=row["last_modified_by"])
+            created_by_user = user_widget.clean(value=row["created_by"])
+
             site = Site.objects.get(id=row["id"])
             widgets_list = row["homepage_widgets"].split(",")
             site_widget_list = SiteWidgetList.objects.create(
                 site=site,
                 last_modified_by=last_modified_by_user,
-                last_modified=row["last_modified"],
                 created_by=created_by_user,
-                created=row["created"],
             )
             site.homepage = site_widget_list
             site.save()
@@ -39,7 +32,5 @@ class SiteHomepageWidgetsResource(resources.ModelResource):
                     site_widget_list=site_widget_list,
                     order=index,
                     last_modified_by=last_modified_by_user,
-                    last_modified=row["last_modified"],
                     created_by=created_by_user,
-                    created=row["created"],
                 )

--- a/firstvoices/backend/resources/site_homepage_widgets.py
+++ b/firstvoices/backend/resources/site_homepage_widgets.py
@@ -1,0 +1,45 @@
+from import_export import resources
+from jwt_auth.models import User
+
+from backend.models import Site
+from backend.models.widget import SiteWidget, SiteWidgetList, SiteWidgetListOrder
+
+
+class SiteHomepageWidgetsResource(resources.ModelResource):
+    class Meta:
+        model = Site
+        fields = ("id",)
+
+    @staticmethod
+    def get_user_or_none(email):
+        try:
+            return User.objects.get(email=email)
+        except User.DoesNotExist:
+            return None
+
+    def before_import_row(self, row, row_number=None, **kwargs):
+        if row["homepage_widgets"] != "":
+            last_modified_by_user = self.get_user_or_none(row["last_modified_by"])
+            created_by_user = self.get_user_or_none(row["created_by"])
+            site = Site.objects.get(id=row["id"])
+            widgets_list = row["homepage_widgets"].split(",")
+            site_widget_list = SiteWidgetList.objects.create(
+                site=site,
+                last_modified_by=last_modified_by_user,
+                last_modified=row["last_modified"],
+                created_by=created_by_user,
+                created=row["created"],
+            )
+            site.homepage = site_widget_list
+            site.save()
+            for index, widget_id in enumerate(widgets_list):
+                widget = SiteWidget.objects.get(id=widget_id)
+                SiteWidgetListOrder.objects.create(
+                    site_widget=widget,
+                    site_widget_list=site_widget_list,
+                    order=index,
+                    last_modified_by=last_modified_by_user,
+                    last_modified=row["last_modified"],
+                    created_by=created_by_user,
+                    created=row["created"],
+                )

--- a/firstvoices/backend/resources/utils/import_export_widgets.py
+++ b/firstvoices/backend/resources/utils/import_export_widgets.py
@@ -64,7 +64,7 @@ class UserForeignKeyWidget(ForeignKeyWidget):
             # leave field empty if no email provided
             return None
 
-        user_exists = self.model.objects.filter(email=value).count() == 1
+        user_exists = self.model.objects.filter(email=value).exists()
         if user_exists:
             return super().clean(value, row, **kwargs)
         else:

--- a/firstvoices/backend/tests/test_resources/test_site_homepage_widgets.py
+++ b/firstvoices/backend/tests/test_resources/test_site_homepage_widgets.py
@@ -1,0 +1,63 @@
+import pytest
+import tablib
+
+from backend.models import Site
+from backend.models.widget import SiteWidget, SiteWidgetList, SiteWidgetListOrder
+from backend.resources.site_homepage_widgets import SiteHomepageWidgetsResource
+from backend.tests import factories
+
+
+class TestSiteHomepageWidgetsImport:
+    @staticmethod
+    def build_table(data: list[str]):
+        headers = [
+            "id,created,created_by,last_modified,last_modified_by,title,slug,visibility,language,contact_email,"
+            "homepage_widgets",
+        ]
+        table = tablib.import_set("\n".join(headers + data), format="csv")
+        return table
+
+    @pytest.mark.django_db
+    def test_import_base_data(self):
+        site = factories.SiteFactory.create()
+        user1 = factories.UserFactory.create()
+        user2 = factories.UserFactory.create()
+        widget1 = factories.SiteWidgetFactory.create(site=site)
+        widget2 = factories.SiteWidgetFactory.create(site=site)
+
+        data = [
+            f"{str(site.id)},2023-02-02 21:21:10.713,{user1.email},2023-02-02 21:21:39.864,{user2.email},Sample site "
+            f'title,sample-site-slug,Public,,test@email.com,"{str(widget1.id)},{str(widget2.id)}"',
+        ]
+        table = self.build_table(data)
+
+        assert site.homepage is None
+        assert len(SiteWidget.objects.all()) == 2
+        assert len(SiteWidgetList.objects.all()) == 0
+        assert len(SiteWidgetListOrder.objects.all()) == 0
+
+        result = SiteHomepageWidgetsResource().import_data(dataset=table)
+
+        assert not result.has_errors()
+        assert not result.has_validation_errors()
+        assert result.totals["update"] == len(data)
+        site = Site.objects.get(id=table["id"][0])
+        assert site.homepage is not None
+
+        assert (
+            SiteWidgetListOrder.objects.get(
+                site_widget_list=site.homepage, order=0
+            ).site_widget
+            == widget1
+        )
+        assert (
+            SiteWidgetListOrder.objects.get(
+                site_widget_list=site.homepage, order=1
+            ).site_widget
+            == widget2
+        )
+
+        assert site.homepage.widgets.count() == 2
+        assert len(SiteWidget.objects.all()) == 2
+        assert len(SiteWidgetList.objects.all()) == 1
+        assert len(SiteWidgetListOrder.objects.all()) == 2


### PR DESCRIPTION
### Description of Changes
This PR adds site homepage widget data migrations. This is done in a separate resource from the original site import while still using the same site CSV. This is because the sites must be imported, followed by the widgets, followed by the site homepage field.

Additionally, the created/modified fields have been added to the SitePage data migration.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [x] Pull the branch and test locally

### Additional Notes
N/A
