### PR TITLE
FW-4992 postgres-document-id replaced by es-document-id in search responses

### DIFF
--- a/firstvoices/backend/search/utils/object_utils.py
+++ b/firstvoices/backend/search/utils/object_utils.py
@@ -115,7 +115,7 @@ def hydrate_objects(search_results, request):
                 # Serializing and adding the object to complete_objects
                 complete_objects.append(
                     {
-                        "searchResultId": obj["_source"]["document_id"],
+                        "searchResultId": obj["_id"],
                         "score": obj["_score"],
                         "type": dictionary_entry.type.lower(),  # 'word' or 'phrase' instead of 'dictionary_entry'
                         "entry": DictionaryEntryMinimalSerializer(
@@ -130,7 +130,7 @@ def hydrate_objects(search_results, request):
                 # Serializing and adding the object to complete_objects
                 complete_objects.append(
                     {
-                        "searchResultId": obj["_source"]["document_id"],
+                        "searchResultId": obj["_id"],
                         "score": obj["_score"],
                         "type": "song",
                         "entry": SongMinimalSerializer(
@@ -145,7 +145,7 @@ def hydrate_objects(search_results, request):
                 # Serializing and adding the object to complete_objects
                 complete_objects.append(
                     {
-                        "searchResultId": obj["_source"]["document_id"],
+                        "searchResultId": obj["_id"],
                         "score": obj["_score"],
                         "type": "story",
                         "entry": StoryMinimalSerializer(

--- a/firstvoices/backend/views/search/base_search_views.py
+++ b/firstvoices/backend/views/search/base_search_views.py
@@ -29,7 +29,7 @@ from backend.views.exceptions import ElasticSearchConnectionError
             200: inline_serializer(
                 name="SearchResults",
                 fields={
-                    "id": serializers.CharField(),
+                    "searchResultId": serializers.CharField(),
                     "score": serializers.FloatField(),
                     "type": serializers.ChoiceField(
                         choices=SearchIndexEntryTypes.choices


### PR DESCRIPTION
### Description of Changes
postgres-document-id replaced by es-document-id in search responses top level "id" field.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
