### PR TITLE
Fw-4845, allow nulls for optional fields

### DIFF
--- a/firstvoices/backend/serializers/dictionary_serializers.py
+++ b/firstvoices/backend/serializers/dictionary_serializers.py
@@ -129,21 +129,27 @@ class DictionaryEntryDetailSerializer(
         many=True,
         required=False,
         source="acknowledgement_set",
+        default=[]
     )
     alternate_spellings = AlternateSpellingSerializer(
-        many=True, required=False, source="alternatespelling_set"
+        many=True, required=False, source="alternatespelling_set",
+        default=[]
     )
-    notes = NoteSerializer(many=True, required=False, source="note_set")
+    notes = NoteSerializer(many=True, required=False, source="note_set",
+        default=[])
     translations = TranslationSerializer(
-        many=True, required=False, source="translation_set"
+        many=True, required=False, source="translation_set",
+        default=[]
     )
     part_of_speech = WritablePartsOfSpeechSerializer(
         queryset=part_of_speech.PartOfSpeech.objects.all(),
         required=False,
         allow_null=True,
+        default=None
     )
     pronunciations = PronunciationSerializer(
-        many=True, required=False, source="pronunciation_set"
+        many=True, required=False, source="pronunciation_set",
+        default=[]
     )
 
     logger = logging.getLogger(__name__)

--- a/firstvoices/backend/serializers/fields.py
+++ b/firstvoices/backend/serializers/fields.py
@@ -87,10 +87,3 @@ class WritableVisibilityField(serializers.CharField):
             return visibility_map[value].lower()
         except KeyError:
             raise serializers.ValidationError("Invalid visibility value.")
-
-
-class NullableCharField(serializers.CharField):
-    def validate_empty_values(self, data):
-        if data is None:
-            data = ""
-        return super().validate_empty_values(data)

--- a/firstvoices/backend/serializers/page_serializers.py
+++ b/firstvoices/backend/serializers/page_serializers.py
@@ -8,7 +8,7 @@ from backend.serializers.base_serializers import (
     BaseControlledSiteContentSerializer,
     WritableControlledSiteContentSerializer,
 )
-from backend.serializers.fields import NullableCharField, SiteHyperlinkedIdentityField
+from backend.serializers.fields import SiteHyperlinkedIdentityField
 from backend.serializers.media_serializers import ImageSerializer, VideoSerializer
 from backend.serializers.utils import get_site_from_context
 from backend.serializers.validators import SameSite
@@ -23,7 +23,7 @@ class SitePageSerializer(
     )
 
     slug = serializers.CharField(required=False)
-    subtitle = NullableCharField(required=False)
+    subtitle = serializers.CharField(required=False)
 
     class Meta:
         model = SitePage
@@ -49,22 +49,25 @@ class SitePageDetailSerializer(SitePageSerializer):
 
 class SitePageDetailWriteSerializer(WritableControlledSiteContentSerializer):
     slug = serializers.CharField(required=False)
-    subtitle = NullableCharField(required=False)
+    subtitle = serializers.CharField(required=False)
     widgets = serializers.PrimaryKeyRelatedField(
         queryset=SiteWidget.objects.all(),
         allow_null=True,
         many=True,
         validators=[SameSite()],
+        required=False,
     )
     banner_image = serializers.PrimaryKeyRelatedField(
         queryset=Image.objects.all(),
         allow_null=True,
         validators=[SameSite()],
+        required=False,
     )
     banner_video = serializers.PrimaryKeyRelatedField(
         queryset=Video.objects.all(),
         allow_null=True,
         validators=[SameSite()],
+        required=False,
     )
 
     def to_representation(self, instance):

--- a/firstvoices/backend/serializers/song_serializers.py
+++ b/firstvoices/backend/serializers/song_serializers.py
@@ -30,8 +30,14 @@ class SongSerializer(
     WritableControlledSiteContentSerializer,
 ):
     site = LinkedSiteSerializer(required=False, read_only=True)
-    lyrics = LyricSerializer(many=True)
     visibility = WritableVisibilityField(required=True)
+
+    title_translation = serializers.CharField(required=False, allow_blank=True, default="")
+    introduction = serializers.CharField(required=False, allow_blank=True, default="")
+    introduction_translation = serializers.CharField(required=False, allow_blank=True, default="")
+
+    lyrics = LyricSerializer(many=True)
+
     notes = serializers.ListField(child=ArbitraryIdSerializer(), required=False)
     acknowledgements = serializers.ListField(
         child=ArbitraryIdSerializer(), required=False

--- a/firstvoices/backend/serializers/story_serializers.py
+++ b/firstvoices/backend/serializers/story_serializers.py
@@ -65,6 +65,8 @@ class StoryPageDetailSerializer(
     story = LinkedStorySerializer(read_only=True)
     site = LinkedSiteSerializer(read_only=True)
 
+    translation = serializers.CharField(required=False, allow_blank=True, default="")
+
     class Meta(StoryPageSummarySerializer.Meta):
         fields = (
             base_timestamp_fields
@@ -97,8 +99,14 @@ class StorySerializer(
     WritableControlledSiteContentSerializer,
 ):
     site = LinkedSiteSerializer(required=False, read_only=True)
-    pages = StoryPageSummarySerializer(many=True, read_only=True)
     visibility = WritableVisibilityField(required=True)
+
+    title_translation = serializers.CharField(required=False, allow_blank=True, default="")
+    introduction = serializers.CharField(required=False, allow_blank=True, default="")
+    introduction_translation = serializers.CharField(required=False, allow_blank=True, default="")
+
+    pages = StoryPageSummarySerializer(many=True, read_only=True)
+
     notes = serializers.ListField(child=ArbitraryIdSerializer(), required=False)
     acknowledgements = serializers.ListField(
         child=ArbitraryIdSerializer(), required=False

--- a/firstvoices/backend/serializers/widget_serializers.py
+++ b/firstvoices/backend/serializers/widget_serializers.py
@@ -56,7 +56,7 @@ class SiteWidgetDetailSerializer(
         )
 
     def create(self, validated_data):
-        settings = validated_data.pop("widgetsettings_set")
+        settings = validated_data.pop("widgetsettings_set") if "widgetsettings_set" in validated_data else []
         validated_data["format"] = WidgetFormats[
             str.upper(validated_data.pop("get_format_display"))
         ]

--- a/firstvoices/backend/serializers/widget_serializers.py
+++ b/firstvoices/backend/serializers/widget_serializers.py
@@ -130,12 +130,13 @@ class SiteWidgetListSerializer(serializers.ModelSerializer, UpdateSerializerMixi
         new_site_widget_list = SiteWidgetList.objects.create(site=site)
 
         # Create new SiteWidgetListOrder objects for each widget in the validated data.
-        SiteWidgetListSerializer.create_site_widget_list_order_instances(
-            validated_data["widgets"],
-            new_site_widget_list,
-            self.context["request"].user,
-            site,
-        )
+        if "widgets" in validated_data:
+            SiteWidgetListSerializer.create_site_widget_list_order_instances(
+                validated_data["widgets"],
+                new_site_widget_list,
+                self.context["request"].user,
+                site,
+            )
 
         validated_data["widgets"] = new_site_widget_list
 
@@ -152,11 +153,12 @@ class SiteWidgetListSerializer(serializers.ModelSerializer, UpdateSerializerMixi
             item.delete()
 
         # Create new SiteWidgetListOrder objects for each widget in the validated data.
-        SiteWidgetListSerializer.create_site_widget_list_order_instances(
-            validated_data["widgets"],
-            new_site_widget_list,
-            self.context["request"].user,
-            site,
-        )
+        if "widgets" in validated_data:
+            SiteWidgetListSerializer.create_site_widget_list_order_instances(
+                validated_data["widgets"],
+                new_site_widget_list,
+                self.context["request"].user,
+                site,
+            )
 
         return SiteWidgetList.objects.get(id=instance.id)

--- a/firstvoices/backend/tests/factories/dictionary_entry.py
+++ b/firstvoices/backend/tests/factories/dictionary_entry.py
@@ -1,8 +1,18 @@
 import factory
+from factory.django import DjangoModelFactory
 
-from backend.models import DictionaryEntry
-from backend.tests.factories import RelatedMediaBaseFactory
+from backend.models import DictionaryEntry, PartOfSpeech
+from backend.tests.factories import RelatedMediaBaseFactory, UserFactory
 from backend.tests.factories.access import SiteFactory, UserFactory
+
+
+class PartOfSpeechFactory(DjangoModelFactory):
+    class Meta:
+        model = PartOfSpeech
+
+    title = factory.Sequence(lambda n: "Part of Speech %03d" % n)
+    created_by = factory.SubFactory(UserFactory)
+    last_modified_by = factory.SubFactory(UserFactory)
 
 
 class DictionaryEntryFactory(RelatedMediaBaseFactory):
@@ -14,3 +24,6 @@ class DictionaryEntryFactory(RelatedMediaBaseFactory):
     site = factory.SubFactory(SiteFactory)
     title = factory.Sequence(lambda n: "Dictionary entry %03d" % n)
     custom_order = factory.Sequence(lambda n: "sort order %03d" % n)
+    part_of_speech = factory.SubFactory(PartOfSpeechFactory)
+
+

--- a/firstvoices/backend/tests/factories/dictionary_factories.py
+++ b/firstvoices/backend/tests/factories/dictionary_factories.py
@@ -2,7 +2,7 @@ import factory
 from django.utils.timezone import datetime
 from factory.django import DjangoModelFactory
 
-from backend.models import PartOfSpeech, dictionary
+from backend.models import dictionary
 from backend.tests.factories.access import SiteFactory, UserFactory
 from backend.tests.factories.character_factories import CharacterFactory
 from backend.tests.factories.dictionary_entry import DictionaryEntryFactory
@@ -10,6 +10,7 @@ from backend.tests.factories.dictionary_entry import DictionaryEntryFactory
 
 class DictionaryModelFactory(DjangoModelFactory):
     dictionary_entry = factory.SubFactory(DictionaryEntryFactory)
+    text = factory.Sequence(lambda n: "Sample text %03d" % n)
 
 
 class AcknowledgementFactory(DictionaryModelFactory):
@@ -69,15 +70,6 @@ class DictionaryEntryRelatedCharacterFactory(DjangoModelFactory):
 
     dictionary_entry = factory.SubFactory(DictionaryEntryFactory)
     character = factory.SubFactory(CharacterFactory)
-
-
-class PartOfSpeechFactory(DjangoModelFactory):
-    class Meta:
-        model = PartOfSpeech
-
-    title = factory.Sequence(lambda n: "Part of Speech %03d" % n)
-    created_by = factory.SubFactory(UserFactory)
-    last_modified_by = factory.SubFactory(UserFactory)
 
 
 class WordOfTheDayFactory(DjangoModelFactory):

--- a/firstvoices/backend/tests/test_apis/base_media_test.py
+++ b/firstvoices/backend/tests/test_apis/base_media_test.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import sys
@@ -259,6 +260,24 @@ class BaseMediaApiTest(
             "original": self.get_sample_file(
                 self.sample_filename, self.sample_filetype
             ),
+        }
+
+    def get_valid_data_with_nulls(self, site=None):
+        return {
+            "title": "A title for the media",
+            "original": self.get_sample_file(
+                self.sample_filename, self.sample_filetype
+            ),
+        }
+
+    def add_expected_defaults(self, data):
+        return {
+            **data,
+            "description": "",
+            "acknowledgement": "",
+            "isShared": False,
+            "excludeFromGames": False,
+            "excludeFromKids": False,
         }
 
     def assert_created_instance(self, pk, data):

--- a/firstvoices/backend/tests/test_apis/test_category_api.py
+++ b/firstvoices/backend/tests/test_apis/test_category_api.py
@@ -1,3 +1,4 @@
+import copy
 import json
 
 import pytest
@@ -57,15 +58,33 @@ class TestCategoryEndpoints(BaseUncontrolledSiteContentApiTest):
             "parent_id": str(parent.id),
         }
 
+    def get_valid_data_with_nulls(self, site=None):
+        return {
+            "title": "Cool new title",
+        }
+
+    def add_expected_defaults(self, data):
+        return {
+            **data,
+            "parent": None,
+            "description": ""
+        }
+
     def assert_updated_instance(self, expected_data, actual_instance):
         assert actual_instance.title == expected_data["title"]
         assert actual_instance.description == expected_data["description"]
-        assert str(actual_instance.parent.id) == expected_data["parent_id"]
+        if "parent_id" in expected_data:
+            assert str(actual_instance.parent.id) == expected_data["parent_id"]
+        else:
+            assert actual_instance.parent == expected_data["parent"]
 
     def assert_update_response(self, expected_data, actual_response):
         assert actual_response["title"] == expected_data["title"]
         assert actual_response["description"] == expected_data["description"]
-        assert actual_response["parent"]["id"] == expected_data["parent_id"]
+        if "parent_id" in expected_data:
+            assert actual_response["parent"]["id"] == expected_data["parent_id"]
+        else:
+            assert actual_response["parent"] == expected_data["parent"]
 
     def assert_created_instance(self, pk, data):
         instance = Category.objects.get(pk=pk)

--- a/firstvoices/backend/tests/test_apis/test_dictionary_api.py
+++ b/firstvoices/backend/tests/test_apis/test_dictionary_api.py
@@ -1,3 +1,4 @@
+import copy
 import json
 
 import pytest
@@ -53,8 +54,8 @@ class TestDictionaryEndpoint(
             "visibility": "public",
             "customOrder": "⚑W⚑o⚑r⚑d",
             "categories": [],
-            "excludeFromGames": False,
-            "excludeFromKids": False,
+            "excludeFromGames": True,
+            "excludeFromKids": True,
             "acknowledgements": [],
             "alternateSpellings": [],
             "notes": [],
@@ -67,6 +68,34 @@ class TestDictionaryEndpoint(
             "relatedImages": list(map(lambda x: str(x.id), related_images)),
             "relatedVideos": list(map(lambda x: str(x.id), related_videos)),
         }
+
+    def get_valid_data_with_nulls(self, site=None):
+        return {
+            "title": "Word",
+            "type": "word",
+            "visibility": "public",
+            "site": str(site.id),
+        }
+
+    def add_expected_defaults(self, data):
+        return {
+            **data,
+            "customOrder": "⚑W⚑o⚑r⚑d",
+            "categories": [],
+            "excludeFromGames": False,
+            "excludeFromKids": False,
+            "acknowledgements": [],
+            "alternateSpellings": [],
+            "notes": [],
+            "translations": [],
+            "partOfSpeech": None,
+            "pronunciations": [],
+            "relatedDictionaryEntries": [],
+            "relatedAudio": [],
+            "relatedImages": [],
+            "relatedVideos": [],
+        }
+
 
     def add_related_objects(self, instance):
         factories.AcknowledgementFactory.create(dictionary_entry=instance)

--- a/firstvoices/backend/tests/test_apis/test_dictionary_api.py
+++ b/firstvoices/backend/tests/test_apis/test_dictionary_api.py
@@ -239,7 +239,6 @@ class TestDictionaryEndpoint(
         audio = factories.AudioFactory.create(site=site)
         image = factories.ImageFactory.create(site=site)
         video = factories.VideoFactory.create(site=site)
-        category = factories.CategoryFactory.create(site=site)
         dictionary_entry = factories.DictionaryEntryFactory.create(
             site=site,
             title="Title",
@@ -250,13 +249,23 @@ class TestDictionaryEndpoint(
             related_images=(image,),
             related_videos=(video,),
         )
+
+        factories.AcknowledgementFactory.create(dictionary_entry=dictionary_entry)
+        factories.AlternateSpellingFactory.create(dictionary_entry=dictionary_entry)
+        factories.NoteFactory.create(dictionary_entry=dictionary_entry)
+        factories.PronunciationFactory.create(dictionary_entry=dictionary_entry)
+        factories.TranslationFactory.create(dictionary_entry=dictionary_entry)
+
         entry_two = factories.DictionaryEntryFactory.create(site=site)
         factories.DictionaryEntryLinkFactory.create(
             from_dictionary_entry=dictionary_entry, to_dictionary_entry=entry_two
         )
+
+        category = factories.CategoryFactory.create(site=site)
         factories.DictionaryEntryCategoryFactory.create(
             category=category, dictionary_entry=dictionary_entry
         )
+
         character = factories.CharacterFactory.create(site=site)
         factories.DictionaryEntryRelatedCharacterFactory.create(
             character=character, dictionary_entry=dictionary_entry
@@ -293,6 +302,21 @@ class TestDictionaryEndpoint(
         self.assert_patch_instance_original_fields_related_media(
             original_instance, updated_instance
         )
+
+        acknowledgements = Acknowledgement.objects.filter(dictionary_entry=updated_instance)
+        assert len(acknowledgements) == len(original_instance.acknowledgement_set.all())
+
+        alternate_spellings = AlternateSpelling.objects.filter(dictionary_entry=updated_instance)
+        assert len(alternate_spellings) == len(original_instance.alternatespelling_set.all())
+
+        notes = Note.objects.filter(dictionary_entry=updated_instance)
+        assert len(notes) == len(original_instance.note_set.all())
+
+        translations = Translation.objects.filter(dictionary_entry=updated_instance)
+        assert len(translations) == len(original_instance.translation_set.all())
+
+        pronunciations = Pronunciation.objects.filter(dictionary_entry=updated_instance)
+        assert len(pronunciations) == len(original_instance.pronunciation_set.all())
 
     def assert_patch_instance_updated_fields(
         self, data, updated_instance: DictionaryEntry

--- a/firstvoices/backend/tests/test_apis/test_pages_api.py
+++ b/firstvoices/backend/tests/test_apis/test_pages_api.py
@@ -41,10 +41,26 @@ class TestSitePageEndpoint(BaseControlledLanguageAdminOnlySiteContentAPITest):
             "title": "Title",
             "visibility": "public",
             "subtitle": "Subtitle",
-            "slug": "test-page-slug",
+            "slug": "test-page-slug",  # required for create
             "widgets": widget_ids,
             "banner_image": str(banner_image.id),
             "banner_video": None,
+        }
+
+    def get_valid_data_with_nulls(self, site=None):
+        return {
+            "title": "Title",
+            "visibility": "public",
+            "slug": "test-page-slug",
+        }
+
+    def add_expected_defaults(self, data):
+        return {
+            **data,
+            "subtitle": "",
+            "widgets": [],
+            "banner_image": None,
+            "banner_video": None
         }
 
     def add_related_objects(self, instance):
@@ -64,25 +80,40 @@ class TestSitePageEndpoint(BaseControlledLanguageAdminOnlySiteContentAPITest):
         )
         assert actual_instance.subtitle == expected_data["subtitle"]
 
-        actual_widgets = SiteWidget.objects.filter(
-            sitewidgetlist_set__id=actual_instance.widgets_id
-        )
-        actual_widget_ids = list(map(lambda x: str(x.id), actual_widgets))
-        for index, actual_id in enumerate(actual_widget_ids):
-            assert actual_id == expected_data["widgets"][index]
+        actual_widget_ids = [str(x["id"]) for x in actual_instance.widgets.widgets.values("id")]
+        assert len(actual_widget_ids) == len(expected_data["widgets"])
 
-        assert str(actual_instance.banner_image.id) == expected_data["banner_image"]
-        assert actual_instance.banner_video == expected_data["banner_video"]
+        for index, actual_id in enumerate(actual_widget_ids):
+            assert str(actual_id) == expected_data["widgets"][index]
+
+        if expected_data["banner_image"]:
+            assert str(actual_instance.banner_image.id) == expected_data["banner_image"]
+        else:
+            assert actual_instance.banner_image is None
+
+        if expected_data["banner_video"]:
+            assert str(actual_instance.banner_video.id) == expected_data["banner_video"]
+        else:
+            assert actual_instance.banner_video is None
 
     def assert_update_response(self, expected_data, actual_response):
         assert actual_response["title"] == expected_data["title"]
         assert actual_response["visibility"] == expected_data["visibility"]
         assert actual_response["subtitle"] == expected_data["subtitle"]
-        assert actual_response["widgets"][0]["id"] == expected_data["widgets"][0]
-        assert actual_response["widgets"][1]["id"] == expected_data["widgets"][1]
-        assert actual_response["widgets"][2]["id"] == expected_data["widgets"][2]
-        assert actual_response["bannerImage"]["id"] == expected_data["banner_image"]
-        assert actual_response["bannerVideo"] == expected_data["banner_video"]
+
+        assert len(actual_response["widgets"]) == len(expected_data["widgets"])
+        for i, w in enumerate(expected_data["widgets"]):
+            assert actual_response["widgets"][i]["id"] == expected_data["widgets"][i]
+
+        if expected_data["banner_image"]:
+            assert actual_response["bannerImage"]["id"] == expected_data["banner_image"]
+        else:
+            assert actual_response["bannerImage"] is None
+
+        if expected_data["banner_video"]:
+            assert actual_response["bannerVideo"]["id"] == expected_data["banner_video"]
+        else:
+            assert actual_response["bannerVideo"] is None
 
     def get_expected_response(self, instance, site):
         controlled_standard_fields = self.get_expected_controlled_standard_fields(

--- a/firstvoices/backend/tests/test_apis/test_person_api.py
+++ b/firstvoices/backend/tests/test_apis/test_person_api.py
@@ -30,6 +30,17 @@ class TestPeopleEndpoints(BaseUncontrolledSiteContentApiTest):
             "bio": "Cool new biography",
         }
 
+    def get_valid_data_with_nulls(self, site=None):
+        return {
+            "name": "Cool new name",
+        }
+
+    def add_expected_defaults(self, data):
+        return {
+            **data,
+            "bio": "",
+        }
+
     def assert_updated_instance(self, expected_data, actual_instance):
         assert actual_instance.name == expected_data["name"]
         assert actual_instance.bio == expected_data["bio"]

--- a/firstvoices/backend/tests/test_apis/test_sites_data_api.py
+++ b/firstvoices/backend/tests/test_apis/test_sites_data_api.py
@@ -151,7 +151,7 @@ class TestSitesDataEndpoint:
             ":content/pexels-stijn-dijkstra-2583852.jpg",
             "theme": [],
             "secondary_theme": None,
-            "optional": [{}],
+            "optional": [{'Part of Speech': entry_one.part_of_speech.title}],
             "compare_form": entry_one.title,
             "sort_form": entry_one.title,
             "sorting_form": [
@@ -184,7 +184,7 @@ class TestSitesDataEndpoint:
             ":content/pexels-stijn-dijkstra-2583852.jpg",
             "theme": [],
             "secondary_theme": None,
-            "optional": [{}],
+            "optional": [{'Part of Speech': entry_two.part_of_speech.title}],
             "compare_form": entry_two.title,
             "sort_form": entry_two.title,
             "sorting_form": [

--- a/firstvoices/backend/tests/test_apis/test_song_api.py
+++ b/firstvoices/backend/tests/test_apis/test_song_api.py
@@ -61,6 +61,42 @@ class TestSongEndpoint(
             "excludeFromKids": False,
         }
 
+    def get_valid_data_with_nulls(self, site=None):
+        return {
+            "title": "Title",
+            "visibility": "Public",
+            "lyrics": [
+                {
+                    "text": "First lyrics page",
+                    "translation": "Translated 1st",
+                },
+                {
+                    "text": "Second lyrics page",
+                    "translation": "Translated 2nd",
+                },
+                {
+                    "text": "Third lyrics page",
+                    "translation": "Translated 3rd",
+                },
+            ],
+        }
+
+    def add_expected_defaults(self, data):
+        return {
+            **data,
+            "hideOverlay": False,
+            "titleTranslation": "",
+            "introduction": "",
+            "introductionTranslation": "",
+            "notes": [],
+            "acknowledgements": [],
+            "excludeFromGames": False,
+            "excludeFromKids": False,
+            "relatedAudio": [],
+            "relatedImages": [],
+            "relatedVideos": [],
+        }
+
     def assert_updated_instance(self, expected_data, actual_instance: Song):
         assert actual_instance.title == expected_data["title"]
         assert actual_instance.title_translation == expected_data["titleTranslation"]
@@ -72,10 +108,16 @@ class TestSongEndpoint(
         assert actual_instance.exclude_from_games == expected_data["excludeFromGames"]
         assert actual_instance.exclude_from_kids == expected_data["excludeFromKids"]
         assert actual_instance.hide_overlay == expected_data["hideOverlay"]
-        assert actual_instance.notes[0] == expected_data["notes"][0]["text"]
-        assert (
-            actual_instance.acknowledgements[0] == expected_data["acknowledgements"][0]["text"]
-        )
+
+        assert len(expected_data["notes"]) == len(actual_instance.notes)
+        for i, n in enumerate(expected_data["notes"]):
+            assert actual_instance.notes[i] == n["text"]
+
+        assert len(expected_data["acknowledgements"]) == len(actual_instance.acknowledgements)
+        for i, ack in enumerate(expected_data["acknowledgements"]):
+            assert (
+                actual_instance.acknowledgements[i] == ack["text"]
+            )
 
         actual_lyrics = Lyric.objects.filter(song__id=actual_instance.id)
 
@@ -87,20 +129,23 @@ class TestSongEndpoint(
 
     def assert_update_response(self, expected_data, actual_response):
         assert actual_response["title"] == expected_data["title"]
-        assert (
-            actual_response["lyrics"][0]["text"] == expected_data["lyrics"][0]["text"]
-        )
-        assert (
-            actual_response["relatedAudio"][0]["id"] == expected_data["relatedAudio"][0]
-        )
-        assert (
-            actual_response["relatedVideos"][0]["id"]
-            == expected_data["relatedVideos"][0]
-        )
-        assert (
-            actual_response["relatedImages"][0]["id"]
-            == expected_data["relatedImages"][0]
-        )
+
+        assert len(actual_response["lyrics"]) == len(expected_data["lyrics"])
+        for i, l in enumerate(expected_data["lyrics"]):
+            assert actual_response["lyrics"][i]["text"] ==l["text"]
+            assert actual_response["lyrics"][i]["translation"] == l["translation"]
+
+        assert len(actual_response["relatedAudio"]) == len(expected_data["relatedAudio"])
+        for i, a in enumerate(expected_data["relatedAudio"]):
+            assert actual_response["relatedAudio"][i]["id"] == a
+
+        assert len(actual_response["relatedVideos"]) == len(expected_data["relatedVideos"])
+        for i, v in enumerate(expected_data["relatedVideos"]):
+            assert actual_response["relatedVideos"][i]["id"] == v
+
+        assert len(actual_response["relatedImages"]) == len(expected_data["relatedImages"])
+        for i, img in enumerate(expected_data["relatedImages"]):
+            assert actual_response["relatedImages"][i]["id"] == img
 
     def assert_created_instance(self, pk, data):
         instance = Song.objects.get(pk=pk)

--- a/firstvoices/backend/tests/test_apis/test_widgets_api.py
+++ b/firstvoices/backend/tests/test_apis/test_widgets_api.py
@@ -27,9 +27,23 @@ class TestSiteWidgetEndpoint(BaseControlledLanguageAdminOnlySiteContentAPITest):
         return {
             "title": "Title",
             "visibility": "Public",
-            "type": WIDGET_TEXT,
-            "format": "Default",
+            "type": "WIDGET_CUSTOM",
+            "format": WidgetFormats.FULL.label,
             "settings": list(map(lambda x: {"key": x.key, "value": x.value}, settings)),
+        }
+
+    def get_valid_data_with_nulls(self, site=None):
+        return {
+            "title": "Title",
+            "visibility": "Public",
+            "type": "WIDGET_TESTING",
+            "format": WidgetFormats.CENTER.label,
+        }
+
+    def add_expected_defaults(self, data):
+        return {
+            **data,
+            "settings": []
         }
 
     def add_related_objects(self, instance):


### PR DESCRIPTION
### Description of Changes
Allow nulls in all optional fields
- In json POST requests, nulls are just omitted. This is reflected in the tests.
- DRF handles this if fields are configured to be required=False and have a default value, so I updated the field configs and removed the NullableCharField we had previously used
- when there is no default for an optional field and the value is null, the default DRF behaviour is to skip setting that value on an update, which seems like a recipe for future bugs for us, so i added base tests and logged a separate ticket (FW-5065) to make sure each api is testing all the relevant values for POST, PUT, and PATCH. (Too much to deal with right now.) I did a pass on the dictionary_entry, song, and story APIs for now.

### Checklist
- [ ] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
