### PR TITLE
FW-4873 Enhance Story update/patch API with page order editing

### DIFF
--- a/firstvoices/backend/serializers/story_serializers.py
+++ b/firstvoices/backend/serializers/story_serializers.py
@@ -147,6 +147,13 @@ class StoryDetailUpdateSerializer(StorySerializer):
                 existing_pages = instance.pages.all()
                 temp_story = Story.objects.create(site=instance.site)
 
+                # Ensure that all updated pages belong to the story
+                for page in updated_pages:
+                    if page not in existing_pages:
+                        raise serializers.ValidationError(
+                            f"Page with ID {page.id} does not belong to the story."
+                        )
+
                 # Get the intersection of the existing and updated pages
                 new_pages = [
                     page for page in updated_pages if page in set(existing_pages)

--- a/firstvoices/backend/tests/test_apis/test_story_api.py
+++ b/firstvoices/backend/tests/test_apis/test_story_api.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from backend.models.constants import Role, Visibility
-from backend.models.story import Story
+from backend.models.story import Story, StoryPage
 from backend.tests import factories
 
 from .base_api_test import BaseControlledSiteContentApiTest
@@ -47,6 +47,7 @@ class TestStoryEndpoint(
             "introductionTranslation": "A translation of the introduction",
             "notes": [{"id": 1, "text": "Test Note One"}, {"id": "5", "text": "Test Note Two"}, {"id": "2", "text": "Test Note Three"}],
             "acknowledgements": [{"id": "5", "text": "Test Author"}, {"id": "51", "text": "Another Acknowledgement"}],
+            "pages": [],
             "excludeFromGames": True,
             "excludeFromKids": False,
             "author": "Dr. Author",
@@ -255,3 +256,67 @@ class TestStoryEndpoint(
         response_data = json.loads(response.content)
         assert response_data["pages"][0]["text"] == page1.text
         assert response_data["pages"][1]["text"] == page2.text
+
+    @pytest.mark.django_db
+    def test_update_page_order(self):
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+
+        user = factories.get_non_member_user()
+        factories.MembershipFactory.create(user=user, site=site, role=Role.ASSISTANT)
+        self.client.force_authenticate(user=user)
+
+        story = factories.StoryFactory.create(visibility=Visibility.TEAM, site=site)
+
+        page1 = factories.StoryPageFactory.create(story=story, ordering=0)
+        page2 = factories.StoryPageFactory.create(story=story, ordering=1)
+
+        assert Story.objects.filter(site=site).count() == 1
+        assert StoryPage.objects.all().count() == 2
+        assert StoryPage.objects.filter(story=story).count() == 2
+        assert StoryPage.objects.get(id=page1.id).ordering == 0
+        assert StoryPage.objects.get(id=page2.id).ordering == 1
+
+        response = self.client.get(
+            self.get_detail_endpoint(key=story.id, site_slug=site.slug)
+        )
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+        assert response_data["pages"][0]["text"] == page1.text
+        assert response_data["pages"][1]["text"] == page2.text
+
+        data = {
+            "title": story.title,
+            "visibility": story.get_visibility_display(),
+            "author": "",
+            "title_translation": "",
+            "introduction": "",
+            "introduction_translation": "",
+            "notes": [],
+            "pages": [str(page2.id), str(page1.id)],
+            "acknowledgements": [],
+            "hide_overlay": False,
+            "exclude_from_games": False,
+            "exclude_from_kids": False,
+            "related_audio": [],
+            "related_images": [],
+            "related_videos": [],
+        }
+
+        response = self.client.put(
+            self.get_detail_endpoint(key=story.id, site_slug=site.slug),
+            data=json.dumps(data),
+            content_type=self.content_type,
+        )
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+
+        assert Story.objects.filter(site=site).count() == 1
+        assert StoryPage.objects.all().count() == 2
+        assert StoryPage.objects.filter(story=story).count() == 2
+        assert StoryPage.objects.get(id=page1.id).ordering == 1
+        assert StoryPage.objects.get(id=page2.id).ordering == 0
+
+        assert response_data["pages"][0]["text"] == page2.text
+        assert response_data["pages"][1]["text"] == page1.text

--- a/firstvoices/backend/tests/test_apis/test_story_api.py
+++ b/firstvoices/backend/tests/test_apis/test_story_api.py
@@ -440,3 +440,53 @@ class TestStoryEndpoint(
         assert StoryPage.objects.get(id=page2.id).ordering == 0
 
         assert response_data["pages"][0]["text"] == page2.text
+
+    @pytest.mark.django_db
+    def test_update_page_order_wrong_story(self):
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+
+        user = factories.get_non_member_user()
+        factories.MembershipFactory.create(
+            user=user, site=site, role=Role.LANGUAGE_ADMIN
+        )
+        self.client.force_authenticate(user=user)
+
+        story_one = factories.StoryFactory.create(
+            visibility=Visibility.PUBLIC, site=site
+        )
+        story_two = factories.StoryFactory.create(
+            visibility=Visibility.PUBLIC, site=site
+        )
+
+        page1 = factories.StoryPageFactory.create(
+            visibility=Visibility.PUBLIC, story=story_one, ordering=0
+        )
+        page2 = factories.StoryPageFactory.create(
+            visibility=Visibility.PUBLIC, story=story_two, ordering=1
+        )
+
+        assert Story.objects.filter(site=site).count() == 2
+        assert StoryPage.objects.all().count() == 2
+        assert StoryPage.objects.filter(story=story_one).count() == 1
+        assert StoryPage.objects.get(id=page1.id).ordering == 0
+        assert StoryPage.objects.get(id=page1.id).story == story_one
+
+        data = {"pages": [str(page2.id), str(page1.id)]}
+
+        response = self.client.patch(
+            self.get_detail_endpoint(key=story_one.id, site_slug=site.slug),
+            data=json.dumps(data),
+            content_type=self.content_type,
+        )
+
+        assert response.status_code == 400
+        response_data = json.loads(response.content)
+
+        assert (
+            response_data[0] == f"Page with ID {page2.id} does not belong to the story."
+        )
+        assert Story.objects.filter(site=site).count() == 2
+        assert StoryPage.objects.all().count() == 2
+        assert StoryPage.objects.filter(story=story_one).count() == 1
+        assert StoryPage.objects.get(id=page1.id).ordering == 0
+        assert StoryPage.objects.get(id=page1.id).story == story_one

--- a/firstvoices/backend/views/story_views.py
+++ b/firstvoices/backend/views/story_views.py
@@ -4,7 +4,11 @@ from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_
 from rest_framework.viewsets import ModelViewSet
 
 from backend.models import Story, StoryPage
-from backend.serializers.story_serializers import StoryListSerializer, StorySerializer
+from backend.serializers.story_serializers import (
+    StoryDetailUpdateSerializer,
+    StoryListSerializer,
+    StorySerializer,
+)
 from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSetMixin
 
 from . import doc_strings
@@ -133,5 +137,7 @@ class StoryViewSet(SiteContentViewSetMixin, FVPermissionViewSetMixin, ModelViewS
     def get_serializer_class(self):
         if self.action in ("list",):
             return StoryListSerializer
+        elif self.action in ("update", "partial_update"):
+            return StoryDetailUpdateSerializer
         else:
             return StorySerializer


### PR DESCRIPTION
### Description of Changes
This PR adds the ability to update page ordering in the Story update/patch APIs. The endpoints can be passed a "pages" field containing a list of page IDs in the desired order.

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
Note to @gmcauliffe and @Cara-Barter this will break any places on the frontend where the story update endpoint is used. A list of story page IDs will now need to be passed.
