### PR TITLE
FW-4973 admin performance improvements

### DIFF
--- a/firstvoices/backend/admin/app_admin.py
+++ b/firstvoices/backend/admin/app_admin.py
@@ -36,6 +36,10 @@ class AppMembershipAdmin(BaseAdmin):
         "role",
     )
 
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.select_related("user", "created_by", "last_modified_by")
+
 
 @admin.register(AppImportStatus)
 class AppImportStatusAdmin(BaseAdmin):

--- a/firstvoices/backend/admin/app_admin.py
+++ b/firstvoices/backend/admin/app_admin.py
@@ -35,6 +35,7 @@ class AppMembershipAdmin(BaseAdmin):
         "user__email",
         "role",
     )
+    autocomplete_fields = ("user",)
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)

--- a/firstvoices/backend/admin/dictionary_admin.py
+++ b/firstvoices/backend/admin/dictionary_admin.py
@@ -91,6 +91,7 @@ class WordOfTheDayInline(RelatedDictionaryEntryAdminMixin, BaseInlineSiteContent
         "dictionary_entry",
         "date",
     ) + BaseInlineAdmin.fields
+    autocomplete_fields = ("dictionary_entry",)
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         if db_field.name == "dictionary_entry":
@@ -111,7 +112,19 @@ class DictionaryEntryAdmin(BaseControlledSiteContentAdmin):
     ]
     list_display = ("title",) + BaseControlledSiteContentAdmin.list_display
     readonly_fields = ("custom_order",) + BaseControlledSiteContentAdmin.readonly_fields
-    filter_horizontal = ("related_audio", "related_images", "related_videos")
+    autocomplete_fields = ("related_audio", "related_images", "related_videos")
+    search_fields = (
+        "title",
+        "site__title",
+        "created_by__email",
+        "last_modified_by__email",
+    )
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.select_related(
+            "site", "created_by", "last_modified_by", "part_of_speech"
+        )
 
 
 @admin.register(PartOfSpeech)

--- a/firstvoices/backend/admin/dictionary_admin.py
+++ b/firstvoices/backend/admin/dictionary_admin.py
@@ -20,6 +20,7 @@ from .base_admin import (
     BaseControlledSiteContentAdmin,
     BaseInlineAdmin,
     BaseInlineSiteContentAdmin,
+    FilterAutocompleteBySiteMixin,
     HiddenBaseAdmin,
 )
 
@@ -102,7 +103,9 @@ class WordOfTheDayInline(RelatedDictionaryEntryAdminMixin, BaseInlineSiteContent
 
 
 @admin.register(DictionaryEntry)
-class DictionaryEntryAdmin(BaseControlledSiteContentAdmin):
+class DictionaryEntryAdmin(
+    FilterAutocompleteBySiteMixin, BaseControlledSiteContentAdmin
+):
     inlines = [
         TranslationInline,
         AlternateSpellingInline,
@@ -125,6 +128,17 @@ class DictionaryEntryAdmin(BaseControlledSiteContentAdmin):
         return qs.select_related(
             "site", "created_by", "last_modified_by", "part_of_speech"
         )
+
+    def get_search_results(
+        self, request, queryset, search_term, referer_models_list=None
+    ):
+        queryset, use_distinct = super().get_search_results(
+            request,
+            queryset,
+            search_term,
+            ["site", "character"],
+        )
+        return queryset, use_distinct
 
 
 @admin.register(PartOfSpeech)

--- a/firstvoices/backend/admin/media_admin.py
+++ b/firstvoices/backend/admin/media_admin.py
@@ -40,6 +40,7 @@ class VisualMediaFileAdmin(FileAdmin):
 class AudioAdmin(BaseSiteContentAdmin):
     list_display = ("title",) + BaseSiteContentAdmin.list_display
     search_fields = ("title",)
+    autocomplete_fields = ("original",)
 
     def delete_queryset(self, request, queryset):
         for obj in queryset.all():
@@ -56,6 +57,7 @@ class VisualMediaAdmin(BaseSiteContentAdmin):
     ) + BaseSiteContentAdmin.readonly_fields
     list_display = ("title",) + BaseSiteContentAdmin.list_display
     search_fields = ("title",)
+    autocomplete_fields = ("original",)
 
     def delete_queryset(self, request, queryset):
         for obj in queryset.all():

--- a/firstvoices/backend/admin/media_admin.py
+++ b/firstvoices/backend/admin/media_admin.py
@@ -70,7 +70,7 @@ class AudioAdmin(FilterAutocompleteBySiteMixin, BaseSiteContentAdmin):
             request,
             queryset,
             search_term,
-            ["site", "storypage", "song", "dictionaryentry"],
+            ["site", "storypage", "song", "dictionaryentry", "character", "story"],
         )
         return queryset, use_distinct
 
