### PR TITLE
Add error handling for ffmpeg probe returning none

### DIFF
--- a/firstvoices/backend/models/media.py
+++ b/firstvoices/backend/models/media.py
@@ -180,8 +180,13 @@ class VideoFile(VisualFileBase):
             with get_local_video_file(self.content) as temp_file:
                 video_info = self.get_video_info(temp_file)
 
-            self.width = int(video_info["width"])
-            self.height = int(video_info["height"])
+            if video_info is None:
+                self.logger.error(
+                    f"Failed to get video info for [{self.content.name}]. \n"
+                )
+            else:
+                self.width = int(video_info["width"])
+                self.height = int(video_info["height"])
 
         except ffmpeg.Error as e:
             self.logger.error(

--- a/firstvoices/backend/models/media.py
+++ b/firstvoices/backend/models/media.py
@@ -181,7 +181,7 @@ class VideoFile(VisualFileBase):
                 video_info = self.get_video_info(temp_file)
 
             if video_info is None:
-                self.logger.error(
+                self.logger.warning(
                     f"Failed to get video info for [{self.content.name}]. \n"
                 )
             else:


### PR DESCRIPTION
### Description of Changes
This PR adds error handling for the case when the ffmpeg probe returns None for the video info.

### Checklist
- ~README / documentation has been updated if needed~
- ~PR title / commit messages contain Jira ticket number if applicable~
- ~Tests have been updated / created if applicable~
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
