### PR TITLE
FW-4667 Mock ffmpeg to improve test suite run time

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -38,8 +38,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.debug.txt ]; then pip install -r requirements.debug.txt; fi
-      - uses: FedericoCarboni/setup-ffmpeg@v2
-        id: setup-ffmpeg
       - name: Run Pytest
         working-directory: ./firstvoices
         env:

--- a/firstvoices/backend/models/media.py
+++ b/firstvoices/backend/models/media.py
@@ -132,10 +132,18 @@ class ImageFile(VisualFileBase):
             "delete": predicates.can_delete_core_uncontrolled_data,
         }
 
+    def get_image_dimensions(self):
+        # separate function to get ability to mock it for tests
+        return {
+            "width": self.content.file.image.width,
+            "height": self.content.file.image.height,
+        }
+
     def save(self, **kwargs):
         try:
-            self.width = self.content.file.image.width
-            self.height = self.content.file.image.height
+            image_dimensions = self.get_image_dimensions()
+            self.width = image_dimensions["width"]
+            self.height = image_dimensions["height"]
 
         except AttributeError as e:
             self.logger.info(

--- a/firstvoices/backend/tests/conftest.py
+++ b/firstvoices/backend/tests/conftest.py
@@ -2,6 +2,10 @@ from unittest.mock import patch
 
 import pytest
 
+from backend.models.media import ImageFile, VideoFile
+
+MOCK_MEDIA_DIMENSIONS = {"width": 100, "height": 100}
+
 
 @pytest.fixture(autouse=True, scope="session")
 def image_thumbnail_generation_does_nothing():
@@ -15,3 +19,19 @@ def video_thumbnail_generation_does_nothing():
     with patch("backend.models.media.Video._request_thumbnail_generation") as mocked:
         mocked.return_value = None
         yield
+
+
+@pytest.fixture(autouse=True)
+def mock_get_video_dimensions(mocker):
+    mock_video_dimensions = mocker.patch.object(
+        VideoFile, "get_video_info", return_value=MOCK_MEDIA_DIMENSIONS
+    )
+    yield mock_video_dimensions
+
+
+@pytest.fixture(autouse=True)
+def mock_get_image_dimensions(mocker):
+    mock_image_dimensions = mocker.patch.object(
+        ImageFile, "get_image_dimensions", return_value=MOCK_MEDIA_DIMENSIONS
+    )
+    yield mock_image_dimensions

--- a/firstvoices/backend/tests/test_models/test_media_models.py
+++ b/firstvoices/backend/tests/test_models/test_media_models.py
@@ -50,11 +50,12 @@ class TestFileModels:
 
     @pytest.mark.django_db
     def test_videofile_generated_properties(self):
+        # Dimensions are from conftest.py/mock_get_video_dimensions
         site = factories.SiteFactory.create()
         instance = factories.VideoFileFactory.create(site=site)
         assert instance.mimetype == "video/mp4"
-        assert instance.height == 46
-        assert instance.width == 80
+        assert instance.height == 100
+        assert instance.width == 100
 
     @pytest.mark.parametrize("media_factory", file_model_factories)
     @pytest.mark.django_db

--- a/firstvoices/pytest.ini
+++ b/firstvoices/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
-addopts = --ds=firstvoices.settings_test --create-db
+addopts = --ds=firstvoices.settings_test --create-db -nauto
 python_files = tests.py test_*.py
+testpaths = backend/tests

--- a/requirements.debug.txt
+++ b/requirements.debug.txt
@@ -13,4 +13,4 @@ pylint-django==2.5.3  # https://github.com/PyCQA/pylint-django
 pre-commit==3.4.0  # https://github.com/pre-commit/pre-commit
 
 # Pytest --------------------------
-pytest-xdist
+pytest-xdist==3.3.1  # https://github.com/pytest-dev/pytest-xdist

--- a/requirements.debug.txt
+++ b/requirements.debug.txt
@@ -11,3 +11,6 @@ coverage==7.3.1  # https://github.com/nedbat/coveragepy
 black==23.7.0  # https://github.com/psf/black
 pylint-django==2.5.3  # https://github.com/PyCQA/pylint-django
 pre-commit==3.4.0  # https://github.com/pre-commit/pre-commit
+
+# Pytest --------------------------
+pytest-xdist


### PR DESCRIPTION
### Description of Changes
- Added pytest-xdist library which allows running tests in parallel reducing the run time from ~23 minutes to ~12 minutes.
- Mocked media dimensions which required ffmpeg before, this does not affect the test suite duration by much. 

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