@@ -102,7 +102,15 @@ class VisualMediaAdmin(FilterAutocompleteBySiteMixin, BaseSiteContentAdmin):
             request,
             queryset,
             search_term,
-            ["site", "sitepage", "storypage", "song", "dictionaryentry"],
+            [
+                "site",
+                "sitepage",
+                "storypage",
+                "song",
+                "dictionaryentry",
+                "character",
+                "story",
+            ],
         )
         return queryset, use_distinct
 

--- a/firstvoices/backend/admin/media_admin.py
+++ b/firstvoices/backend/admin/media_admin.py
@@ -86,6 +86,15 @@ class EmbeddedVideoAdmin(BaseSiteContentAdmin, AdminVideoMixin):
 class AudioSpeakerAdmin(BaseAdmin):
     fields = ("audio", "speaker")
     list_display = ("audio", "speaker") + BaseAdmin.list_display
+    list_select_related = (
+        "audio",
+        "audio__site",
+        "speaker",
+        "speaker__site",
+        "created_by",
+        "last_modified_by",
+    )
+    autocomplete_fields = ("audio", "speaker")
 
 
 @admin.register(Person)

--- a/firstvoices/backend/admin/media_admin.py
+++ b/firstvoices/backend/admin/media_admin.py
@@ -3,6 +3,7 @@ from django.utils.html import format_html
 from embed_video.admin import AdminVideoMixin
 
 from backend.admin import BaseAdmin, BaseSiteContentAdmin, HiddenBaseAdmin
