### PR TITLE
Fix thumbnail generation error when original is not JPEG

### DIFF
--- a/firstvoices/backend/models/media.py
+++ b/firstvoices/backend/models/media.py
@@ -132,7 +132,6 @@ class ImageFile(VisualFileBase):
             "delete": predicates.can_delete_core_uncontrolled_data,
         }
 
-
     def save(self, **kwargs):
         try:
             self.width = self.content.file.image.width
@@ -471,7 +470,11 @@ class Image(ThumbnailMixin, MediaBase):
         # Remove transparency values if they exist so that the image can be converted to JPEG.
         if img.mode in ("RGBA", "P"):
             img = img.convert("RGB")
-        if output_size[0] == img.width and output_size[1] == img.height:
+        if (
+            output_size[0] == img.width
+            and output_size[1] == img.height
+            and img.format == "JPEG"
+        ):
             img.save(output_img, format="JPEG", quality="keep")
         else:
             img.save(output_img, format="JPEG", quality=80)


### PR DESCRIPTION
### Description of Changes
This PR fixes the thumbnail generation error when generating a thumbnail with a small input image that is not a JPEG.

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
