### PR TITLE
Fw 4807 improve search api response time

### DIFF
--- a/firstvoices/backend/search/utils/object_utils.py
+++ b/firstvoices/backend/search/utils/object_utils.py
@@ -125,11 +125,6 @@ def hydrate_objects(search_results, request):
                             "request": request,
                             "view": "search",
                             "site": dictionary_entry.site,
-                            # "alphabet": alphabet,
-                            # "ignored_characters": ignored_characters,
-                            # "base_characters": base_characters,
-                            # "character_variants": character_variants,
-                            # "ignorable_characters": ignorable_characters,
                         },
                     ).data,
                 }

--- a/firstvoices/backend/search/utils/object_utils.py
+++ b/firstvoices/backend/search/utils/object_utils.py
@@ -80,7 +80,7 @@ def hydrate_objects(search_results, request):
     # Fetching objects from the database
     dictionary_objects = list(
         DictionaryEntry.objects.filter(id__in=dictionary_search_results_ids)
-        .select_related("site", "created_by", "last_modified_by")
+        .select_related("site", "created_by", "last_modified_by", "part_of_speech")
         .prefetch_related(
             "categories",
             "acknowledgement_set",

--- a/firstvoices/backend/search/utils/object_utils.py
+++ b/firstvoices/backend/search/utils/object_utils.py
@@ -98,10 +98,6 @@ def hydrate_objects(search_results, request):
                 ),
             ),
             *get_media_prefetch_list(request.user)
-            # "site__alphabet_set",
-            # "site__ignoredcharacter_set",
-            # "site__character_set",
-            # "site__charactervariant_set",
         )
     )
     song_objects = list(
@@ -117,15 +113,6 @@ def hydrate_objects(search_results, request):
             dictionary_entry = get_object_by_id(
                 dictionary_objects, obj["_source"]["document_id"]
             )
-
-            # Commenting out to improve response time. Will be added back with a parameter when required for games
-            # alphabet = dictionary_entry.site.alphabet_set.first()
-            # ignored_characters = dictionary_entry.site.ignoredcharacter_set.values_list(
-            #     "title", flat=True
-            # )
-            # base_characters = dictionary_entry.site.character_set.order_by("sort_order")
-            # character_variants = dictionary_entry.site.charactervariant_set.all()
-            # ignorable_characters = dictionary_entry.site.character_set.all()
 
             # Serializing and adding the object to complete_objects
             complete_objects.append(

--- a/firstvoices/backend/search/utils/object_utils.py
+++ b/firstvoices/backend/search/utils/object_utils.py
@@ -110,13 +110,14 @@ def hydrate_objects(search_results, request):
                 dictionary_objects, obj["_source"]["document_id"]
             )
 
-            alphabet = dictionary_entry.site.alphabet_set.first()
-            ignored_characters = dictionary_entry.site.ignoredcharacter_set.values_list(
-                "title", flat=True
-            )
-            base_characters = dictionary_entry.site.character_set.order_by("sort_order")
-            character_variants = dictionary_entry.site.charactervariant_set.all()
-            ignorable_characters = dictionary_entry.site.character_set.all()
+            # Commenting out to improve response time. Will be added back with a parameter when required for games
+            # alphabet = dictionary_entry.site.alphabet_set.first()
+            # ignored_characters = dictionary_entry.site.ignoredcharacter_set.values_list(
+            #     "title", flat=True
+            # )
+            # base_characters = dictionary_entry.site.character_set.order_by("sort_order")
+            # character_variants = dictionary_entry.site.charactervariant_set.all()
+            # ignorable_characters = dictionary_entry.site.character_set.all()
 
             # Serializing and adding the object to complete_objects
             complete_objects.append(
@@ -129,11 +130,11 @@ def hydrate_objects(search_results, request):
                             "request": request,
                             "view": "search",
                             "site": dictionary_entry.site,
-                            "alphabet": alphabet,
-                            "ignored_characters": ignored_characters,
-                            "base_characters": base_characters,
-                            "character_variants": character_variants,
-                            "ignorable_characters": ignorable_characters,
+                            # "alphabet": alphabet,
+                            # "ignored_characters": ignored_characters,
+                            # "base_characters": base_characters,
+                            # "character_variants": character_variants,
+                            # "ignorable_characters": ignorable_characters,
                         },
                     ).data,
                 }
