### PR TITLE
FW-4403 Add environment banner

### DIFF
--- a/firstvoices/firstvoices/settings.py
+++ b/firstvoices/firstvoices/settings.py
@@ -41,6 +41,7 @@ ALLOWED_HOSTS = [
 
 INSTALLED_APPS = [
     "corsheaders",
+    "django_admin_env_notice",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -149,6 +150,7 @@ TEMPLATES = [
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
+                "django_admin_env_notice.context_processors.from_settings",
                 "django.template.context_processors.debug",
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
@@ -286,3 +288,7 @@ EMBED_VIDEO_BACKENDS = (
     "embed_video.backends.YoutubeBackend",
     "embed_video.backends.VimeoBackend",
 )
+
+# Variables for the environment banners in the admin site
+ENVIRONMENT_NAME = os.getenv("ENVIRONMENT_NAME", "Local")
+ENVIRONMENT_COLOR = os.getenv("ENVIRONMENT_COLOR", "#9c9897")

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ coloredlogs==14.0
 cron-descriptor==1.4.0
 cryptography==41.0.3
 Django==4.2.4
+django-admin-env-notice==1.0
 django-celery-beat==2.5.0
 django-cors-headers==4.2.0
 django-debug-toolbar==4.2.0


### PR DESCRIPTION
### Description of Changes
This PR adds the django-admin-env-notice package with appropriate variables.

**To set up in dev/prod:**
- Set the ENVIRONMENT_NAME env variable to the appropriate name (Dev Server, Prod Server)
- Set the ENVIRONMENT_COLOR to the appropriate colour (any hex code)

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
For the dev server I would recommend #1dc022 (Green meaning it's okay to make changes)
For the prod server I would recommend #FF0000 (big red banner to let you know it's prod) 
