### PR TITLE
FW-4922 Add lyric notes migration

### DIFF
--- a/firstvoices/backend/resources/songs.py
+++ b/firstvoices/backend/resources/songs.py
@@ -40,6 +40,9 @@ class LyricResource(BaseResource):
         # If the book entry is a lyric and has notes, add them to the song
         if Song.objects.filter(id=row["parent_id"]).exists() and row["notes"] != "":
             song = Song.objects.get(id=row["parent_id"])
-            for note in row["notes"].split(self.array_sep):
+
+            for note in [
+                string.strip() for string in row["notes"].split(sep=self.array_sep)
+            ]:
                 song.notes.append("From lyric: " + note)
             song.save()

--- a/firstvoices/backend/tests/test_resources/test_song_resource.py
+++ b/firstvoices/backend/tests/test_resources/test_song_resource.py
@@ -71,7 +71,7 @@ class TestLyricsImport:
     @staticmethod
     def build_table(data: list[str]):
         headers = [
-            "id,created,created_by,last_modified,last_modified_by,text,translation,ordering,parent_id",
+            "id,created,created_by,last_modified,last_modified_by,parent_id,text,translation,ordering,notes",
         ]
         table = tablib.import_set("\n".join(headers + data), format="csv")
         return table
@@ -83,11 +83,11 @@ class TestLyricsImport:
 
         data = [
             f"{uuid.uuid4()},2023-02-02 21:21:10.713,user_one@test.com,2023-02-02 21:21:39.864,user_one@test.com,"
-            f"Test non lyric book entry one,Test lyric translation,0,{uuid.uuid4()}",
+            f"{uuid.uuid4()},Test non lyric book entry one,Test lyric translation,0,",
             f"{uuid.uuid4()},2023-02-02 21:21:10.713,user_one@test.com,2023-02-02 21:21:39.864,user_one@test.com,"
-            f"Test lyric text,Test lyric translation,0,{song.id}",
+            f"{song.id},Test lyric text,Test lyric translation,0,",
             f"{uuid.uuid4()},2023-02-02 21:21:10.713,user_one@test.com,2023-02-02 21:21:39.864,user_one@test.com,"
-            f"Test non lyric book entry two,Test translation,0,{uuid.uuid4()}",
+            f"{uuid.uuid4()},Test non lyric book entry two,Test translation,0,",
         ]
         table = self.build_table(data)
 
@@ -107,3 +107,31 @@ class TestLyricsImport:
         assert new_lyric.translation == table["translation"][1]
         assert new_lyric.ordering == int(table["ordering"][1])
         assert new_lyric.song == song
+
+    @pytest.mark.django_db
+    def test_import_book_note_to_song_note(self):
+        site = factories.SiteFactory.create()
+        song = factories.SongFactory.create(site=site, notes=["Test note one"])
+
+        data = [
+            f"{uuid.uuid4()},2023-02-02 21:21:10.713,user_one@test.com,2023-02-02 21:21:39.864,user_one@test.com,"
+            f"{song.id},Test lyric text,Test lyric translation,0,Lyric note one|||Lyric note two",
+        ]
+        table = self.build_table(data)
+
+        assert len(Lyric.objects.all()) == 0
+        assert song.lyrics.count() == 0
+        assert Song.objects.all().count() == 1
+
+        result = LyricResource().import_data(dataset=table)
+
+        assert not result.has_errors()
+        assert not result.has_validation_errors()
+        assert result.totals["new"] == 1
+        assert Lyric.objects.all().count() == 1
+
+        assert Song.objects.all().count() == 1
+        updated_song = Song.objects.get(id=song.id)
+        assert updated_song.notes[0] == "Test note one"
+        assert updated_song.notes[1] == "From lyric: Lyric note one"
+        assert updated_song.notes[2] == "From lyric: Lyric note two"

--- a/firstvoices/backend/tests/test_resources/test_song_resource.py
+++ b/firstvoices/backend/tests/test_resources/test_song_resource.py
@@ -115,7 +115,7 @@ class TestLyricsImport:
 
         data = [
             f"{uuid.uuid4()},2023-02-02 21:21:10.713,user_one@test.com,2023-02-02 21:21:39.864,user_one@test.com,"
-            f"{song.id},Test lyric text,Test lyric translation,0,Lyric note one|||Lyric note two",
+            f"{song.id},Test lyric text,Test lyric translation,0,Lyric note one||| Lyric note two ",
         ]
         table = self.build_table(data)
 


### PR DESCRIPTION
### Description of Changes
This PR adds a migration for the information held in FVBookEntry documents. If a book entry is a lyric and the notes column contains information then the information is added to the lyric's parent song notes. Each note entry is prefixed with the text "From lyric: " to distinguish notes added this way from other notes.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [X] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
