### PR TITLE
Move contact-us email sending to async task

### DIFF
--- a/firstvoices/backend/tasks/send_email_tasks.py
+++ b/firstvoices/backend/tasks/send_email_tasks.py
@@ -1,0 +1,31 @@
+from smtplib import SMTPException
+
+from celery import shared_task
+from django.conf import settings
+from django.core.mail import send_mail
+
+from backend.views.exceptions import ContactUsError
+
+
+@shared_task
+def send_contact_us_email(name, from_email, message, to_email_list):
+    """
+    Formats and sends a contact-us email using the email backend specified in settings.py
+    """
+    try:
+        # Format the final email
+        final_message = (
+            "The following message was sent from the contact us form on the FirstVoices website:\n\n"
+            f"Name: {name}\n"
+            f"Email: {from_email}\n\n"
+            f"Message:\n{message}\n"
+        )
+        # Send the email
+        send_mail(
+            subject=f"Contact Us Form Submission from {name} ({from_email})",
+            message=final_message,
+            recipient_list=to_email_list,
+            from_email=settings.EMAIL_SENDER_ADDRESS,
+        )
+    except (ConnectionRefusedError, SMTPException) as e:
+        raise ContactUsError(f"Contact us email failed to send. Error: {e}")

--- a/firstvoices/backend/tasks/send_email_tasks.py
+++ b/firstvoices/backend/tasks/send_email_tasks.py
@@ -1,31 +1,23 @@
+import logging
 from smtplib import SMTPException
 
 from celery import shared_task
 from django.conf import settings
 from django.core.mail import send_mail
 
-from backend.views.exceptions import ContactUsError
-
 
 @shared_task
-def send_contact_us_email(name, from_email, message, to_email_list):
+def send_email_task(subject, message, to_email_list):
     """
-    Formats and sends a contact-us email using the email backend specified in settings.py
+    Sends an email using the email backend specified in settings.py
     """
+    logger = logging.getLogger(__name__)
     try:
-        # Format the final email
-        final_message = (
-            "The following message was sent from the contact us form on the FirstVoices website:\n\n"
-            f"Name: {name}\n"
-            f"Email: {from_email}\n\n"
-            f"Message:\n{message}\n"
-        )
-        # Send the email
         send_mail(
-            subject=f"Contact Us Form Submission from {name} ({from_email})",
-            message=final_message,
+            subject=subject,
+            message=message,
             recipient_list=to_email_list,
             from_email=settings.EMAIL_SENDER_ADDRESS,
         )
     except (ConnectionRefusedError, SMTPException) as e:
-        raise ContactUsError(f"Contact us email failed to send. Error: {e}")
+        logger.error(f"Failed to send email. Error: {e}")

--- a/firstvoices/backend/tests/test_apis/test_contact_us_api.py
+++ b/firstvoices/backend/tests/test_apis/test_contact_us_api.py
@@ -117,7 +117,7 @@ class TestContactUsEndpoint(WriteApiTestMixin, BaseApiTest):
             )
             assert response.status_code == 202
             assert len(mail.outbox) == 0
-            assert f"Contact us email failed to send. Error: {exception}" in caplog.text
+            assert f"Failed to send email. Error: {exception}" in caplog.text
 
     @pytest.mark.parametrize("role", [Role.MEMBER, Role.EDITOR, Role.LANGUAGE_ADMIN])
     @pytest.mark.django_db

--- a/firstvoices/backend/views/contact_us_views.py
+++ b/firstvoices/backend/views/contact_us_views.py
@@ -1,10 +1,7 @@
 import logging
 import re
-from smtplib import SMTPException
 
-from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, ValidationError
-from django.core.mail import send_mail
 from django.core.validators import validate_email
 from drf_spectacular.utils import (
     OpenApiResponse,
@@ -18,6 +15,7 @@ from rest_framework.viewsets import GenericViewSet
 
 from backend.models import AppJson, Site
 from backend.serializers.contact_us_serializers import ContactUsSerializer
+from backend.tasks.send_email_tasks import send_contact_us_email
 from backend.utils.contact_us_utils import get_fallback_emails
 from backend.views import doc_strings
 from backend.views.api_doc_variables import site_slug_parameter
@@ -129,25 +127,12 @@ class ContactUsView(
                 )
                 to_email_list = get_fallback_emails()
 
-            try:
-                # Format the final email
-                final_message = (
-                    "The following message was sent from the contact us form on the FirstVoices website:\n\n"
-                    f"Name: {name}\n"
-                    f"Email: {from_email}\n\n"
-                    f"Message:\n{message}\n"
-                )
-                send_mail(
-                    subject=f"Contact Us Form Submission from {name} ({from_email})",
-                    message=final_message,
-                    recipient_list=to_email_list,
-                    from_email=settings.EMAIL_SENDER_ADDRESS,
-                )
-            except (ConnectionRefusedError, SMTPException):
-                raise ContactUsError("Contact us email failed to send.")
+            send_contact_us_email.apply_async(
+                (name, from_email, message, to_email_list)
+            )
 
             return Response(
-                {"message": "The email has been successfully sent."},
+                {"message": "The email has been accepted."},
                 status=status.HTTP_202_ACCEPTED,
             )
         except Exception as e:

--- a/firstvoices/backend/views/contact_us_views.py
+++ b/firstvoices/backend/views/contact_us_views.py
@@ -15,7 +15,7 @@ from rest_framework.viewsets import GenericViewSet
 
 from backend.models import AppJson, Site
 from backend.serializers.contact_us_serializers import ContactUsSerializer
-from backend.tasks.send_email_tasks import send_contact_us_email
+from backend.tasks.send_email_tasks import send_email_task
 from backend.utils.contact_us_utils import get_fallback_emails
 from backend.views import doc_strings
 from backend.views.api_doc_variables import site_slug_parameter
@@ -127,9 +127,16 @@ class ContactUsView(
                 )
                 to_email_list = get_fallback_emails()
 
-            send_contact_us_email.apply_async(
-                (name, from_email, message, to_email_list)
+            # Format the final email
+            subject = f"Contact Us Form Submission from {name} ({from_email})"
+            final_message = (
+                "The following message was sent from the contact us form on the FirstVoices website:\n\n"
+                f"Name: {name}\n"
+                f"Email: {from_email}\n\n"
+                f"Message:\n{message}\n"
             )
+
+            send_email_task.apply_async((subject, final_message, to_email_list))
 
             return Response(
                 {"message": "The email has been accepted."},


### PR DESCRIPTION
### Description of Changes
This PR moves the contact-us send_email function to an asynchronous task so that the user does not have to wait for the SMTP server to respond.

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
