### PR TITLE
Update run-pytest.yml to match deployed python version

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11.4"]
 
     services:
       postgres:


### PR DESCRIPTION
### Description of Changes

Run the tests with the same python version we use for deployment, to catch any dependency conflicts. Turns out this does not catch the problem we were seeing with numpy 1.26.0, but maybe we'll get lucky next time.

See: https://github.com/First-Peoples-Cultural-Council/fv-be/commit/2ff6ba724f16327e3de6134c2d2e8f4226fd2568

### Checklist
- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
