### PR TITLE
fw-4939, cache jwks signing keys

### DIFF
--- a/firstvoices/jwt_auth/authentication.py
+++ b/firstvoices/jwt_auth/authentication.py
@@ -1,5 +1,3 @@
-import json
-
 import jwt
 import requests
 from django.conf import settings
@@ -24,7 +22,7 @@ def extract_bearer_token(auth):
 
 
 def get_signing_key(token):
-    jwks_client = jwt.PyJWKClient(settings.JWT["JWKS_URL"])
+    jwks_client = jwt.PyJWKClient(settings.JWT["JWKS_URL"], cache_keys=True)
 
     try:
         return jwks_client.get_signing_key_from_jwt(token)
@@ -97,15 +95,6 @@ class JwtAuthentication(authentication.BaseAuthentication):
     """
     Decode JWT token and map to user
     """
-
-    def refresh_jwk(self):
-        certs_response = requests.get(settings.JWT["JWKS_URL"])
-        jwks = json.loads(certs_response.text)
-        self.jwks = jwks
-
-    def __init__(self):
-        self.jwks = None
-        self.refresh_jwk()
 
     def authenticate(self, request):
         """Verify the JWT token and find (or create) the correct user in the DB"""


### PR DESCRIPTION
### Description of Changes
* Enable caching for jwks signing keys. The library handles refreshing these if the keys are rotated.

### Checklist
- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