@@ -151,7 +152,7 @@ def hydrate_objects(search_results, request):
                         context={
                             "request": request,
                             "view": "search",
-                            "site_slug": song.site.slug,
+                            "site": song.site,
                         },
                     ).data,
                 }
@@ -169,7 +170,7 @@ def hydrate_objects(search_results, request):
                         context={
                             "request": request,
                             "view": "search",
-                            "site_slug": story.site.slug,
+                            "site": story.site,
                         },
                     ).data,
                 }

--- a/firstvoices/backend/search/utils/object_utils.py
+++ b/firstvoices/backend/search/utils/object_utils.py
@@ -77,9 +77,20 @@ def hydrate_objects(search_results, request):
 
     # Fetching objects from the database
     dictionary_objects = list(
-        DictionaryEntry.objects.filter(
-            id__in=dictionary_search_results_ids
-        ).prefetch_related("translation_set")
+        DictionaryEntry.objects.filter(id__in=dictionary_search_results_ids)
+        .select_related("site", "created_by", "last_modified_by")
+        .prefetch_related(
+            "categories",
+            "acknowledgement_set",
+            "translation_set",
+            "pronunciation_set",
+            "note_set",
+            "alternatespelling_set",
+            "site__language",
+            "related_audio",
+            "related_images",
+            "related_videos",
+        )
     )
     song_objects = list(
         Song.objects.filter(id__in=song_search_results_ids).prefetch_related("lyrics")
@@ -105,7 +116,7 @@ def hydrate_objects(search_results, request):
                         context={
                             "request": request,
                             "view": "search",
-                            "site_slug": dictionary_entry.site.slug,
+                            "site": dictionary_entry.site,
                         },
                     ).data,
                 }

