### PR TITLE
Remove extra fields from search related serializers

### DIFF
--- a/firstvoices/backend/search/utils/hydration_utils.py
+++ b/firstvoices/backend/search/utils/hydration_utils.py
@@ -149,7 +149,7 @@ def hydrate_objects(search_results, request):
                 ] = dictionary_entry.type.lower()  # 'word' or 'phrase'
                 complete_object["entry"] = DictionaryEntryMinimalSerializer(
                     dictionary_entry,
-                    context={"request": request},
+                    context={"request": request, "site": dictionary_entry.site},
                 ).data
 
             elif ELASTICSEARCH_SONG_INDEX in obj["_index"]:

--- a/firstvoices/backend/search/utils/hydration_utils.py
+++ b/firstvoices/backend/search/utils/hydration_utils.py
@@ -14,7 +14,7 @@ from backend.search.utils.constants import (
 from backend.search.utils.object_utils import get_object_by_id
 from backend.serializers.dictionary_serializers import DictionaryEntryMinimalSerializer
 from backend.serializers.media_serializers import (
-    AudioSerializer,
+    AudioMinimalSerializer,
     ImageMinimalSerializer,
     VideoMinimalSerializer,
 )
@@ -172,7 +172,7 @@ def hydrate_objects(search_results, request):
             ):
                 audio = get_object_by_id(audio_objects, obj["_source"]["document_id"])
                 complete_object["type"] = TYPE_AUDIO
