### PR TITLE
FW-4923 Update categories API to return in case-insensitive order

### DIFF
--- a/firstvoices/backend/tests/test_apis/test_category_api.py
+++ b/firstvoices/backend/tests/test_apis/test_category_api.py
@@ -479,12 +479,16 @@ class TestCategoryEndpoints(BaseUncontrolledSiteContentApiTest):
         Category.objects.filter(site=self.site).delete()
 
         parent_category_1 = ParentCategoryFactory.create(site=self.site, title="b")
-        parent_category_2 = ParentCategoryFactory.create(site=self.site, title="a")
+        parent_category_2 = ParentCategoryFactory.create(site=self.site, title="A")
+        parent_category_3 = ParentCategoryFactory.create(site=self.site, title="C")
         child_category_1 = ChildCategoryFactory.create(
-            site=self.site, parent=parent_category_1, title="d"
+            site=self.site, parent=parent_category_1, title="e"
         )
         child_category_2 = ChildCategoryFactory.create(
-            site=self.site, parent=parent_category_1, title="c"
+            site=self.site, parent=parent_category_1, title="D"
+        )
+        child_category_3 = ChildCategoryFactory.create(
+            site=self.site, parent=parent_category_1, title="F"
         )
 
         response = self.client.get(
@@ -504,21 +508,35 @@ class TestCategoryEndpoints(BaseUncontrolledSiteContentApiTest):
         actual_parent_category_2_object = find_object_by_id(
             response_data["results"], parent_category_2.id
         )
+        actual_parent_category_3_object = find_object_by_id(
+            response_data["results"], parent_category_3.id
+        )
         actual_child_category_1_object = find_object_by_id(
             actual_parent_category_1_object["children"], child_category_1.id
         )
         actual_child_category_2_object = find_object_by_id(
             actual_parent_category_1_object["children"], child_category_2.id
         )
+        actual_child_category_3_object = find_object_by_id(
+            actual_parent_category_1_object["children"], child_category_3.id
+        )
 
         # Check that the parent categories are ordered by title
-        assert response_data["results"].index(
-            actual_parent_category_1_object
-        ) > response_data["results"].index(actual_parent_category_2_object)
+        assert (
+            response_data["results"].index(actual_parent_category_2_object)
+            < response_data["results"].index(actual_parent_category_1_object)
+            < response_data["results"].index(actual_parent_category_3_object)
+        )
 
         # Check that the child categories are ordered by title within a parent category
-        assert actual_parent_category_1_object["children"].index(
-            actual_child_category_1_object
-        ) > actual_parent_category_1_object["children"].index(
-            actual_child_category_2_object
+        assert (
+            actual_parent_category_1_object["children"].index(
+                actual_child_category_2_object
+            )
+            < actual_parent_category_1_object["children"].index(
+                actual_child_category_1_object
+            )
+            < actual_parent_category_1_object["children"].index(
+                actual_child_category_3_object
+            )
         )

--- a/firstvoices/backend/views/category_views.py
+++ b/firstvoices/backend/views/category_views.py
@@ -1,6 +1,7 @@
 import itertools
 
 from django.db.models import Prefetch, Q
+from django.db.models.functions import Lower
 from django.utils.translation import gettext as _
 from drf_spectacular.utils import (
     OpenApiExample,
@@ -193,7 +194,7 @@ class CategoryViewSet(SiteContentViewSetMixin, FVPermissionViewSetMixin, ModelVi
         ]
         flat_child_ids_list = list(itertools.chain(*child_categories))
         child_queryset = Category.objects.filter(id__in=filtered_categories).order_by(
-            "title"
+            Lower("title")
         )
 
         if nested_flag:
@@ -204,13 +205,13 @@ class CategoryViewSet(SiteContentViewSetMixin, FVPermissionViewSetMixin, ModelVi
                     )  # Remove duplicate child entries being shown at top level
                 )
                 .prefetch_related(Prefetch("children", queryset=child_queryset))
-                .order_by("title")
+                .order_by(Lower("title"))
             )
         else:
             return (
                 filtered_categories.filter()
                 .prefetch_related(Prefetch("children", queryset=child_queryset))
-                .order_by("title")
+                .order_by(Lower("title"))
             )
 
     def get_serializer_class(self):


### PR DESCRIPTION
### Description of Changes
This change updates the categories API to return the list of categories in case-insensitive order. For categories with titles "A", "b", and "C" the API will return categories in that order instead of "A", "C", "b".

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
