### PR TITLE
FW-4940 import resources allow blank metadata

### DIFF
--- a/firstvoices/backend/resources/app.py
+++ b/firstvoices/backend/resources/app.py
@@ -1,12 +1,10 @@
-from import_export import fields
+from django.contrib.auth import get_user_model
+from import_export import fields, widgets
 
 from backend.models.app import AppMembership
 from backend.models.constants import AppRole
 from backend.resources.base import BaseResource
-from backend.resources.utils.import_export_widgets import (
-    ChoicesWidget,
-    UserForeignKeyWidget,
-)
+from backend.resources.utils.import_export_widgets import ChoicesWidget
 
 
 class AppMembershipResource(BaseResource):
@@ -18,7 +16,7 @@ class AppMembershipResource(BaseResource):
     user = fields.Field(
         column_name="user",
         attribute="user",
-        widget=UserForeignKeyWidget(),
+        widget=widgets.ForeignKeyWidget(get_user_model(), field="email"),
     )
 
     class Meta:

--- a/firstvoices/backend/resources/sites.py
+++ b/firstvoices/backend/resources/sites.py
@@ -1,3 +1,4 @@
+from django.contrib.auth import get_user_model
 from django.db import connection
 from import_export import fields
 from import_export.widgets import ForeignKeyWidget
@@ -7,10 +8,7 @@ from backend.models.constants import Role, Visibility
 from backend.models.media import File, ImageFile, VideoFile
 from backend.models.sites import Language, Membership, Site
 from backend.resources.base import BaseResource, SiteContentResource
-from backend.resources.utils.import_export_widgets import (
-    ChoicesWidget,
-    UserForeignKeyWidget,
-)
+from backend.resources.utils.import_export_widgets import ChoicesWidget
 
 
 class SiteResource(BaseResource):
@@ -77,7 +75,7 @@ class MembershipResource(SiteContentResource):
     user = fields.Field(
         column_name="user",
         attribute="user",
-        widget=UserForeignKeyWidget(),
+        widget=ForeignKeyWidget(get_user_model(), field="email"),
     )
 
     class Meta:

--- a/firstvoices/backend/resources/users.py
+++ b/firstvoices/backend/resources/users.py
@@ -1,14 +1,14 @@
+from django.contrib.auth import get_user_model
 from import_export import resources
-from jwt_auth.models import User
 
 
 class UserResource(resources.ModelResource):
     class Meta:
-        model = User
+        model = get_user_model()
 
     def skip_row(self, instance, original, row, import_validation_errors=None):
         """Skip users that already exist."""
-        user_exists = User.objects.filter(email=instance.email).exists()
+        user_exists = get_user_model().objects.filter(email=instance.email).exists()
         if user_exists:
             return True
         return super().skip_row(instance, original, row, import_validation_errors)

--- a/firstvoices/backend/resources/utils/import_export_widgets.py
+++ b/firstvoices/backend/resources/utils/import_export_widgets.py
@@ -60,10 +60,6 @@ class UserForeignKeyWidget(ForeignKeyWidget):
 
     def clean(self, value, row=None, **kwargs):
         """Converts email value from CSV to a User object."""
-        if not value:
-            # leave field empty if no email provided
-            return None
-
         user_exists = self.model.objects.filter(email=value).exists()
         if user_exists:
             return super().clean(value, row, **kwargs)

--- a/firstvoices/backend/tests/test_resources/test_media_resources.py
+++ b/firstvoices/backend/tests/test_resources/test_media_resources.py
@@ -112,23 +112,17 @@ class TestAudioImport(BaseMediaImportTest):
             f"{id_one}/somefile.mp3",
         ]
         table = self.build_table(data)
-
         result = AudioResource().import_data(dataset=table)
 
         assert not result.has_errors()
         assert not result.has_validation_errors()
         assert result.totals["new"] == len(data)
-        assert Audio.objects.filter(site=site.id).count() == len(data)
-        assert File.objects.filter(site=site.id).count() == len(data)
-
-        new_audio = Audio.objects.get(id=table["id"][0])
-        assert table["title"][0] == new_audio.title
-        assert table["site"][0] == str(new_audio.site.id)
-        assert table["description"][0] == new_audio.description
-        assert table["acknowledgement"][0] == new_audio.acknowledgement
-        assert table["is_shared"][0] == str(new_audio.is_shared)
-        assert table["exclude_from_kids"][0] == str(new_audio.exclude_from_kids)
-        assert table["content"][0] == str(new_audio.original.content)
+        assert Audio.objects.filter(site=site.id).count() == 1
+        assert File.objects.filter(site=site.id).count() == 1
+        assert (
+            Audio.objects.get(id=table["id"][0]).original
+            == File.objects.filter(site=site.id).first()
+        )
 
 
 class TestAudioSpeakerImport:

--- a/firstvoices/backend/tests/test_resources/test_membership_resource.py
+++ b/firstvoices/backend/tests/test_resources/test_membership_resource.py
@@ -37,7 +37,7 @@ class TestAppMembershipImport:
         assert new_membership.exists()
         assert new_membership.first().user == user
         assert new_membership.first().role == AppRole.STAFF
-        assert new_membership.first().created_by is None
+        assert new_membership.first().created_by.email == "support@fpcc.ca"
 
     @pytest.mark.django_db
     def test_no_overwrite(self):
@@ -91,7 +91,7 @@ class TestSiteMembershipImport:
         assert new_membership.exists()
         assert new_membership.first().user == user
         assert new_membership.first().role == Role.LANGUAGE_ADMIN
-        assert new_membership.first().created_by is None
+        assert new_membership.first().created_by.email == "support@fpcc.ca"
 
     @pytest.mark.django_db
     @pytest.mark.parametrize(

--- a/firstvoices/backend/tests/test_resources/test_site_resource.py
+++ b/firstvoices/backend/tests/test_resources/test_site_resource.py
@@ -52,6 +52,22 @@ class TestSiteImport:
         assert new_site.visibility == Visibility.TEAM
 
     @pytest.mark.django_db
+    def test_import_no_metadata(self):
+        """
+        If created/modified dates or users are absent, import successfully with some default.
+        """
+        site_id = uuid.uuid4()
+        data = [
+            f"{site_id},,,,,Blank,blank,Public,,",
+        ]
+        table = build_table(data)
+
+        result = SiteResource().import_data(dataset=table)
+        assert not result.has_errors()
+        assert not result.has_validation_errors()
+        assert result.totals["new"] == 1
+
+    @pytest.mark.django_db
     def test_import_metadata_custom_timestamps(self):
         """
         Allow manual created/modified dates when creating object from import,

--- a/firstvoices/backend/tests/test_resources/test_site_resource.py
+++ b/firstvoices/backend/tests/test_resources/test_site_resource.py
@@ -67,6 +67,9 @@ class TestSiteImport:
         assert not result.has_validation_errors()
         assert result.totals["new"] == 1
 
+        new_site = Site.objects.get(id=table["id"][0])
+        assert new_site.created_by.email == "support@fpcc.ca"
+
     @pytest.mark.django_db
     def test_import_metadata_custom_timestamps(self):
         """

--- a/firstvoices/backend/tests/test_resources/test_user_resource.py
+++ b/firstvoices/backend/tests/test_resources/test_user_resource.py
@@ -1,6 +1,6 @@
 import pytest
 import tablib
-from jwt_auth.models import User
+from django.contrib.auth import get_user_model
 
 from backend.resources.users import UserResource
 from backend.tests.factories import UserFactory
@@ -30,10 +30,10 @@ class TestUserImport:
         assert not result.has_errors()
         assert not result.has_validation_errors()
         assert result.totals["new"] == len(data)
-        assert User.objects.count() == len(data)
+        assert get_user_model().objects.count() == len(data)
 
-        assert User.objects.filter(email=table["email"][0]).exists()
-        assert User.objects.filter(email=table["email"][1]).exists()
+        assert get_user_model().objects.filter(email=table["email"][0]).exists()
+        assert get_user_model().objects.filter(email=table["email"][1]).exists()
 
     @pytest.mark.django_db
     def test_skip_existing_users(self):


### PR DESCRIPTION
### Description of Changes
If import rows have no user metadata (created_by/last_modified_by) add `support@fpcc.ca` in that field instead so the object can be imported. For files inserted directly with SQL, add default `now` timestamps.

### Checklist
- [ ] README / documentation has been updated if needed
- [X] PR title / commit messages contain Jira ticket number if applicable
- [X] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
