### PR TITLE
FW-4921 song empty notes fix

### DIFF
--- a/firstvoices/backend/resources/site_homepage_widgets.py
+++ b/firstvoices/backend/resources/site_homepage_widgets.py
@@ -8,7 +8,7 @@ from backend.resources.utils.import_export_widgets import UserForeignKeyWidget
 class SiteHomepageWidgetsResource(resources.ModelResource):
     class Meta:
         model = Site
-        fields = ("id",)
+        fields = ("id", "created", "last_modified", "homepage")
 
     def before_import_row(self, row, row_number=None, **kwargs):
         if row["homepage_widgets"] != "":
@@ -23,8 +23,7 @@ class SiteHomepageWidgetsResource(resources.ModelResource):
                 last_modified_by=last_modified_by_user,
                 created_by=created_by_user,
             )
-            site.homepage = site_widget_list
-            site.save()
+            row["homepage"] = site_widget_list.id
             for index, widget_id in enumerate(widgets_list):
                 widget = SiteWidget.objects.get(id=widget_id)
                 SiteWidgetListOrder.objects.create(

--- a/firstvoices/backend/resources/songs.py
+++ b/firstvoices/backend/resources/songs.py
@@ -7,15 +7,23 @@ from backend.resources.base import (
     ControlledSiteContentResource,
     RelatedMediaResourceMixin,
 )
+from backend.resources.utils.import_export_widgets import ArrayOfStringsWidget
 
 
 class SongResource(ControlledSiteContentResource, RelatedMediaResourceMixin):
+    acknowledgements = fields.Field(
+        column_name="acknowledgements",
+        attribute="acknowledgements",
+        widget=ArrayOfStringsWidget(sep="|"),
+    )
+    notes = fields.Field(
+        column_name="notes",
+        attribute="notes",
+        widget=ArrayOfStringsWidget(sep="|"),
+    )
+
     class Meta:
         model = Song
-
-    def before_save_instance(self, instance, using_transactions, dry_run):
-        instance.acknowledgements = ",".join(instance.acknowledgements).split("|")
-        instance.notes = ",".join(instance.notes).split("|")
 
 
 class LyricResource(BaseResource):

--- a/firstvoices/backend/resources/utils/import_export_widgets.py
+++ b/firstvoices/backend/resources/utils/import_export_widgets.py
@@ -38,9 +38,9 @@ class ArrayOfStringsWidget(Widget):
 
     def clean(self, value: str, row=None, *args, **kwargs) -> list:
         """Converts the display value (string with separator) into array on sep"""
-        if value:
-            return [string.strip() for string in value.split(sep=self.sep)]
-        return []
+        return [
+            string.strip() for string in value.split(sep=self.sep) if string.strip()
+        ]
 
     def render(self, value: list, obj=None) -> str:
         """Converts the db value (array) into a single string for display, using separator"""

--- a/firstvoices/backend/tests/test_resources/test_song_resource.py
+++ b/firstvoices/backend/tests/test_resources/test_song_resource.py
@@ -31,7 +31,7 @@ class TestSongsImport:
         data = [
             f"{uuid.uuid4()},2023-02-02 21:21:10.713,user_one@test.com,2023-02-02 21:21:39.864,user_one@test.com,"
             f"Public,Sample Song,Sample introduction,False,{site.id},Sample title translation,"
-            f'"Sample acknowledgement one, with comma|Sample acknowledgement two","Sample note one|Sample note two",'
+            f'"Sample acknowledgement one, with comma|Sample acknowledgement two",,'
             f'Sample intro translation,False,False,"{audio_one.id},{audio_two.id}",{image.id},{video.id}'
         ]
         table = self.build_table(data)
@@ -51,7 +51,7 @@ class TestSongsImport:
         assert new_song.introduction == table["introduction"][0]
         assert new_song.introduction_translation == table["introduction_translation"][0]
         assert new_song.acknowledgements == table["acknowledgements"][0].split("|")
-        assert new_song.notes == table["notes"][0].split("|")
+        assert new_song.notes == []
         assert new_song.hide_overlay == eval(table["hide_overlay"][0])
         assert new_song.exclude_from_games == eval(table["exclude_from_games"][0])
         assert new_song.exclude_from_kids == eval(table["exclude_from_kids"][0])

--- a/firstvoices/backend/tests/test_resources/test_stories_resource.py
+++ b/firstvoices/backend/tests/test_resources/test_stories_resource.py
@@ -71,6 +71,8 @@ class TestStoryImport:
         assert new_story.related_audio.all().count() == 0
         assert new_story.related_images.all().count() == 0
         assert new_story.related_videos.all().count() == 0
+        assert new_story.acknowledgements == []
+        assert new_story.notes == []
 
         # other possible hide-overlay value
         new_story = Story.objects.get(id=table["id"][1])
@@ -221,6 +223,7 @@ class TestStoryPageImport:
         assert new_page.related_images.all().count() == 0
         assert new_page.related_videos.all().count() == 0
         assert new_page.visibility == story.visibility
+        assert new_page.notes == []
 
     @pytest.mark.django_db
     def test_skip_song_lyrics(self):


### PR DESCRIPTION
### Description of Changes
Fix a bug in how empty notes and acknowledgements are imported on Songs. Also tried to add metadata into the site homepage import to keep it from overwriting.

### Checklist
- README / documentation has been updated if needed
- [X] PR title / commit messages contain Jira ticket number if applicable
- [X] Tests have been updated / created if applicable
- Admin Panel has been updated if models have been added or modified
- Migrations have been updated and committed if applicable
- Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
