### PR TITLE
FW-4340 Make join request status read only (default to pending)

### DIFF
--- a/firstvoices/backend/serializers/join_request_serializers.py
+++ b/firstvoices/backend/serializers/join_request_serializers.py
@@ -13,12 +13,19 @@ from backend.serializers.base_serializers import (
 from backend.serializers.fields import SiteHyperlinkedIdentityField
 from backend.serializers.user_serializers import UserLookupField
 
+
 class JoinRequestDetailSerializer(WritableSiteContentSerializer):
     url = SiteHyperlinkedIdentityField(
         view_name="api:joinrequest-detail", read_only=True
     )
     user = UserLookupField(required=True, allow_null=False)
-    status = fields.EnumField(enum=JoinRequestStatus, required=True, allow_null=False)
+    status = fields.EnumField(
+        enum=JoinRequestStatus,
+        allow_null=False,
+        default=JoinRequestStatus.PENDING,
+        required=False,
+        read_only=True,
+    )
     reason = fields.EnumField(enum=JoinRequestReason, required=True, allow_null=False)
 
     def validate(self, attrs):

--- a/firstvoices/backend/tests/test_apis/test_join_request_api.py
+++ b/firstvoices/backend/tests/test_apis/test_join_request_api.py
@@ -76,7 +76,6 @@ class TestJoinRequestEndpoints(
     def get_valid_data(self, site=None):
         return {
             "user": factories.UserFactory().email,
-            "status": "pending",
             "reason": "other",
             "reason_note": self.REASON_NOTE,
         }
@@ -95,14 +94,12 @@ class TestJoinRequestEndpoints(
 
     def assert_update_response(self, expected_data, actual_response):
         assert actual_response["user"]["email"] == expected_data["user"]
-        assert actual_response["status"] == expected_data["status"]
         assert actual_response["reason"] == expected_data["reason"]
         assert actual_response["reasonNote"] == expected_data["reason_note"]
 
     def assert_created_instance(self, pk, data):
         instance = JoinRequest.objects.get(pk=pk)
         assert instance.user.email == data["user"]
-        assert instance.get_status_display().lower() == data["status"]
         assert instance.get_reason_display().lower() == data["reason"]
         assert instance.reason_note == data["reason_note"]
 


### PR DESCRIPTION
### Description of Changes
- Makes the `status` field of the join request API read-only and always defaults to pending on creation.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