--- a/firstvoices/backend/serializers/dictionary_serializers.py
+++ b/firstvoices/backend/serializers/dictionary_serializers.py
@@ -140,11 +140,6 @@ class DictionaryEntryDetailSerializer(
     pronunciations = PronunciationSerializer(
         many=True, required=False, source="pronunciation_set"
     )
-    # Commenting out to improve response time. Will be added back with a parameter when required for games
-    # split_chars = serializers.SerializerMethodField(read_only=True)
-    # split_chars_base = serializers.SerializerMethodField(read_only=True)
-    # split_words = serializers.SerializerMethodField(read_only=True)
-    # split_words_base = serializers.SerializerMethodField(read_only=True)
 
     logger = logging.getLogger(__name__)
 
@@ -337,10 +332,6 @@ class DictionaryEntryDetailSerializer(
                 "translations",
                 "part_of_speech",
                 "pronunciations",
-                # "split_chars",
-                # "split_chars_base",
-                # "split_words",
-                # "split_words_base",
             )
             + RelatedMediaSerializerMixin.Meta.fields
             + RelatedDictionaryEntrySerializerMixin.Meta.fields

--- a/firstvoices/backend/serializers/dictionary_serializers.py
+++ b/firstvoices/backend/serializers/dictionary_serializers.py
@@ -140,10 +140,11 @@ class DictionaryEntryDetailSerializer(
     pronunciations = PronunciationSerializer(
         many=True, required=False, source="pronunciation_set"
     )
-    split_chars = serializers.SerializerMethodField(read_only=True)
-    split_chars_base = serializers.SerializerMethodField(read_only=True)
-    split_words = serializers.SerializerMethodField(read_only=True)
-    split_words_base = serializers.SerializerMethodField(read_only=True)
+    # Commenting out to improve response time. Will be added back with a parameter when required for games
+    # split_chars = serializers.SerializerMethodField(read_only=True)
+    # split_chars_base = serializers.SerializerMethodField(read_only=True)
+    # split_words = serializers.SerializerMethodField(read_only=True)
+    # split_words_base = serializers.SerializerMethodField(read_only=True)
 
     logger = logging.getLogger(__name__)
 
@@ -336,10 +337,10 @@ class DictionaryEntryDetailSerializer(
                 "translations",
                 "part_of_speech",
                 "pronunciations",
-                "split_chars",
-                "split_chars_base",
-                "split_words",
-                "split_words_base",
+                # "split_chars",
+                # "split_chars_base",
+                # "split_words",
+                # "split_words_base",
             )
             + RelatedMediaSerializerMixin.Meta.fields
             + RelatedDictionaryEntrySerializerMixin.Meta.fields

--- a/firstvoices/backend/tests/test_apis/test_dictionary_api.py
+++ b/firstvoices/backend/tests/test_apis/test_dictionary_api.py
@@ -62,10 +62,6 @@ class TestDictionaryEndpoint(
             "partOfSpeech": None,
             "pronunciations": [],
             "site": str(site.id),
-            "splitChars": [],
-            "splitCharsBase": [],
-            "splitWords": ["Word"],
-            "splitWordsBase": ["Word"],
             "relatedDictionaryEntries": [],
             "relatedAudio": list(map(lambda x: str(x.id), related_audio)),
             "relatedImages": list(map(lambda x: str(x.id), related_images)),
@@ -181,10 +177,6 @@ class TestDictionaryEndpoint(
             "translations": [],
             "partOfSpeech": None,
             "pronunciations": [],
-            "splitChars": [],
-            "splitCharsBase": [],
-            "splitWords": instance.title.split(" "),
-            "splitWordsBase": instance.title.split(" "),
             "relatedDictionaryEntries": [],
             "relatedAudio": [],
             "relatedImages": [],
@@ -482,9 +474,6 @@ class TestDictionaryEndpoint(
         assert response_data["count"] == 1
         assert len(response_data["results"]) == 1
 
-        assert response_data["results"][0]["splitChars"] == ["b", "c", " ", "a"]
-        assert response_data["results"][0]["splitCharsBase"] == ["b", "c", " ", "a"]
-
     @pytest.mark.django_db
     def test_character_lists_generation_with_variants(self):
         user = factories.get_non_member_user()
@@ -521,27 +510,6 @@ class TestDictionaryEndpoint(
         assert response_data["count"] == 1
         assert len(response_data["results"]) == 1
 
-        assert response_data["results"][0]["splitChars"] == [
-            "Ch",
-            "x",
-            "y",
-            "AA",
-            " ",
-            "h",
-            "c",
-            "H",
-        ]
-        assert response_data["results"][0]["splitCharsBase"] == [
-            "ch",
-            "x",
-            "y",
-            "aa",
-            " ",
-            "h",
-            "c",
-            "h",
-        ]
-
     @pytest.mark.django_db
     def test_character_lists_unrecognized_characters(self):
         user = factories.get_non_member_user()
@@ -561,9 +529,6 @@ class TestDictionaryEndpoint(
         response_data = json.loads(response.content)
         assert response_data["count"] == 1
         assert len(response_data["results"]) == 1
-
-        assert response_data["results"][0]["splitChars"] == []
-        assert response_data["results"][0]["splitCharsBase"] == []
 
     @pytest.mark.django_db
     def test_character_lists_with_ignored_characters(self):
@@ -589,9 +554,6 @@ class TestDictionaryEndpoint(
         assert response_data["count"] == 1
         assert len(response_data["results"]) == 1
 
-        assert response_data["results"][0]["splitChars"] == []
-        assert response_data["results"][0]["splitCharsBase"] == []
-
     @pytest.mark.django_db
     def test_character_lists_ignored_character_edge_case(self):
         user = factories.get_non_member_user()
@@ -615,9 +577,6 @@ class TestDictionaryEndpoint(
         response_data = json.loads(response.content)
         assert response_data["count"] == 1
         assert len(response_data["results"]) == 1
-
-        assert response_data["results"][0]["splitChars"] == ["x-", "y"]
-        assert response_data["results"][0]["splitCharsBase"] == ["x-", "y"]
 
     @pytest.mark.django_db
     def test_word_lists(self):
@@ -646,9 +605,6 @@ class TestDictionaryEndpoint(
         response_data = json.loads(response.content)
         assert response_data["count"] == 1
         assert len(response_data["results"]) == 1
-
-        assert response_data["results"][0]["splitWords"] == ["abc", "bca", "caba"]
-        assert response_data["results"][0]["splitWordsBase"] == ["abc", "bca", "caba"]
 
     @pytest.mark.django_db
     def test_word_lists_with_variants(self):
@@ -680,9 +636,6 @@ class TestDictionaryEndpoint(
         assert response_data["count"] == 1
         assert len(response_data["results"]) == 1
 
-        assert response_data["results"][0]["splitWords"] == ["xyY", "yYx", "xYy"]
-        assert response_data["results"][0]["splitWordsBase"] == ["xyy", "yyx", "xyy"]
-
     @pytest.mark.django_db
     def test_word_lists_single_word(self):
         user = factories.get_non_member_user()
@@ -710,9 +663,6 @@ class TestDictionaryEndpoint(
         response_data = json.loads(response.content)
         assert response_data["count"] == 1
         assert len(response_data["results"]) == 1
-
-        assert response_data["results"][0]["splitWords"] == ["abc"]
-        assert response_data["results"][0]["splitWordsBase"] == ["abc"]
 
     @pytest.mark.django_db
     def test_word_lists_with_unknown_characters(self):
@@ -742,19 +692,6 @@ class TestDictionaryEndpoint(
         assert response_data["count"] == 1
         assert len(response_data["results"]) == 1
 
-        assert response_data["results"][0]["splitWords"] == [
-            "xyY",
-            "yYx",
-            "xYy",
-            "Hello",
-        ]
-        assert response_data["results"][0]["splitWordsBase"] == [
-            "xyy",
-            "yyx",
-            "xyy",
-            "Hello",
-        ]
-
     @pytest.mark.django_db
     def test_word_lists_with_ignored_characters(self):
         user = factories.get_non_member_user()
@@ -782,9 +719,6 @@ class TestDictionaryEndpoint(
         response_data = json.loads(response.content)
         assert response_data["count"] == 1
         assert len(response_data["results"]) == 1
-
-        assert response_data["results"][0]["splitWords"] == ["xy-y", "-y-x", "x-y-"]
-        assert response_data["results"][0]["splitWordsBase"] == ["xy-y", "-y-x", "x-y-"]
 
     @pytest.mark.django_db
     def test_dictionary_entry_create_no_content(self):


### PR DESCRIPTION
### Description of Changes
Fixes done to improve the performance for site-wide search (`/api/1.0/sites/{site_slug}/search/`)
- Passing `site` object directly in `context` during hydration process to reduce site lookup from slug
- Adding lookup fields in select_related for dictionary entries hydration. `site,created_by,last_modified_by,part_of_speech`
- Added M2M and foreign key lookups in prefetch_related to reduce additional DB hits and time for the following: `categories,acknowledgement_set,pronunciation_set,note_set,alternatespelling_set,site__language` and prefetch media fields.
- Removed game related fields from dictionary_entry serializer and its related tests. fields: `split_chars,split_chars_base,split_words,split_words_base`. To be added back as a part of [FW-4931](https://firstvoices.atlassian.net/browse/FW-4931)

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- [x] Migrations have been updated and committed if applicable
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [x] Pull the branch and test locally

### Additional Notes
N/A


[FW-4931]: https://firstvoices.atlassian.net/browse/FW-4931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