+from backend.admin.base_admin import FilterAutocompleteBySiteMixin
 from backend.models.media import (
     Audio,
     AudioSpeaker,
@@ -17,14 +18,26 @@ from backend.models.media import (
 
 
 @admin.register(File)
-class FileAdmin(HiddenBaseAdmin):
+class FileAdmin(FilterAutocompleteBySiteMixin, HiddenBaseAdmin):
     list_display = ("content", "mimetype") + HiddenBaseAdmin.list_display
     search_fields = ("content",)
     readonly_fields = ("mimetype", "size") + HiddenBaseAdmin.readonly_fields
 
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.select_related("site", "created_by", "last_modified_by")
+
     def delete_queryset(self, request, queryset):
         for obj in queryset.all():
             obj.delete()
+
+    def get_search_results(
+        self, request, queryset, search_term, referer_models_list=None
+    ):
+        queryset, use_distinct = super().get_search_results(
+            request, queryset, search_term, ["audio", "image", "video"]
+        )
+        return queryset, use_distinct
 
 
 @admin.register(ImageFile)
@@ -37,19 +50,34 @@ class VisualMediaFileAdmin(FileAdmin):
 
 
 @admin.register(Audio)
-class AudioAdmin(BaseSiteContentAdmin):
+class AudioAdmin(FilterAutocompleteBySiteMixin, BaseSiteContentAdmin):
     list_display = ("title",) + BaseSiteContentAdmin.list_display
-    search_fields = ("title",)
+    search_fields = ("title", "site__title")
     autocomplete_fields = ("original",)
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.select_related("site", "created_by", "last_modified_by")
 
     def delete_queryset(self, request, queryset):
         for obj in queryset.all():
             obj.delete()
 
+    def get_search_results(
+        self, request, queryset, search_term, referer_models_list=None
+    ):
+        queryset, use_distinct = super().get_search_results(
+            request,
+            queryset,
+            search_term,
+            ["site", "storypage", "song", "dictionaryentry"],
+        )
+        return queryset, use_distinct
+
 
 @admin.register(Image)
 @admin.register(Video)
-class VisualMediaAdmin(BaseSiteContentAdmin):
+class VisualMediaAdmin(FilterAutocompleteBySiteMixin, BaseSiteContentAdmin):
     readonly_fields = (
         "thumbnail",
         "small",
@@ -59,9 +87,24 @@ class VisualMediaAdmin(BaseSiteContentAdmin):
     search_fields = ("title",)
     autocomplete_fields = ("original",)
 
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.select_related("site", "created_by", "last_modified_by")
+
     def delete_queryset(self, request, queryset):
         for obj in queryset.all():
             obj.delete()
+
+    def get_search_results(
+        self, request, queryset, search_term, referer_models_list=None
+    ):
+        queryset, use_distinct = super().get_search_results(
+            request,
+            queryset,
+            search_term,
+            ["site", "sitepage", "storypage", "song", "dictionaryentry"],
+        )
+        return queryset, use_distinct
 
 
 @admin.register(EmbeddedVideo)

--- a/firstvoices/backend/admin/sites_admin.py
+++ b/firstvoices/backend/admin/sites_admin.py
@@ -56,10 +56,7 @@ class MembershipAdmin(BaseSiteContentAdmin):
         "site__title",
     )
     list_filter = ("role",) + BaseSiteContentAdmin.list_filter
-
-    def get_queryset(self, request):
-        qs = super().get_queryset(request)
-        return qs.select_related("user")
+    list_select_related = ("user", "site", "created_by", "last_modified_by")
 
 
 @admin.register(SiteFeature)
@@ -95,6 +92,10 @@ class MembershipInline(BaseInlineSiteContentAdmin):
     readonly_fields = (
         ("user",) + BaseInlineAdmin.readonly_fields + MembershipAdmin.readonly_fields
     )
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request).select_related("user")
+        return qs
 
 
 class SiteFeatureInline(BaseInlineAdmin):

--- a/firstvoices/backend/admin/sites_admin.py
+++ b/firstvoices/backend/admin/sites_admin.py
@@ -45,6 +45,10 @@ class LanguageAdmin(BaseAdmin):
     )
     autocomplete_fields = ("language_family",)
 
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.select_related("language_family", "created_by", "last_modified_by")
+
 
 @admin.register(Membership)
 class MembershipAdmin(BaseSiteContentAdmin):

--- a/firstvoices/backend/admin/sites_admin.py
+++ b/firstvoices/backend/admin/sites_admin.py
@@ -61,6 +61,7 @@ class MembershipAdmin(BaseSiteContentAdmin):
     )
     list_filter = ("role",) + BaseSiteContentAdmin.list_filter
     list_select_related = ("user", "site", "created_by", "last_modified_by")
+    autocomplete_fields = ("user", "site")
 
 
 @admin.register(SiteFeature)

--- a/firstvoices/backend/admin/songs_admin.py
+++ b/firstvoices/backend/admin/songs_admin.py
@@ -17,4 +17,9 @@ class LyricAdmin(BaseInlineAdmin):
 class SongAdmin(BaseSiteContentAdmin, DynamicArrayMixin):
     list_display = ("title",) + BaseSiteContentAdmin.list_display
     inlines = [LyricAdmin]
-    filter_horizontal = ("related_audio", "related_images", "related_videos")
+    autocomplete_fields = ("related_audio", "related_images", "related_videos")
+    search_fields = ("title", "id")
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.select_related("site", "created_by", "last_modified_by")

--- a/firstvoices/backend/admin/story_admin.py
+++ b/firstvoices/backend/admin/story_admin.py
@@ -29,15 +29,21 @@ class StoryPageInlineAdmin(BaseInlineSiteContentAdmin, DynamicArrayMixin):
 class StoryPageAdmin(BaseSiteContentAdmin):
     list_display = ("story", "ordering") + BaseSiteContentAdmin.list_display
     list_select_related = ["story"] + BaseSiteContentAdmin.list_select_related
-    filter_horizontal = ("related_audio", "related_images", "related_videos")
+    autocomplete_fields = ("related_audio", "related_images", "related_videos")
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.select_related("story", "site", "created_by", "last_modified_by")
 
 
 @admin.register(Story)
 class StoryAdmin(BaseSiteContentAdmin):
     list_display = ("title",) + BaseSiteContentAdmin.list_display
     inlines = [StoryPageInlineAdmin]
