### PR TITLE
FW-5025 FW-4998 Add missing media file metadata update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,11 @@ docker-compatible defaults shown):
 For async and periodic tasks to successfully execute, a worker process must be running. In another terminal, with the
 virtual environment setup, execute `celery -A firstvoices worker -B` in the `./firstvoices` directory
 
+## Management Commands
+The following management commands are available to run from the `firstvoices` directory:
+- `python manage.py convert_lyrics_draftjs_to_text` - Converts all lyric text and translations from draftjs to plain text.
+- `python manage.py update_missing_media_metadata` - Queues up asynchronous Celery workers which will update the metadata on any ImageFile, VideoFile, and File (audio) instances that are missing metadata.
+
 ## Useful Local URLs On Startup
 
 - Admin panel (login using a superuser account as explained in the [Setting Up Your Users](#setting-up-your-users) section): `localhost:8000/admin`

--- a/firstvoices/backend/management/commands/update_missing_media_metadata.py
+++ b/firstvoices/backend/management/commands/update_missing_media_metadata.py
@@ -1,0 +1,19 @@
+from django.core.management import BaseCommand
+
+from backend.tasks.update_metadata_tasks import (
+    update_missing_audio_metadata,
+    update_missing_image_metadata,
+    update_missing_video_metadata,
+)
+
+
+class Command(BaseCommand):
+    def handle(self, **options):
+        """
+        This command is used to update the metadata for all media files that are missing metadata.
+        It will queue up each of the three update tasks (image/video/audio) in a separate Celery worker.
+        """
+
+        update_missing_image_metadata.apply_async()
+        update_missing_video_metadata.apply_async()
+        update_missing_audio_metadata.apply_async()

--- a/firstvoices/backend/models/media.py
+++ b/firstvoices/backend/models/media.py
@@ -9,6 +9,7 @@ import ffmpeg
 import magic
 import rules
 from django.conf import settings
+from django.core.files.images import get_image_dimensions
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.db import NotSupportedError, models
 from django.utils.translation import gettext as _
@@ -63,8 +64,8 @@ class FileBase(BaseSiteContentModel):
     def __str__(self):
         return f"{self.content.name} ({self.site})"
 
-    def save(self, **kwargs):
-        if not self._state.adding:
+    def save(self, update_metadata_command=False, **kwargs):
+        if not self._state.adding and not update_metadata_command:
             raise NotSupportedError(
                 "Editing existing files is not supported at this time. Please create a new file if you would like to "
                 "update a media file."
@@ -139,11 +140,11 @@ class ImageFile(VisualFileBase):
             "height": self.content.file.image.height,
         }
 
-    def save(self, **kwargs):
+    def save(self, update_metadata_command=False, **kwargs):
         try:
-            image_dimensions = self.get_image_dimensions()
-            self.width = image_dimensions["width"]
-            self.height = image_dimensions["height"]
+            image_dimensions = get_image_dimensions(self.content)
+            self.width = image_dimensions[0]
+            self.height = image_dimensions[1]
 
         except AttributeError as e:
             self.logger.info(
@@ -151,7 +152,7 @@ class ImageFile(VisualFileBase):
                 f"Error: {e}\n"
             )
 
-        super().save(**kwargs)
+        super().save(update_metadata_command, **kwargs)
 
 
 def get_local_video_file(original):
@@ -174,7 +175,7 @@ class VideoFile(VisualFileBase):
             "delete": predicates.can_delete_core_uncontrolled_data,
         }
 
-    def save(self, **kwargs):
+    def save(self, update_metadata_command=False, **kwargs):
         try:
             with get_local_video_file(self.content) as temp_file:
                 video_info = self.get_video_info(temp_file)
@@ -189,7 +190,7 @@ class VideoFile(VisualFileBase):
                 f"{e.stderr.decode('utf8')}\n"
             )
 
-        super().save(**kwargs)
+        super().save(update_metadata_command, **kwargs)
 
     def get_video_info(self, temp_file):
         probe = ffmpeg.probe(temp_file.name)

--- a/firstvoices/backend/tasks/update_metadata_tasks.py
+++ b/firstvoices/backend/tasks/update_metadata_tasks.py
@@ -1,0 +1,104 @@
+import logging
+
+from celery import shared_task
+from django.db.models import Q
+
+from backend.models.media import File, ImageFile, VideoFile
+
+
+@shared_task
+def update_missing_image_metadata():
+    """
+    Updates the metadata for all ImageFile objects that are missing mimetype, size, height, or width metadata.
+    Also updates when the height or width is set to the migration import default of -1.
+    """
+
+    logger = logging.getLogger(__name__)
+
+    # Gather the ImageFile objects that are missing metadata
+    missing_metadata_images = ImageFile.objects.filter(
+        Q(height=-1)
+        | Q(height=None)
+        | Q(width=-1)
+        | Q(width=None)
+        | Q(size=None)
+        | Q(mimetype=None)
+        | Q(mimetype="")
+    ).all()
+
+    # Update the metadata for each ImageFile object using the save method on the model
+    logger.info(
+        f"Updating metadata for {missing_metadata_images.count()} image file(s)."
+    )
+    for image in missing_metadata_images:
+        try:
+            image.save(update_metadata_command=True)
+        except FileNotFoundError as e:
+            logger.warning(f"File not found for ImageFile {image.id}. Error: {e}")
+        else:
+            logger.info(
+                f"Successfully updated metadata for ImageFile {image.id} with path {image.content}."
+            )
+
+
+@shared_task
+def update_missing_video_metadata():
+    """
+    Updates the metadata for all VideoFile objects that are missing mimetype, size, height, or width metadata.
+    Also updates when the height or width is set to the migration import default of -1.
+    """
+
+    logger = logging.getLogger(__name__)
+
+    # Gather the VideoFile objects that are missing metadata
+    missing_metadata_videos = VideoFile.objects.filter(
+        Q(height=-1)
+        | Q(height=None)
+        | Q(width=-1)
+        | Q(width=None)
+        | Q(size=None)
+        | Q(mimetype=None)
+        | Q(mimetype="")
+    ).all()
+
+    # Update the metadata for each VideoFile object using the save method on the model
+    logger.info(
+        f"Updating metadata for {missing_metadata_videos.count()} video file(s)."
+    )
+    for video in missing_metadata_videos:
+        try:
+            video.save(update_metadata_command=True)
+        except FileNotFoundError as e:
+            logger.warning(f"File not found for VideoFile {video.id}. Error: {e}")
+        else:
+            logger.info(
+                f"Successfully updated metadata for VideoFile {video.id} with path {video.content}."
+            )
+
+
+@shared_task
+def update_missing_audio_metadata():
+    """
+    Updates the metadata for all File (audio) objects that are missing mimetype, or size metadata.
+    """
+
+    logger = logging.getLogger(__name__)
+
+    # Gather the File (audio) objects that are missing metadata
+    missing_metadata_audio = File.objects.filter(
+        Q(size=None) | Q(mimetype=None) | Q(mimetype="")
+    ).all()
+
+    # Update the metadata for each File (audio) object using the save method on the model
+    logger.info(
+        f"Updating metadata for {missing_metadata_audio.count()} audio file(s)."
+    )
+    for audio in missing_metadata_audio:
+        try:
+            audio.save(update_metadata_command=True)
+        except FileNotFoundError as e:
+            logger.warning(f"File not found for audio File {audio.id}. Error: {e}")
+        else:
+            logger.info(
+                f"Successfully updated metadata for audio File {audio.id} with path {audio.content}."
+            )

--- a/firstvoices/backend/tasks/update_metadata_tasks.py
+++ b/firstvoices/backend/tasks/update_metadata_tasks.py
@@ -6,14 +6,32 @@ from django.db.models import Q
 from backend.models.media import File, ImageFile, VideoFile
 
 
+def update_missing_media_metadata(missing_media_files):
+    logger = logging.getLogger(__name__)
+
+    # Update the metadata for each file object using the save method on the model
+    logger.debug(
+        f"Updating metadata for {missing_media_files.count()} {missing_media_files.first().__class__.__name__} file(s)."
+    )
+    for file in missing_media_files:
+        try:
+            file.save(update_metadata_command=True)
+        except FileNotFoundError as e:
+            logger.warning(
+                f"File not found for {file.__class__.__name__} - {file.id}. Error: {e}"
+            )
+        else:
+            logger.debug(
+                f"Successfully updated metadata for {file.__class__.__name__} - {file.id} with path {file.content}."
+            )
+
+
 @shared_task
 def update_missing_image_metadata():
     """
     Updates the metadata for all ImageFile objects that are missing mimetype, size, height, or width metadata.
     Also updates when the height or width is set to the migration import default of -1.
     """
-
-    logger = logging.getLogger(__name__)
 
     # Gather the ImageFile objects that are missing metadata
     missing_metadata_images = ImageFile.objects.filter(
@@ -27,18 +45,7 @@ def update_missing_image_metadata():
     ).all()
 
     # Update the metadata for each ImageFile object using the save method on the model
-    logger.info(
-        f"Updating metadata for {missing_metadata_images.count()} image file(s)."
-    )
-    for image in missing_metadata_images:
-        try:
-            image.save(update_metadata_command=True)
-        except FileNotFoundError as e:
-            logger.warning(f"File not found for ImageFile {image.id}. Error: {e}")
-        else:
-            logger.info(
-                f"Successfully updated metadata for ImageFile {image.id} with path {image.content}."
-            )
+    update_missing_media_metadata(missing_metadata_images)
 
 
 @shared_task
@@ -47,8 +54,6 @@ def update_missing_video_metadata():
     Updates the metadata for all VideoFile objects that are missing mimetype, size, height, or width metadata.
     Also updates when the height or width is set to the migration import default of -1.
     """
-
-    logger = logging.getLogger(__name__)
 
     # Gather the VideoFile objects that are missing metadata
     missing_metadata_videos = VideoFile.objects.filter(
@@ -62,18 +67,7 @@ def update_missing_video_metadata():
     ).all()
 
     # Update the metadata for each VideoFile object using the save method on the model
-    logger.info(
-        f"Updating metadata for {missing_metadata_videos.count()} video file(s)."
-    )
-    for video in missing_metadata_videos:
-        try:
-            video.save(update_metadata_command=True)
-        except FileNotFoundError as e:
-            logger.warning(f"File not found for VideoFile {video.id}. Error: {e}")
-        else:
-            logger.info(
-                f"Successfully updated metadata for VideoFile {video.id} with path {video.content}."
-            )
+    update_missing_media_metadata(missing_metadata_videos)
 
 
 @shared_task
@@ -82,23 +76,10 @@ def update_missing_audio_metadata():
     Updates the metadata for all File (audio) objects that are missing mimetype, or size metadata.
     """
 
-    logger = logging.getLogger(__name__)
-
     # Gather the File (audio) objects that are missing metadata
     missing_metadata_audio = File.objects.filter(
         Q(size=None) | Q(mimetype=None) | Q(mimetype="")
     ).all()
 
     # Update the metadata for each File (audio) object using the save method on the model
-    logger.info(
-        f"Updating metadata for {missing_metadata_audio.count()} audio file(s)."
-    )
-    for audio in missing_metadata_audio:
-        try:
-            audio.save(update_metadata_command=True)
-        except FileNotFoundError as e:
-            logger.warning(f"File not found for audio File {audio.id}. Error: {e}")
-        else:
-            logger.info(
-                f"Successfully updated metadata for audio File {audio.id} with path {audio.content}."
-            )
+    update_missing_media_metadata(missing_metadata_audio)

--- a/firstvoices/backend/tests/test_tasks/test_update_metadata_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_update_metadata_tasks.py
@@ -118,7 +118,7 @@ class TestUpdateMetadataTasks:
             "backend.models.media.ImageFile.save", side_effect=FileNotFoundError()
         ):
             update_missing_image_metadata()
-            assert f"File not found for ImageFile {image.id}." in caplog.text
+            assert f"File not found for ImageFile - {image.id}." in caplog.text
 
     @pytest.mark.django_db
     def test_video_file_not_found(self, caplog):
@@ -131,7 +131,7 @@ class TestUpdateMetadataTasks:
             "backend.models.media.VideoFile.save", side_effect=FileNotFoundError()
         ):
             update_missing_video_metadata()
-            assert f"File not found for VideoFile {video.id}." in caplog.text
+            assert f"File not found for VideoFile - {video.id}." in caplog.text
 
     @pytest.mark.django_db
     def test_audio_file_not_found(self, caplog):
@@ -142,7 +142,7 @@ class TestUpdateMetadataTasks:
 
         with patch("backend.models.media.File.save", side_effect=FileNotFoundError()):
             update_missing_audio_metadata()
-            assert f"File not found for audio File {audio.id}." in caplog.text
+            assert f"File not found for File - {audio.id}." in caplog.text
 
     def test_command(self):
         with patch(

--- a/firstvoices/backend/tests/test_tasks/test_update_metadata_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_update_metadata_tasks.py
@@ -1,0 +1,106 @@
+from unittest.mock import patch
+
+import pytest
+
+from backend.models.media import File, ImageFile, VideoFile
+from backend.tasks.update_metadata_tasks import (
+    update_missing_audio_metadata,
+    update_missing_image_metadata,
+    update_missing_video_metadata,
+)
+from backend.tests import factories
+
+
+class TestUpdateMetadataTasks:
+    @pytest.mark.parametrize(
+        "empty_field_name, expected_value",
+        [("mimetype", "image/jpeg"), ("size", 818), ("width", 100), ("height", 100)],
+    )
+    @pytest.mark.django_db
+    def test_update_missing_image_metadata(self, empty_field_name, expected_value):
+        site = factories.SiteFactory.create()
+        image = factories.ImageFileFactory.create(site=site)
+        ImageFile.objects.filter(pk=image.pk).update(**{empty_field_name: None})
+
+        image = ImageFile.objects.get(pk=image.pk)
+        assert getattr(image, empty_field_name) is None
+
+        update_missing_image_metadata()
+
+        image = ImageFile.objects.get(pk=image.pk)
+
+        if empty_field_name == "size":
+            assert abs(getattr(image, empty_field_name) - expected_value) <= 10
+        else:
+            assert getattr(image, empty_field_name) == expected_value
+
+    @pytest.mark.parametrize(
+        "empty_field_name, expected_value",
+        [("mimetype", "video/mp4"), ("size", 6415), ("width", 100), ("height", 100)],
+    )
+    @pytest.mark.django_db
+    def test_update_missing_video_metadata(self, empty_field_name, expected_value):
+        site = factories.SiteFactory.create()
+        video = factories.VideoFileFactory.create(site=site)
+        VideoFile.objects.filter(pk=video.pk).update(**{empty_field_name: None})
+
+        video = VideoFile.objects.get(pk=video.pk)
+        assert getattr(video, empty_field_name) is None
+
+        update_missing_video_metadata()
+
+        video = VideoFile.objects.get(pk=video.pk)
+
+        assert getattr(video, empty_field_name) == expected_value
+
+    @pytest.mark.parametrize(
+        "empty_field_name, expected_value",
+        [("mimetype", "application/x-empty"), ("size", 0)],
+    )
+    @pytest.mark.django_db
+    def test_update_missing_audio_metadata(self, empty_field_name, expected_value):
+        site = factories.SiteFactory.create()
+        audio = factories.FileFactory.create(site=site)
+        File.objects.filter(pk=audio.pk).update(**{empty_field_name: None})
+
+        audio = File.objects.get(pk=audio.pk)
+        assert getattr(audio, empty_field_name) is None
+
+        update_missing_audio_metadata()
+
+        audio = File.objects.get(pk=audio.pk)
+
+        assert getattr(audio, empty_field_name) == expected_value
+
+    @pytest.mark.django_db
+    def test_no_image_metadata_to_update_and_save_not_called(self):
+        site = factories.SiteFactory.create()
+        factories.ImageFactory.create(site=site)
+
+        assert ImageFile.objects.count() == 4
+
+        with patch("backend.models.media.ImageFile.save") as mock_save:
+            update_missing_image_metadata()
+            assert not mock_save.called
+
+    @pytest.mark.django_db
+    def test_no_video_metadata_to_update_and_save_not_called(self):
+        site = factories.SiteFactory.create()
+        factories.VideoFactory.create(site=site)
+
+        assert VideoFile.objects.count() == 1
+
+        with patch("backend.models.media.VideoFile.save") as mock_save:
+            update_missing_video_metadata()
+            assert not mock_save.called
+
+    @pytest.mark.django_db
+    def test_no_audio_metadata_to_update_and_save_not_called(self):
+        site = factories.SiteFactory.create()
+        factories.FileFactory.create(site=site)
+
+        assert File.objects.count() == 1
+
+        with patch("backend.models.media.File.save") as mock_save:
+            update_missing_audio_metadata()
+            assert not mock_save.called

--- a/firstvoices/firstvoices/settings.py
+++ b/firstvoices/firstvoices/settings.py
@@ -241,6 +241,8 @@ else:
 CELERY_RESULT_BACKEND = os.getenv("CELERY_RESULT_BACKEND", "redis://localhost/0")
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 CELERY_ALWAYS_EAGER = True
+# Celery tasks are not picked up by autodiscover_tasks() if they are not globally imported. This adds missing tasks.
+CELERY_IMPORTS = ("backend.tasks.update_metadata_tasks",)
 
 ELASTICSEARCH_HOST = os.getenv("ELASTICSEARCH_HOST", "localhost")
 ELASTICSEARCH_PRIMARY_INDEX = os.getenv("ELASTICSEARCH_PRIMARY_INDEX", "fv")


### PR DESCRIPTION
### Description of Changes
This PR adds a command to asynchronously update the metadata of any image/video/audio files which are missing metadata. The command queues up three separate Celery workers (one for each of the file types). The command can be executed as follows: `python manage.py update_missing_media_metadata`

The files are updated using the `save` method for each of the models. The following missing metadata on a model instance will trigger a call to `save` for that instance:

- ImageFile
    - `mimetype` = None or ""
    - `size` = None
    - `height` = None or -1 (the default set by the data migrations)
    - `width` = None or -1 (the default set by the data migrations)
- VideoFile
    - `mimetype` = None or ""
    - `size` = None
    - `height` = None or -1 (the default set by the data migrations)
    - `width` = None or -1 (the default set by the data migrations)
- File (audio)
    - `mimetype` = None or ""
    - `size` = None

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
