### PR TITLE
FW-4995 Add command to convert lyric draftjs to plain text

### DIFF
--- a/firstvoices/backend/management/commands/convert_lyrics_draftjs_to_text.py
+++ b/firstvoices/backend/management/commands/convert_lyrics_draftjs_to_text.py
@@ -35,10 +35,4 @@ def lyric_draftjs_to_text():
 
 
 def extract_plain_text(draftjs):
-    plain_text = ""
-    for index, block in enumerate(draftjs["blocks"]):
-        if block["text"] != "":
-            plain_text += block["text"]
-        if index != len(draftjs["blocks"]) - 1:
-            plain_text += delimiter
-    return plain_text
+    return delimiter.join([block["text"] for block in draftjs["blocks"]])

--- a/firstvoices/backend/management/commands/convert_lyrics_draftjs_to_text.py
+++ b/firstvoices/backend/management/commands/convert_lyrics_draftjs_to_text.py
@@ -1,0 +1,44 @@
+import json
+from json import JSONDecodeError
+
+from django.core.management import BaseCommand
+
+from backend.models import Lyric
+
+delimiter = "\n"
+
+
+class Command(BaseCommand):
+    def handle(self, **options):
+        lyric_draftjs_to_text()
+
+
+def lyric_draftjs_to_text():
+    lyric_text_list = Lyric.objects.exclude(text__exact="")
+    lyric_translation_list = Lyric.objects.exclude(translation__exact="")
+
+    for lyric in lyric_text_list:
+        try:
+            new_lyric_text = extract_plain_text(json.loads(lyric.text))
+            lyric.text = new_lyric_text
+            lyric.save()
+        except JSONDecodeError:
+            continue
+
+    for lyric in lyric_translation_list:
+        try:
+            new_lyric_translation = extract_plain_text(json.loads(lyric.translation))
+            lyric.translation = new_lyric_translation
+            lyric.save()
+        except JSONDecodeError:
+            continue
+
+
+def extract_plain_text(draftjs):
+    plain_text = ""
+    for index, block in enumerate(draftjs["blocks"]):
+        if block["text"] != "":
+            plain_text += block["text"]
+        if index != len(draftjs["blocks"]) - 1:
+            plain_text += delimiter
+    return plain_text

--- a/firstvoices/backend/tests/test_commands/__init__.py
+++ b/firstvoices/backend/tests/test_commands/__init__.py
@@ -1,0 +1,1 @@
+from . import test_convert_lyrics_draftjs_to_text  # noqa F401

--- a/firstvoices/backend/tests/test_commands/test_convert_lyrics_draftjs_to_text.py
+++ b/firstvoices/backend/tests/test_commands/test_convert_lyrics_draftjs_to_text.py
@@ -1,0 +1,87 @@
+import pytest
+
+from backend.management.commands import convert_lyrics_draftjs_to_text
+from backend.models import Lyric
+from backend.tests import factories
+
+
+class TestConvertLyricsDraftjsToText:
+    @pytest.mark.django_db
+    def test_lyric_text(self):
+        existing_text = """{
+                          "entityMap": {},
+                          "blocks": [
+                            {
+                              "key": "",
+                              "text": "test line one",
+                              "type": "unstyled",
+                              "depth": 0,
+                              "inlineStyleRanges": [],
+                              "entityRanges": [],
+                              "data": {}
+                            },
+                            {
+                              "key": "",
+                              "text": "test line two",
+                              "type": "unstyled",
+                              "depth": 0,
+                              "inlineStyleRanges": [],
+                              "entityRanges": [],
+                              "data": {}
+                            }
+                          ]
+                        }"""
+        factories.LyricsFactory.create(text=existing_text)
+
+        assert Lyric.objects.count() == 1
+
+        convert_lyrics_draftjs_to_text.lyric_draftjs_to_text()
+
+        assert Lyric.objects.count() == 1
+        assert Lyric.objects.first().text == "test line one\ntest line two"
+
+    @pytest.mark.django_db
+    def test_lyric_translation(self):
+        existing_translation = """{
+                  "entityMap": {},
+                  "blocks": [
+                    {
+                      "key": "",
+                      "text": "test line one",
+                      "type": "unstyled",
+                      "depth": 0,
+                      "inlineStyleRanges": [],
+                      "entityRanges": [],
+                      "data": {}
+                    },
+                    {
+                      "key": "",
+                      "text": "test line two",
+                      "type": "unstyled",
+                      "depth": 0,
+                      "inlineStyleRanges": [],
+                      "entityRanges": [],
+                      "data": {}
+                    }
+                  ]
+                }"""
+        factories.LyricsFactory.create(translation=existing_translation)
+
+        assert Lyric.objects.count() == 1
+
+        convert_lyrics_draftjs_to_text.lyric_draftjs_to_text()
+
+        assert Lyric.objects.count() == 1
+        assert Lyric.objects.first().translation == "test line one\ntest line two"
+
+    @pytest.mark.django_db
+    def test_lyric_unchanged(self):
+        existing_text = "already plain text"
+        factories.LyricsFactory.create(text=existing_text)
+
+        assert Lyric.objects.count() == 1
+
+        convert_lyrics_draftjs_to_text.lyric_draftjs_to_text()
+
+        assert Lyric.objects.count() == 1
+        assert Lyric.objects.first().text == existing_text


### PR DESCRIPTION
### Description of Changes
This PR adds a command to convert all lyric text and lyric translations from draftjs to plain text. The command can be run in the shell as follows: `python manage.py convert_lyrics_draftjs_to_text`.

The script will iterate over all lyrics that don't contain an empty `text` field or an empty `translation` field. If either of those fields contain a draftjs string then the blocks in the draftjs will be looped over. Each text field within the blocks will be pulled out and combined into a single string with a newline delimiter separating each.

For example, a text field containing the following draftjs string:
```
{
  "entityMap": {},
  "blocks": [
    {
      "key": "",
      "text": "Test line one",
      "type": "unstyled",
      "depth": 0,
      "inlineStyleRanges": [],
      "entityRanges": [],
      "data": {}
    },
    {
      "key": "",
      "text": "Test line two",
      "type": "unstyled",
      "depth": 0,
      "inlineStyleRanges": [],
      "entityRanges": [],
      "data": {}
    }
  ]
}
```
will be converted to the following string:
```
Test line one\nTest line two
```

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [x] Pull the branch and test locally

### Additional Notes
N/A