-    filter_horizontal = ("related_audio", "related_images", "related_videos")
+    autocomplete_fields = ("related_audio", "related_images", "related_videos")
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
-        return qs.prefetch_related("pages")
+        return qs.select_related(
+            "site", "created_by", "last_modified_by"
+        ).prefetch_related("pages")

--- a/firstvoices/backend/admin/widget_admin.py
+++ b/firstvoices/backend/admin/widget_admin.py
@@ -42,7 +42,9 @@ class WidgetAdmin(BaseAdmin):
 
 
 @admin.register(SiteWidget)
-class SiteWidgetAdmin(WidgetAdmin, BaseControlledSiteContentAdmin):
+class SiteWidgetAdmin(
+    FilterAutocompleteBySiteMixin, WidgetAdmin, BaseControlledSiteContentAdmin
+):
     def get_queryset(self, request):
         return SiteWidget.objects.all()
 
@@ -59,6 +61,14 @@ class SiteWidgetAdmin(WidgetAdmin, BaseControlledSiteContentAdmin):
     )
     inlines = [WidgetSettingsInline]
 
+    def get_search_results(
+        self, request, queryset, search_term, referer_models_list=None
+    ):
+        queryset, use_distinct = super().get_search_results(
+            request, queryset, search_term, ["sitewidgetlist"]
+        )
+        return queryset, use_distinct
+
 
 class SiteWidgetListOrderInline(BaseInlineAdmin):
     model = SiteWidgetListOrder
@@ -67,6 +77,7 @@ class SiteWidgetListOrderInline(BaseInlineAdmin):
         "order",
     ) + BaseInlineAdmin.fields
     readonly_fields = BaseInlineAdmin.readonly_fields
+    autocomplete_fields = ("site_widget",)
 
 
 @admin.register(SiteWidgetList)

--- a/firstvoices/backend/admin/widget_admin.py
+++ b/firstvoices/backend/admin/widget_admin.py
@@ -5,6 +5,7 @@ from backend.admin.base_admin import (
     BaseControlledSiteContentAdmin,
     BaseInlineAdmin,
     BaseSiteContentAdmin,
+    FilterAutocompleteBySiteMixin,
     HiddenBaseAdmin,
 )
 from backend.models.widget import (
@@ -69,7 +70,7 @@ class SiteWidgetListOrderInline(BaseInlineAdmin):
 
 
 @admin.register(SiteWidgetList)
-class SiteWidgetListAdmin(BaseSiteContentAdmin):
+class SiteWidgetListAdmin(FilterAutocompleteBySiteMixin, BaseSiteContentAdmin):
     list_display = ("__str__",) + BaseSiteContentAdmin.list_display
     fields = (
         "site",
@@ -85,6 +86,18 @@ class SiteWidgetListAdmin(BaseSiteContentAdmin):
         "site__title",
     ) + BaseSiteContentAdmin.search_fields
     inlines = [SiteWidgetListOrderInline]
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.select_related("site", "created_by", "last_modified_by")
+
+    def get_search_results(
+        self, request, queryset, search_term, referer_models_list=None
+    ):
+        queryset, use_distinct = super().get_search_results(
+            request, queryset, search_term, ["site", "sitepage"]
+        )
+        return queryset, use_distinct
 
 
 class HiddenSiteWidgetListOrder(HiddenBaseAdmin):


### PR DESCRIPTION
### Description of Changes
This PR contains a large number of admin site performance improvements. 

Notably, the related media selectors have been updated to use `autocomplete_fields` instead of `filter_horizontal`. The `autocomplete_fields` selector has a filterable dropdown that is automatically paginated instead of loading all possible entries. A mixin has been added to `base_admin.py` which allows these `autocomplete_fields` to be auto-filtered, (using `get_search_results`), by site as needed.

Additional queryset `select_related` and `prefetch_related` calls have been added as needed.

Also added autocomplete fields to membership/app membership create/edit (to make it easy to search through long lists).

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~
- [x] Admin Panel has been updated if models have been added or modified
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [x] Pull the branch and test locally

### Additional Notes
If reviewing, please test the admin site locally for correct default site filtering on autocomplete fields and improved performance.
