### PR TITLE
fw-4961, move django key into env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ License: Apache Software License 2.0
    - `SENTRY_TRACES_SAMPLE_RATE`: the sample rate for error events, in the range of 0.0 to 1.0 (defaults to 1.0 if not set, meaning 100% of the errors are sent).
    - `DJANGO_ADMIN_URL`: sets the URL of the admin panel for security purposes (defaults to `admin/` if not set).
    - `DATA_S3_BUCKET`: the name of the S3 Bucket that export data is stored in (if using the aws_download_utils.py script to download export data).
+   - `DJANGO_SECRET_KEY`: required for non-debug (production) installations
+   - `ENVIRONMENT_COLOR`: optional css-compatible color string, to highlight the environment name on the admin site
    - If using [venv](https://docs.python.org/3/library/venv.html)
      - You can add `export <variable name>=<variable value>` to the `<name for your venv>/bin/activate` file.
    - If using [direnv](https://direnv.net/)

--- a/firstvoices/firstvoices/settings.py
+++ b/firstvoices/firstvoices/settings.py
@@ -228,9 +228,13 @@ FIXTURES_DIR = BASE_DIR / "backend" / "fixtures"
 
 CELERY_TASK_SERIALIZER = "json"
 CELERY_TIMEZONE = "America/Vancouver"
-CELERY_BROKER_URL = os.getenv(
-    "CELERY_BROKER_URL", "amqp://rabbitmq:rabbitmq@localhost:5672//fv"
-)
+
+if not DEBUG:
+    CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL")
+else:
+    CELERY_BROKER_URL = os.getenv(
+        "CELERY_BROKER_URL", "amqp://rabbitmq:rabbitmq@localhost:5672//fv"
+    )
 CELERY_RESULT_BACKEND = os.getenv("CELERY_RESULT_BACKEND", "redis://localhost/0")
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 CELERY_ALWAYS_EAGER = True

--- a/firstvoices/firstvoices/settings.py
+++ b/firstvoices/firstvoices/settings.py
@@ -25,11 +25,15 @@ load_dotenv()
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-5^%n@uxu*tev&gyzsf-2_s8bdr#thg%qbtor3&k0zodl12j-1s"
-
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG: bool = os.environ.get("DEBUG_DISABLE") is None
+
+if not DEBUG:
+    # SECURITY WARNING: keep the secret key used in production secret!
+    SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")
+else:
+    SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY",
+                                "django-insecure-5^%n@uxu*tev&gyzsf-2_s8bdr#thg%qbtor3&k0zodl12j-1s")
 
 ALLOWED_HOSTS = [
     os.environ.get("HOST_HEADER"),


### PR DESCRIPTION
### Description of Changes
- kept the insecure key as a fallback for local/debug work
- note that deploying this will log out all admin users and revoke any other uses of secure keys
- note that if this is deployed without setting the appropriate env var, there will be a startup error (intentional)

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
