### PR TITLE
FW-4888 Categories search index fixes

### DIFF
--- a/firstvoices/backend/management/commands/_helper.py
+++ b/firstvoices/backend/management/commands/_helper.py
@@ -22,6 +22,7 @@ from backend.search.indices.dictionary_entry_document import (
     delete_from_index,
     update_acknowledgement,
     update_categories,
+    update_categories_m2m,
     update_dictionary_entry_index,
     update_notes,
     update_translation,
@@ -233,6 +234,9 @@ def disconnect_signals():
     signals.post_delete.disconnect(update_acknowledgement, sender=Acknowledgement)
     signals.post_save.disconnect(update_categories, sender=DictionaryEntryCategory)
     signals.post_delete.disconnect(update_categories, sender=DictionaryEntryCategory)
+    signals.m2m_changed.disconnect(
+        update_categories_m2m, sender=DictionaryEntryCategory
+    )
 
     # backend.search.indices.song_document
     signals.post_save.disconnect(update_song_index, sender=Song)
@@ -267,6 +271,7 @@ def reconnect_signals():
     signals.post_delete.connect(update_acknowledgement, sender=Acknowledgement)
     signals.post_save.connect(update_categories, sender=DictionaryEntryCategory)
     signals.post_delete.connect(update_categories, sender=DictionaryEntryCategory)
+    signals.m2m_changed.connect(update_categories_m2m, sender=DictionaryEntryCategory)
 
     # backend.search.indices.song_document
     signals.post_save.connect(update_song_index, sender=Song)

--- a/firstvoices/backend/search/indices/dictionary_entry_document.py
+++ b/firstvoices/backend/search/indices/dictionary_entry_document.py
@@ -2,9 +2,8 @@ import logging
 
 from django.db.models.signals import m2m_changed, post_delete, post_save
 from django.dispatch import receiver
-from django_elasticsearch_dsl import Index
 from elasticsearch.exceptions import ConnectionError, NotFoundError
-from elasticsearch_dsl import Keyword, Text
+from elasticsearch_dsl import Index, Keyword, Text
 
 from backend.models.dictionary import (
     Acknowledgement,
@@ -286,8 +285,9 @@ def update_categories(sender, instance, **kwargs):
 # Category update when called through the APIs
 @receiver(m2m_changed, sender=DictionaryEntryCategory)
 def update_categories_m2m(sender, instance, **kwargs):
-    dictionary_entry = instance
-    update_dictionary_entry_index_categories(dictionary_entry, instance)
+    if instance.__class__ == DictionaryEntry:
+        dictionary_entry = instance
+        update_dictionary_entry_index_categories(dictionary_entry, instance)
 
 
 def update_dictionary_entry_index_categories(dictionary_entry, instance):

--- a/firstvoices/backend/search/indices/song_document.py
+++ b/firstvoices/backend/search/indices/song_document.py
@@ -2,9 +2,8 @@ import logging
 
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
-from django_elasticsearch_dsl import Index
 from elasticsearch.exceptions import ConnectionError, NotFoundError
-from elasticsearch_dsl import Keyword, Text
+from elasticsearch_dsl import Index, Keyword, Text
 
 from backend.models import Lyric, Song
 from backend.search.indices.base_document import BaseDocument

--- a/firstvoices/backend/search/indices/song_document.py
+++ b/firstvoices/backend/search/indices/song_document.py
@@ -2,6 +2,7 @@ import logging
 
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
+from django_elasticsearch_dsl import Index
 from elasticsearch.exceptions import ConnectionError, NotFoundError
 from elasticsearch_dsl import Keyword, Text
 
@@ -77,6 +78,9 @@ def update_song_index(sender, instance, **kwargs):
                 lyrics_translation=lyrics_translation_text,
             )
             index_entry.save()
+        # Refresh the index to ensure the index is up-to-date for related field signals
+        song_index = Index(ELASTICSEARCH_SONG_INDEX)
+        song_index.refresh()
     except ConnectionError as e:
         logger = logging.getLogger(ELASTICSEARCH_LOGGER)
         logger.error(

--- a/firstvoices/backend/search/indices/story_document.py
+++ b/firstvoices/backend/search/indices/story_document.py
@@ -2,6 +2,7 @@ import logging
 
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
+from django_elasticsearch_dsl import Index
 from elasticsearch.exceptions import ConnectionError, NotFoundError
 from elasticsearch_dsl import Keyword, Text
 
@@ -81,6 +82,9 @@ def update_story_index(sender, instance, **kwargs):
                 page_translation=page_translation,
             )
             index_entry.save()
+        # Refresh the index to ensure the index is up-to-date for related field signals
+        story_index = Index(ELASTICSEARCH_STORY_INDEX)
+        story_index.refresh()
     except ConnectionError as e:
         logger = logging.getLogger(ELASTICSEARCH_LOGGER)
         logger.error(

--- a/firstvoices/backend/search/indices/story_document.py
+++ b/firstvoices/backend/search/indices/story_document.py
@@ -2,9 +2,8 @@ import logging
 
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
-from django_elasticsearch_dsl import Index
 from elasticsearch.exceptions import ConnectionError, NotFoundError
-from elasticsearch_dsl import Keyword, Text
+from elasticsearch_dsl import Index, Keyword, Text
 
 from backend.models.story import Story, StoryPage
 from backend.search.indices.base_document import BaseDocument

--- a/firstvoices/backend/search/utils/object_utils.py
+++ b/firstvoices/backend/search/utils/object_utils.py
@@ -1,5 +1,4 @@
 import logging
-from itertools import chain
 
 from elasticsearch.exceptions import ConnectionError, NotFoundError
 from elasticsearch_dsl import Search
@@ -173,13 +172,8 @@ def get_notes_text(dictionary_entry_instance):
 def get_categories_ids(dictionary_entry_instance):
     return [
         str(category_id)
-        for category_id in list(
-            chain(
-                dictionary_entry_instance.categories.values_list("id", flat=True),
-                dictionary_entry_instance.categories.values_list(
-                    "parent_id", flat=True
-                ),
-            )
+        for category_id in dictionary_entry_instance.categories.values_list(
+            "id", flat=True
         )
     ]
 

--- a/firstvoices/backend/search/utils/object_utils.py
+++ b/firstvoices/backend/search/utils/object_utils.py
@@ -1,4 +1,5 @@
 import logging
+from itertools import chain
 
 from elasticsearch.exceptions import ConnectionError, NotFoundError
 from elasticsearch_dsl import Search
@@ -171,8 +172,15 @@ def get_notes_text(dictionary_entry_instance):
 
 def get_categories_ids(dictionary_entry_instance):
     return [
-        str(id)
-        for id in dictionary_entry_instance.categories.values_list("id", flat=True)
+        str(category_id)
+        for category_id in list(
+            chain(
+                dictionary_entry_instance.categories.values_list("id", flat=True),
+                dictionary_entry_instance.categories.values_list(
+                    "parent_id", flat=True
+                ),
+            )
+        )
     ]
 
 


### PR DESCRIPTION
### Description of Changes
This PR adds the following three changes:
- Refreshes the dictionary entry/song/story indices when a dictionary entry is saved to allow related field signals to grab the index before the default 1 second has passed between ES updates.
- Adds a category field index update on the m2m_changed signal which is used in the APIs.
- Includes parent category IDs in the index so that dictionary entries will be returned when filtering entries with child categories by a parent category.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
