### PR TITLE
FW-4935 Fix related media admin bug and update multi-select display

### DIFF
--- a/firstvoices/backend/admin/base_admin.py
+++ b/firstvoices/backend/admin/base_admin.py
@@ -81,13 +81,12 @@ class BaseSiteContentAdmin(BaseAdmin):
         return super().formfield_for_manytomany(db_field, request, **kwargs)
 
     def get_site_from_object(self, request):
-        if not hasattr(self, "parent_site"):
-            self.parent_site = None
-            object_id = request.resolver_match.kwargs.get("object_id")
-            instance = self.get_object(request, object_id)
-            if instance:
-                self.parent_site = instance.site
-        return self.parent_site
+        parent_site = None
+        object_id = request.resolver_match.kwargs.get("object_id")
+        instance = self.get_object(request, object_id)
+        if instance:
+            parent_site = instance.site
+        return parent_site
 
 
 class BaseControlledSiteContentAdmin(BaseSiteContentAdmin):
@@ -151,15 +150,14 @@ class BaseInlineSiteContentAdmin(BaseInlineAdmin):
         return qs.select_related("site")
 
     def get_site_from_object(self, request):
-        if not hasattr(self, "parent_site"):
-            self.parent_site = None
-            object_id = request.resolver_match.kwargs.get("object_id")
-            instance = self.parent_model.objects.filter(id=object_id).first()
-            if instance and isinstance(instance, Site):
-                self.parent_site = instance
-            elif instance and hasattr(instance, "site"):
-                self.parent_site = instance.site
-        return self.parent_site
+        parent_site = None
+        object_id = request.resolver_match.kwargs.get("object_id")
+        instance = self.parent_model.objects.filter(id=object_id).first()
+        if instance and isinstance(instance, Site):
+            parent_site = instance
+        elif instance and hasattr(instance, "site"):
+            parent_site = instance.site
+        return parent_site
 
 
 class HiddenBaseAdmin(BaseAdmin):

--- a/firstvoices/backend/admin/dictionary_admin.py
+++ b/firstvoices/backend/admin/dictionary_admin.py
@@ -111,6 +111,7 @@ class DictionaryEntryAdmin(BaseControlledSiteContentAdmin):
     ]
     list_display = ("title",) + BaseControlledSiteContentAdmin.list_display
     readonly_fields = ("custom_order",) + BaseControlledSiteContentAdmin.readonly_fields
+    filter_horizontal = ("related_audio", "related_images", "related_videos")
 
 
 @admin.register(PartOfSpeech)

--- a/firstvoices/backend/admin/songs_admin.py
+++ b/firstvoices/backend/admin/songs_admin.py
@@ -17,3 +17,4 @@ class LyricAdmin(BaseInlineAdmin):
 class SongAdmin(BaseSiteContentAdmin, DynamicArrayMixin):
     list_display = ("title",) + BaseSiteContentAdmin.list_display
     inlines = [LyricAdmin]
+    filter_horizontal = ("related_audio", "related_images", "related_videos")

--- a/firstvoices/backend/admin/story_admin.py
+++ b/firstvoices/backend/admin/story_admin.py
@@ -29,12 +29,14 @@ class StoryPageInlineAdmin(BaseInlineSiteContentAdmin, DynamicArrayMixin):
 class StoryPageAdmin(BaseSiteContentAdmin):
     list_display = ("story", "ordering") + BaseSiteContentAdmin.list_display
     list_select_related = ["story"] + BaseSiteContentAdmin.list_select_related
+    filter_horizontal = ("related_audio", "related_images", "related_videos")
 
 
 @admin.register(Story)
 class StoryAdmin(BaseSiteContentAdmin):
     list_display = ("title",) + BaseSiteContentAdmin.list_display
     inlines = [StoryPageInlineAdmin]
+    filter_horizontal = ("related_audio", "related_images", "related_videos")
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)


### PR DESCRIPTION
### Description of Changes
These changes fix the related media bug where the wrong site's media would be listed.

Additionally, this PR updates the related media selector to use the filter_horizontal widget which is more intuitive for large lists.

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~
- [x] Admin Panel has been updated if models have been added or modified
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [x] Pull the branch and test locally

### Additional Notes
N/A
