### PR TITLE
FW-4667 Parallel tests with github actions

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11.4"]
+        group: [1, 2, 3]
 
     services:
       postgres:
@@ -48,4 +49,4 @@ jobs:
           DB_USERNAME: ${{ secrets.DB_USERNAME }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
         run: |
-          pytest
+          pytest --splits 5 --group ${{ matrix.group }}

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11.4"]
-        group: [1, 2, 3]
+        group: [1, 2, 3, 4]
 
     services:
       postgres:

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -49,4 +49,4 @@ jobs:
           DB_USERNAME: ${{ secrets.DB_USERNAME }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
         run: |
-          pytest --splits 5 --group ${{ matrix.group }}
+          pytest --splits 4 --group ${{ matrix.group }}

--- a/requirements.debug.txt
+++ b/requirements.debug.txt
@@ -14,3 +14,4 @@ pre-commit==3.4.0  # https://github.com/pre-commit/pre-commit
 
 # Pytest --------------------------
 pytest-xdist==3.3.1  # https://github.com/pytest-dev/pytest-xdist
+pytest-split==0.8.1  # https://github.com/jerry-git/pytest-split


### PR DESCRIPTION
### Description of Changes
- Introduced a library called pytest-split, which splits tests into sub-groups.
- Modified workflow to run the above sub-groups in parallel. They are also divided internally into smaller subgroups to take advantage of more than 1 core if present.
- This brings down the time form ~12 minutes to ~6 minutes to run all the tests. 

### Checklist
- ~README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
