### PR TITLE
fw-4854, remove mobile apps from default menu

### DIFF
--- a/firstvoices/backend/fixtures/appjson-defaults.json
+++ b/firstvoices/backend/fixtures/appjson-defaults.json
@@ -47,10 +47,6 @@
 				"title": "Resources",
 				"transKey": "general.resources",
 				"itemsData": [{
-					"href": "/apps",
-					"title": "Mobile App",
-					"transKey": "general.apps"
-				}, {
 					"href": "/keyboards",
 					"title": "Keyboards",
 					"transKey": "general.keyboards"


### PR DESCRIPTION
### Description of Changes
* Removed the mobile apps menu item from our default data fixture. 
* This only affects new installations-- existing ones need to be edited. (Already made the switch on beta and dev.)

### Checklist
- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
