### PR TITLE
FW-4867 Order categories API response alphabetically by title

### DIFF
--- a/firstvoices/backend/views/category_views.py
+++ b/firstvoices/backend/views/category_views.py
@@ -192,17 +192,25 @@ class CategoryViewSet(SiteContentViewSetMixin, FVPermissionViewSetMixin, ModelVi
             if len(category.children.all())
         ]
         flat_child_ids_list = list(itertools.chain(*child_categories))
-        child_queryset = Category.objects.filter(id__in=filtered_categories)
+        child_queryset = Category.objects.filter(id__in=filtered_categories).order_by(
+            "title"
+        )
 
         if nested_flag:
-            return filtered_categories.filter(
-                ~Q(
-                    id__in=flat_child_ids_list
-                )  # Remove duplicate child entries being shown at top level
-            ).prefetch_related(Prefetch("children", queryset=child_queryset))
+            return (
+                filtered_categories.filter(
+                    ~Q(
+                        id__in=flat_child_ids_list
+                    )  # Remove duplicate child entries being shown at top level
+                )
+                .prefetch_related(Prefetch("children", queryset=child_queryset))
+                .order_by("title")
+            )
         else:
-            return filtered_categories.filter().prefetch_related(
-                Prefetch("children", queryset=child_queryset)
+            return (
+                filtered_categories.filter()
+                .prefetch_related(Prefetch("children", queryset=child_queryset))
+                .order_by("title")
             )
 
     def get_serializer_class(self):


### PR DESCRIPTION
### Description of Changes
This PR updates the categories list API to return the categories as follows:
- When using nested = true the categories are ordered by parent category title and any children within a parent are ordered by title as well.
- When using nested = false the full list of categories are ordered by title.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
