### PR TITLE
fw-4991, uids for song notes and acks

### DIFF
--- a/firstvoices/backend/serializers/base_serializers.py
+++ b/firstvoices/backend/serializers/base_serializers.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.core.exceptions import PermissionDenied
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
@@ -203,3 +205,11 @@ class WritableControlledSiteContentSerializer(
 
     class Meta(BaseControlledSiteContentSerializer.Meta):
         fields = BaseControlledSiteContentSerializer.Meta.fields
+
+
+class ArbitraryIdSerializer(serializers.CharField):
+    def to_representation(self, value):
+        return {
+            "id": str(uuid.uuid4()),  # better for frontend
+            "text": str(value),
+        }

--- a/firstvoices/backend/serializers/song_serializers.py
+++ b/firstvoices/backend/serializers/song_serializers.py
@@ -1,3 +1,4 @@
+from rest_framework import serializers
 from rest_framework.serializers import ModelSerializer
 
 from backend.models import Lyric, Song
@@ -8,7 +9,7 @@ from backend.serializers.base_serializers import (
     WritableVisibilityField,
     audience_fields,
     base_id_fields,
-    base_timestamp_fields,
+    base_timestamp_fields, ArbitraryIdSerializer,
 )
 from backend.serializers.media_serializers import (
     RelatedImageMinimalSerializer,
@@ -31,6 +32,10 @@ class SongSerializer(
     site = LinkedSiteSerializer(required=False, read_only=True)
     lyrics = LyricSerializer(many=True)
     visibility = WritableVisibilityField(required=True)
+    notes = serializers.ListField(child=ArbitraryIdSerializer(), required=False)
+    acknowledgements = serializers.ListField(
+        child=ArbitraryIdSerializer(), required=False
+    )
 
     def create(self, validated_data):
         lyrics = validated_data.pop("lyrics")

--- a/firstvoices/backend/serializers/story_serializers.py
+++ b/firstvoices/backend/serializers/story_serializers.py
@@ -1,5 +1,3 @@
-import uuid
-
 from rest_framework import serializers
 from rest_framework_nested.relations import NestedHyperlinkedIdentityField
 from rest_framework_nested.serializers import NestedHyperlinkedModelSerializer
@@ -14,7 +12,7 @@ from backend.serializers.base_serializers import (
     WritableVisibilityField,
     audience_fields,
     base_id_fields,
-    base_timestamp_fields,
+    base_timestamp_fields, ArbitraryIdSerializer,
 )
 from backend.serializers.media_serializers import (
     RelatedImageMinimalSerializer,
@@ -22,14 +20,6 @@ from backend.serializers.media_serializers import (
 )
 from backend.serializers.site_serializers import LinkedSiteSerializer
 from backend.serializers.utils import get_story_from_context
-
-
-class ArbitraryIdSerializer(serializers.CharField):
-    def to_representation(self, value):
-        return {
-            "id": str(uuid.uuid4()),  # better for frontend
-            "text": str(value),
-        }
 
 
 class LinkedStorySerializer(SiteContentLinkedTitleSerializer):

--- a/firstvoices/backend/tests/test_apis/test_song_api.py
+++ b/firstvoices/backend/tests/test_apis/test_song_api.py
@@ -5,7 +5,7 @@ import pytest
 from backend.models.constants import Role, Visibility
 from backend.tests import factories
 
-from ...models import Lyric, Song
+from backend.models.song import Lyric, Song
 from .base_api_test import BaseControlledSiteContentApiTest
 from .base_media_test import RelatedMediaTestMixin
 
@@ -241,13 +241,13 @@ class TestSongEndpoint(
             actual_response["visibility"]
             == original_instance.get_visibility_display().lower()
         )
-        assert actual_response["notes"][0] == original_instance.notes[0]
+        assert actual_response["notes"][0]["text"] == original_instance.notes[0]
         assert (
             actual_response["lyrics"][0]["text"]
             == original_instance.lyrics.first().text
         )
         assert (
-            actual_response["acknowledgements"][0]
+            actual_response["acknowledgements"][0]["text"]
             == original_instance.acknowledgements[0]
         )
 


### PR DESCRIPTION
### Description of Changes
* Add arbitrary uids to notes and acknowledgements in song apis, to match our other apis and make life easier for the frontend

### Checklist
- [ ] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
