### PR TITLE
FW-4938 Audio list DB performance improvements

### DIFF
--- a/firstvoices/backend/pagination.py
+++ b/firstvoices/backend/pagination.py
@@ -15,10 +15,10 @@ class FasterCountPagination(Paginator):
     @cached_property
     def count(self):
         # Override the count property to select only the id field to speed up the count query
-        c = getattr(self.object_list.values("id"), "count", None)
+        c = getattr(self.object_list.values("pk"), "count", None)
         if callable(c) and not inspect.isbuiltin(c) and method_has_no_args(c):
             return c()
-        return len(self.object_list.values("id"))
+        return len(self.object_list.values("pk"))
 
 
 class PageNumberPagination(pagination.PageNumberPagination):

--- a/firstvoices/backend/views/audio_views.py
+++ b/firstvoices/backend/views/audio_views.py
@@ -80,7 +80,11 @@ class AudioViewSet(
         site = self.get_validated_site()
         return (
             Audio.objects.filter(site__slug=site[0].slug)
-            .select_related("original", "site")
-            .prefetch_related("speakers")
+            .prefetch_related("original", "site", "speakers")
             .order_by("-created")
+            .defer(
+                "created_by_id",
+                "last_modified_by_id",
+                "last_modified",
+            )
         )


### PR DESCRIPTION
### Description of Changes
These changes improve the Audio list view database query performance as follows:
- The query to get the pagination object count has been optimized to fetch only the ID instead of all fields on an object reducing the query latency by approximately 75%.
- The get_queryset function in AudioViewSet has been updated to use `prefetch_related` for the site and original relations instead of `select_related`, reducing the query latency by approximately 80%.
- A few of the unneeded fields have been removed from the query selection using `defer`.

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [x] Pull the branch and test locally

### Additional Notes
N/A
