### PR TITLE
FW-4339 Only show pending requests in list view API

### DIFF
--- a/firstvoices/backend/views/join_request_views.py
+++ b/firstvoices/backend/views/join_request_views.py
@@ -25,7 +25,9 @@ from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSe
 
 @extend_schema_view(
     list=extend_schema(
-        description=_("A list of join requests associated with the specified site."),
+        description=_(
+            "A list of pending join requests associated with the specified site."
+        ),
         responses={
             200: OpenApiResponse(
                 description=doc_strings.success_200_list,

--- a/firstvoices/backend/views/join_request_views.py
+++ b/firstvoices/backend/views/join_request_views.py
@@ -135,7 +135,9 @@ class JoinRequestViewSet(
 
     def get_queryset(self):
         site = self.get_validated_site()
-        return JoinRequest.objects.filter(site__slug=site[0].slug).select_related(
+        return JoinRequest.objects.filter(
+            site__slug=site[0].slug, status=JoinRequestStatus.PENDING
+        ).select_related(
             "site", "site__language", "created_by", "last_modified_by", "user"
         )
 


### PR DESCRIPTION
### Description of Changes
- Tweaks the join request API list view to only show `pending` requests.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