-                complete_object["entry"] = AudioSerializer(
+                complete_object["entry"] = AudioMinimalSerializer(
                     audio, context={"request": request, "site": audio.site}
                 ).data
 

--- a/firstvoices/backend/search/utils/object_utils.py
+++ b/firstvoices/backend/search/utils/object_utils.py
@@ -77,10 +77,9 @@ def hydrate_objects(search_results, request):
 
     # Fetching objects from the database
     dictionary_objects = list(
-        DictionaryEntry.objects.filter(
-            id__in=dictionary_search_results_ids
-        ).prefetch_related(
-            "site",
+        DictionaryEntry.objects.filter(id__in=dictionary_search_results_ids)
+        .select_related("site")
+        .prefetch_related(
             "translation_set",
             "related_audio",
             "related_images",
@@ -90,15 +89,17 @@ def hydrate_objects(search_results, request):
         )
     )
     song_objects = list(
-        Song.objects.filter(id__in=song_search_results_ids).prefetch_related(
-            "site",
+        Song.objects.filter(id__in=song_search_results_ids)
+        .select_related("site")
+        .prefetch_related(
             "related_images",
             "related_images__original",
         )
     )
     story_objects = list(
-        Story.objects.filter(id__in=story_search_results_ids).prefetch_related(
-            "site",
+        Story.objects.filter(id__in=story_search_results_ids)
+        .select_related("site")
+        .prefetch_related(
             "related_images",
             "related_images__original",
         )
@@ -120,7 +121,7 @@ def hydrate_objects(search_results, request):
                         "type": dictionary_entry.type.lower(),  # 'word' or 'phrase' instead of 'dictionary_entry'
                         "entry": DictionaryEntryMinimalSerializer(
                             dictionary_entry,
-                            context={"request": request, "site": dictionary_entry.site},
+                            context={"request": request},
                         ).data,
                     }
                 )

--- a/firstvoices/backend/serializers/base_serializers.py
+++ b/firstvoices/backend/serializers/base_serializers.py
@@ -138,7 +138,7 @@ class LinkedSiteSerializer(
     ReadOnlyVisibilityFieldMixin, serializers.HyperlinkedModelSerializer
 ):
     """
-    Minimal info about a site, suitable for serializing a site as a related field.
+    Info about a linked site, suitable for serializing a site as a related field.
     """
 
     url = serializers.HyperlinkedIdentityField(
@@ -150,6 +150,17 @@ class LinkedSiteSerializer(
     class Meta:
         model = Site
         fields = base_id_fields + ("slug", "visibility", "language")
+
+
+class LinkedSiteMinimalSerializer(serializers.ModelSerializer):
+    """
+    Minimal info about a site, suitable for search results.
+    """
+
+    class Meta:
+        model = Site
+        fields = ("id", "slug", "title")
+        read_only_fields = ("id", "slug", "title")
 
 
 class BaseSiteContentSerializer(SiteContentLinkedTitleSerializer):

--- a/firstvoices/backend/serializers/base_serializers.py
+++ b/firstvoices/backend/serializers/base_serializers.py
@@ -152,14 +152,16 @@ class LinkedSiteSerializer(
         fields = base_id_fields + ("slug", "visibility", "language")
 
 
-class LinkedSiteMinimalSerializer(serializers.ModelSerializer):
+class LinkedSiteMinimalSerializer(
+    ReadOnlyVisibilityFieldMixin, serializers.ModelSerializer
+):
     """
     Minimal info about a site, suitable for search results.
     """
 
     class Meta:
         model = Site
-        fields = ("id", "slug", "title")
+        fields = ("id", "slug", "title", "visibility")
         read_only_fields = ("id", "slug", "title")
 
 

--- a/firstvoices/backend/serializers/dictionary_serializers.py
+++ b/firstvoices/backend/serializers/dictionary_serializers.py
@@ -6,7 +6,7 @@ from rest_framework import serializers
 
 from backend.models import category, dictionary, part_of_speech
 from backend.serializers.base_serializers import (
-    LinkedSiteSerializer,
+    LinkedSiteMinimalSerializer,
     SiteContentLinkedTitleSerializer,
     WritableControlledSiteContentSerializer,
     audience_fields,
@@ -126,30 +126,23 @@ class DictionaryEntryDetailSerializer(
         required=False,
     )
     acknowledgements = AcknowledgementSerializer(
-        many=True,
-        required=False,
-        source="acknowledgement_set",
-        default=[]
+        many=True, required=False, source="acknowledgement_set", default=[]
     )
     alternate_spellings = AlternateSpellingSerializer(
-        many=True, required=False, source="alternatespelling_set",
-        default=[]
+        many=True, required=False, source="alternatespelling_set", default=[]
     )
-    notes = NoteSerializer(many=True, required=False, source="note_set",
-        default=[])
+    notes = NoteSerializer(many=True, required=False, source="note_set", default=[])
     translations = TranslationSerializer(
-        many=True, required=False, source="translation_set",
-        default=[]
+        many=True, required=False, source="translation_set", default=[]
     )
     part_of_speech = WritablePartsOfSpeechSerializer(
         queryset=part_of_speech.PartOfSpeech.objects.all(),
         required=False,
         allow_null=True,
-        default=None
+        default=None,
     )
     pronunciations = PronunciationSerializer(
-        many=True, required=False, source="pronunciation_set",
-        default=[]
+        many=True, required=False, source="pronunciation_set", default=[]
     )
 
     logger = logging.getLogger(__name__)
@@ -374,7 +367,7 @@ class DictionaryEntryDetailWriteResponseSerializer(DictionaryEntryDetailSerializ
 
 
 class DictionaryEntryMinimalSerializer(serializers.ModelSerializer):
-    site = LinkedSiteSerializer(read_only=True)
+    site = LinkedSiteMinimalSerializer(read_only=True)
     translations = TranslationSerializer(
         many=True, required=False, source="translation_set", read_only=True
     )

--- a/firstvoices/backend/serializers/dictionary_serializers.py
+++ b/firstvoices/backend/serializers/dictionary_serializers.py
@@ -7,6 +7,7 @@ from rest_framework import serializers
 from backend.models import category, dictionary, part_of_speech
 from backend.serializers.base_serializers import (
     LinkedSiteMinimalSerializer,
+    ReadOnlyVisibilityFieldMixin,
     SiteContentLinkedTitleSerializer,
     WritableControlledSiteContentSerializer,
     audience_fields,
@@ -366,7 +367,9 @@ class DictionaryEntryDetailWriteResponseSerializer(DictionaryEntryDetailSerializ
         ) + audience_fields
 
 
-class DictionaryEntryMinimalSerializer(serializers.ModelSerializer):
+class DictionaryEntryMinimalSerializer(
+    ReadOnlyVisibilityFieldMixin, serializers.ModelSerializer
+):
     site = LinkedSiteMinimalSerializer(read_only=True)
     translations = TranslationSerializer(
         many=True, required=False, source="translation_set", read_only=True
@@ -386,5 +389,6 @@ class DictionaryEntryMinimalSerializer(serializers.ModelSerializer):
             "translations",
             "related_audio",
             "related_images",
+            "visibility",
         )
         read_only_fields = ("id", "title", "type")

--- a/firstvoices/backend/serializers/dictionary_serializers.py
+++ b/firstvoices/backend/serializers/dictionary_serializers.py
@@ -13,7 +13,7 @@ from backend.serializers.base_serializers import (
 )
 from backend.serializers.category_serializers import LinkedCategorySerializer
 from backend.serializers.media_serializers import (
-    RelatedAudioMinimalSerializer,
+    AudioMinimalSerializer,
     RelatedImageMinimalSerializer,
     RelatedMediaSerializerMixin,
 )
@@ -371,9 +371,7 @@ class DictionaryEntryMinimalSerializer(serializers.ModelSerializer):
     translations = TranslationSerializer(
         many=True, required=False, source="translation_set", read_only=True
     )
-    related_audio = RelatedAudioMinimalSerializer(
-        many=True, required=False, read_only=True
-    )
+    related_audio = AudioMinimalSerializer(many=True, required=False, read_only=True)
     related_images = RelatedImageMinimalSerializer(
         many=True, required=False, read_only=True
     )

--- a/firstvoices/backend/serializers/media_serializers.py
+++ b/firstvoices/backend/serializers/media_serializers.py
@@ -306,6 +306,7 @@ class ImageMinimalSerializer(MediaMinimalSerializer):
 
 class VideoMinimalSerializer(ImageMinimalSerializer):
     original = VideoUploadSerializer(read_only=True)
+    small = MediaImageFileSerializer(read_only=True)
 
     class Meta(MediaMinimalSerializer.Meta):
         model = media.Video

--- a/firstvoices/backend/serializers/media_serializers.py
+++ b/firstvoices/backend/serializers/media_serializers.py
@@ -264,7 +264,7 @@ class RelatedMediaSerializerMixin(metaclass=serializers.SerializerMetaclass):
         fields = ("related_audio", "related_images", "related_videos")
 
 
-class RelatedAudioMinimalSerializer(serializers.ModelSerializer):
+class AudioMinimalSerializer(serializers.ModelSerializer):
     original = MediaFileSerializer(read_only=True)
     speakers = PersonSerializer(many=True, read_only=True)
 
@@ -281,7 +281,7 @@ class RelatedAudioMinimalSerializer(serializers.ModelSerializer):
         read_only_fields = ("id", "original")
 
 
-class RelatedImageMinimalSerializer(RelatedAudioMinimalSerializer):
+class RelatedImageMinimalSerializer(serializers.ModelSerializer):
     class Meta:
         model = media.Image
         fields = ("id", "original")
@@ -306,20 +306,6 @@ class ImageMinimalSerializer(MediaMinimalSerializer):
 
 class VideoMinimalSerializer(ImageMinimalSerializer):
     original = VideoUploadSerializer(read_only=True)
-    small = MediaImageFileSerializer(read_only=True)
 
-    class Meta(MediaMinimalSerializer.Meta):
+    class Meta(ImageMinimalSerializer.Meta):
         model = media.Video
-
-
-class AudioMinimalSerializer(MediaMinimalSerializer):
-    original = MediaFileUploadSerializer(read_only=True)
-    speakers = WriteableRelatedPersonSerializer(many=True, read_only=True)
-
-    class Meta(MediaMinimalSerializer.Meta):
-        model = media.Audio
-        fields = MediaMinimalSerializer.Meta.fields + ("acknowledgement", "speakers")
-        read_only_fields = MediaMinimalSerializer.Meta.read_only_fields + (
-            "acknowledgement",
-            "speakers",
-        )

--- a/firstvoices/backend/serializers/media_serializers.py
+++ b/firstvoices/backend/serializers/media_serializers.py
@@ -282,10 +282,19 @@ class AudioMinimalSerializer(serializers.ModelSerializer):
 
 
 class RelatedImageMinimalSerializer(serializers.ModelSerializer):
+    original = ImageUploadSerializer(read_only=True)
+
     class Meta:
         model = media.Image
         fields = ("id", "original")
         read_only_fields = ("id", "original")
+
+
+class RelatedVideoMinimalSerializer(RelatedImageMinimalSerializer):
+    original = VideoUploadSerializer(read_only=True)
+
+    class Meta(RelatedImageMinimalSerializer.Meta):
+        model = media.Video
 
 
 class MediaMinimalSerializer(serializers.ModelSerializer):

--- a/firstvoices/backend/serializers/song_serializers.py
+++ b/firstvoices/backend/serializers/song_serializers.py
@@ -17,6 +17,7 @@ from backend.serializers.base_serializers import (
 from backend.serializers.media_serializers import (
     RelatedImageMinimalSerializer,
     RelatedMediaSerializerMixin,
+    RelatedVideoMinimalSerializer,
 )
 
 
@@ -112,6 +113,9 @@ class SongMinimalSerializer(ModelSerializer):
     related_images = RelatedImageMinimalSerializer(
         many=True, required=False, read_only=True
     )
+    related_videos = RelatedVideoMinimalSerializer(
+        many=True, required=False, read_only=True
+    )
 
     class Meta:
         model = Song
@@ -122,5 +126,6 @@ class SongMinimalSerializer(ModelSerializer):
             "hide_overlay",
             "site",
             "related_images",
+            "related_videos",
         )
         read_only_fields = ("id", "title", "title_translation", "hide_overlay")

--- a/firstvoices/backend/serializers/song_serializers.py
+++ b/firstvoices/backend/serializers/song_serializers.py
@@ -3,19 +3,21 @@ from rest_framework.serializers import ModelSerializer
 
 from backend.models import Lyric, Song
 from backend.serializers.base_serializers import (
+    ArbitraryIdSerializer,
+    LinkedSiteMinimalSerializer,
+    LinkedSiteSerializer,
     ReadOnlyVisibilityFieldMixin,
     SiteContentLinkedTitleSerializer,
     WritableControlledSiteContentSerializer,
     WritableVisibilityField,
     audience_fields,
     base_id_fields,
-    base_timestamp_fields, ArbitraryIdSerializer,
+    base_timestamp_fields,
 )
 from backend.serializers.media_serializers import (
     RelatedImageMinimalSerializer,
     RelatedMediaSerializerMixin,
 )
-from backend.serializers.site_serializers import LinkedSiteSerializer
 
 
 class LyricSerializer(ModelSerializer):
@@ -32,9 +34,13 @@ class SongSerializer(
     site = LinkedSiteSerializer(required=False, read_only=True)
     visibility = WritableVisibilityField(required=True)
 
-    title_translation = serializers.CharField(required=False, allow_blank=True, default="")
+    title_translation = serializers.CharField(
+        required=False, allow_blank=True, default=""
+    )
     introduction = serializers.CharField(required=False, allow_blank=True, default="")
-    introduction_translation = serializers.CharField(required=False, allow_blank=True, default="")
+    introduction_translation = serializers.CharField(
+        required=False, allow_blank=True, default=""
+    )
 
     lyrics = LyricSerializer(many=True)
 
@@ -102,7 +108,7 @@ class SongListSerializer(
 
 
 class SongMinimalSerializer(ModelSerializer):
-    site = LinkedSiteSerializer(read_only=True)
+    site = LinkedSiteMinimalSerializer(read_only=True)
     related_images = RelatedImageMinimalSerializer(
         many=True, required=False, read_only=True
     )

--- a/firstvoices/backend/serializers/song_serializers.py
+++ b/firstvoices/backend/serializers/song_serializers.py
@@ -108,7 +108,7 @@ class SongListSerializer(
         )
 
 
-class SongMinimalSerializer(ModelSerializer):
+class SongMinimalSerializer(ReadOnlyVisibilityFieldMixin, serializers.ModelSerializer):
     site = LinkedSiteMinimalSerializer(read_only=True)
     related_images = RelatedImageMinimalSerializer(
         many=True, required=False, read_only=True
@@ -127,5 +127,6 @@ class SongMinimalSerializer(ModelSerializer):
             "site",
             "related_images",
             "related_videos",
+            "visibility",
         )
         read_only_fields = ("id", "title", "title_translation", "hide_overlay")

--- a/firstvoices/backend/serializers/story_serializers.py
+++ b/firstvoices/backend/serializers/story_serializers.py
@@ -10,6 +10,7 @@ from backend.serializers.base_serializers import (
     CreateControlledSiteContentSerializerMixin,
     LinkedSiteMinimalSerializer,
     LinkedSiteSerializer,
+    ReadOnlyVisibilityFieldMixin,
     SiteContentLinkedTitleSerializer,
     SiteContentUrlMixin,
     WritableControlledSiteContentSerializer,
@@ -204,7 +205,7 @@ class StoryListSerializer(BaseControlledSiteContentSerializer):
         )
 
 
-class StoryMinimalSerializer(serializers.ModelSerializer):
+class StoryMinimalSerializer(ReadOnlyVisibilityFieldMixin, serializers.ModelSerializer):
     site = LinkedSiteMinimalSerializer(read_only=True)
     related_images = RelatedImageMinimalSerializer(
         many=True, required=False, read_only=True
@@ -224,4 +225,5 @@ class StoryMinimalSerializer(serializers.ModelSerializer):
             "site",
             "related_images",
             "related_videos",
+            "visibility",
         )

--- a/firstvoices/backend/serializers/story_serializers.py
+++ b/firstvoices/backend/serializers/story_serializers.py
@@ -8,6 +8,8 @@ from backend.serializers.base_serializers import (
     ArbitraryIdSerializer,
     BaseControlledSiteContentSerializer,
     CreateControlledSiteContentSerializerMixin,
+    LinkedSiteMinimalSerializer,
+    LinkedSiteSerializer,
     SiteContentLinkedTitleSerializer,
     SiteContentUrlMixin,
     WritableControlledSiteContentSerializer,
@@ -20,7 +22,6 @@ from backend.serializers.media_serializers import (
     RelatedImageMinimalSerializer,
     RelatedMediaSerializerMixin,
 )
-from backend.serializers.site_serializers import LinkedSiteSerializer
 from backend.serializers.utils import get_story_from_context
 from backend.serializers.validators import SameSite
 
@@ -101,9 +102,13 @@ class StorySerializer(
     site = LinkedSiteSerializer(required=False, read_only=True)
     visibility = WritableVisibilityField(required=True)
 
-    title_translation = serializers.CharField(required=False, allow_blank=True, default="")
+    title_translation = serializers.CharField(
+        required=False, allow_blank=True, default=""
+    )
     introduction = serializers.CharField(required=False, allow_blank=True, default="")
-    introduction_translation = serializers.CharField(required=False, allow_blank=True, default="")
+    introduction_translation = serializers.CharField(
+        required=False, allow_blank=True, default=""
+    )
 
     pages = StoryPageSummarySerializer(many=True, read_only=True)
 
@@ -199,7 +204,7 @@ class StoryListSerializer(BaseControlledSiteContentSerializer):
 
 
 class StoryMinimalSerializer(serializers.ModelSerializer):
-    site = LinkedSiteSerializer(read_only=True)
+    site = LinkedSiteMinimalSerializer(read_only=True)
     related_images = RelatedImageMinimalSerializer(
         many=True, required=False, read_only=True
     )

--- a/firstvoices/backend/serializers/story_serializers.py
+++ b/firstvoices/backend/serializers/story_serializers.py
@@ -21,6 +21,7 @@ from backend.serializers.base_serializers import (
 from backend.serializers.media_serializers import (
     RelatedImageMinimalSerializer,
     RelatedMediaSerializerMixin,
+    RelatedVideoMinimalSerializer,
 )
 from backend.serializers.utils import get_story_from_context
 from backend.serializers.validators import SameSite
@@ -208,6 +209,9 @@ class StoryMinimalSerializer(serializers.ModelSerializer):
     related_images = RelatedImageMinimalSerializer(
         many=True, required=False, read_only=True
     )
+    related_videos = RelatedVideoMinimalSerializer(
+        many=True, required=False, read_only=True
+    )
 
     class Meta:
         model = Story
@@ -219,4 +223,5 @@ class StoryMinimalSerializer(serializers.ModelSerializer):
             "hide_overlay",
             "site",
             "related_images",
+            "related_videos",
         )


### PR DESCRIPTION
### Description of Changes
- Added a site minimal serializers, which removes a few fields such as url, language from site objects returned as nested objects during any object search such as words, phrases, songs, stories etc.
- Added media related minimal serializers
- Added related_videos to songs and stories minimal serializers as per FE requirement

### Checklist
- ~README / documentation has been updated if needed~
- ~PR title / commit messages contain Jira ticket number if applicable~
- ~Tests have been updated / created if applicable~
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
