### PR TITLE
FW-4945 Add usage throttling

### DIFF
--- a/firstvoices/backend/tests/test_apis/test_throttling_limits.py
+++ b/firstvoices/backend/tests/test_apis/test_throttling_limits.py
@@ -1,0 +1,74 @@
+import pytest
+from django.conf import settings
+from django.core.cache import caches
+from rest_framework.test import APIClient
+
+from backend.models.constants import Role
+from backend.tests import factories
+from backend.tests.test_apis.base_api_test import BaseApiTest
+
+
+class TestThrottling(BaseApiTest):
+    API_LIST_VIEW = "api:site-list"
+
+    def setup_method(self):
+        self.client = APIClient()
+        self.site = factories.SiteFactory.create()
+        self.user = factories.UserFactory.create()
+        caches["throttle"].clear()
+
+    @pytest.fixture
+    def use_burst_rate(self):
+        settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["burst"] = "3/min"
+        settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["sustained"] = "1000/day"
+        yield "settings"
+        settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["burst"] = "60/min"
+        settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["sustained"] = "1000/day"
+
+    @pytest.fixture
+    def use_sustained_rate(self):
+        settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["burst"] = "1000/min"
+        settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["sustained"] = "3/day"
+        yield "settings"
+        settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["burst"] = "60/min"
+        settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["sustained"] = "1000/day"
+
+    @pytest.mark.usefixtures("use_burst_rate")
+    @pytest.mark.parametrize(
+        "user_role",
+        [None, Role.MEMBER, Role.EDITOR, Role.ASSISTANT, Role.LANGUAGE_ADMIN],
+    )
+    @pytest.mark.django_db
+    def test_throttling_burst_limit(self, user_role):
+        if user_role:
+            factories.MembershipFactory.create(
+                user=self.user, site=self.site, role=user_role
+            )
+        self.client.force_authenticate(user=self.user)
+
+        for i in range(0, 3):
+            response = self.client.get(self.get_list_endpoint())
+            assert response.status_code == 200
+
+        response = self.client.get(self.get_list_endpoint())
+        assert response.status_code == 429
+
+    @pytest.mark.usefixtures("use_sustained_rate")
+    @pytest.mark.parametrize(
+        "user_role",
+        [None, Role.MEMBER, Role.EDITOR, Role.ASSISTANT, Role.LANGUAGE_ADMIN],
+    )
+    @pytest.mark.django_db
+    def test_throttling_sustained_limit(self, user_role):
+        if user_role:
+            factories.MembershipFactory.create(
+                user=self.user, site=self.site, role=user_role
+            )
+        self.client.force_authenticate(user=self.user)
+
+        for i in range(0, 3):
+            response = self.client.get(self.get_list_endpoint())
+            assert response.status_code == 200
+
+        response = self.client.get(self.get_list_endpoint())
+        assert response.status_code == 429

--- a/firstvoices/backend/views/base_views.py
+++ b/firstvoices/backend/views/base_views.py
@@ -9,7 +9,15 @@ from backend.permissions import utils
 from backend.views.utils import BurstRateThrottle, SustainedRateThrottle
 
 
-class FVPermissionViewSetMixin:
+class ThrottlingMixin:
+    """
+    A mixin to provide request usage throttling for viewsets.
+    """
+
+    throttle_classes = [BurstRateThrottle, SustainedRateThrottle]
+
+
+class FVPermissionViewSetMixin(ThrottlingMixin):
     """
     Forked from ``rules.contrib.rest_framework.AutoPermissionViewSetMixin`` to provide extension points.
 
@@ -42,7 +50,6 @@ class FVPermissionViewSetMixin:
         "retrieve": "view",
         "update": "change",
     }
-    throttle_classes = [BurstRateThrottle, SustainedRateThrottle]
 
     def initial(self, *args, **kwargs):
         """Ensures user has permission to perform the requested action."""
@@ -130,8 +137,6 @@ class SiteContentViewSetMixin:
     """
     Provides common methods for handling site content, usually for data models that use the ``BaseSiteContentModel``.
     """
-
-    throttle_classes = [BurstRateThrottle, SustainedRateThrottle]
 
     def get_site_slug(self):
         return self.kwargs["site_slug"]

--- a/firstvoices/backend/views/base_views.py
+++ b/firstvoices/backend/views/base_views.py
@@ -6,6 +6,7 @@ from rest_framework.viewsets import GenericViewSet
 
 from backend.models import Alphabet, Character, CharacterVariant, IgnoredCharacter, Site
 from backend.permissions import utils
+from backend.views.utils import BurstRateThrottle, SustainedRateThrottle
 
 
 class FVPermissionViewSetMixin:
@@ -41,6 +42,7 @@ class FVPermissionViewSetMixin:
         "retrieve": "view",
         "update": "change",
     }
+    throttle_classes = [BurstRateThrottle, SustainedRateThrottle]
 
     def initial(self, *args, **kwargs):
         """Ensures user has permission to perform the requested action."""
@@ -128,6 +130,8 @@ class SiteContentViewSetMixin:
     """
     Provides common methods for handling site content, usually for data models that use the ``BaseSiteContentModel``.
     """
+
+    throttle_classes = [BurstRateThrottle, SustainedRateThrottle]
 
     def get_site_slug(self):
         return self.kwargs["site_slug"]

--- a/firstvoices/backend/views/contact_us_views.py
+++ b/firstvoices/backend/views/contact_us_views.py
@@ -19,7 +19,7 @@ from backend.tasks.send_email_tasks import send_email_task
 from backend.utils.contact_us_utils import get_fallback_emails
 from backend.views import doc_strings
 from backend.views.api_doc_variables import site_slug_parameter
-from backend.views.base_views import SiteContentViewSetMixin
+from backend.views.base_views import SiteContentViewSetMixin, ThrottlingMixin
 from backend.views.doc_strings import error_403
 from backend.views.exceptions import ContactUsError
 
@@ -53,6 +53,7 @@ from backend.views.exceptions import ContactUsError
     ),
 )
 class ContactUsView(
+    ThrottlingMixin,
     SiteContentViewSetMixin,
     mixins.ListModelMixin,
     mixins.CreateModelMixin,

--- a/firstvoices/backend/views/data_views.py
+++ b/firstvoices/backend/views/data_views.py
@@ -6,7 +6,7 @@ from rules.contrib.rest_framework import AutoPermissionViewSetMixin
 from backend.models.dictionary import DictionaryEntry
 from backend.serializers.site_data_serializers import SiteDataSerializer
 from backend.views.api_doc_variables import site_slug_parameter
-from backend.views.base_views import SiteContentViewSetMixin
+from backend.views.base_views import SiteContentViewSetMixin, ThrottlingMixin
 
 
 def dict_entry_type_mtd_conversion(type):
@@ -37,6 +37,7 @@ def dict_entry_type_mtd_conversion(type):
     ),
 )
 class SitesDataViewSet(
+    ThrottlingMixin,
     AutoPermissionViewSetMixin,
     SiteContentViewSetMixin,
     mixins.ListModelMixin,

--- a/firstvoices/backend/views/search/base_search_views.py
+++ b/firstvoices/backend/views/search/base_search_views.py
@@ -19,6 +19,7 @@ from backend.search.utils.query_builder_utils import (
     get_valid_document_types,
     get_valid_domain,
 )
+from backend.views.base_views import ThrottlingMixin
 from backend.views.exceptions import ElasticSearchConnectionError
 
 
@@ -216,7 +217,9 @@ from backend.views.exceptions import ElasticSearchConnectionError
         ],
     ),
 )
-class BaseSearchViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
+class BaseSearchViewSet(
+    ThrottlingMixin, mixins.ListModelMixin, viewsets.GenericViewSet
+):
     http_method_names = ["get"]
     queryset = ""
     pagination_class = SearchPageNumberPagination

--- a/firstvoices/backend/views/utils.py
+++ b/firstvoices/backend/views/utils.py
@@ -1,4 +1,6 @@
+from django.core.cache import caches
 from django.db.models import Prefetch
+from rest_framework.throttling import UserRateThrottle
 
 from backend.models.media import Audio, Image, Video
 
@@ -42,3 +44,15 @@ def get_media_prefetch_list(user):
             ),
         ),
     ]
+
+
+class CustomUserRateThrottle(UserRateThrottle):
+    cache = caches["throttle"]
+
+
+class BurstRateThrottle(CustomUserRateThrottle):
+    scope = "burst"
+
+
+class SustainedRateThrottle(CustomUserRateThrottle):
+    scope = "sustained"

--- a/firstvoices/firstvoices/settings.py
+++ b/firstvoices/firstvoices/settings.py
@@ -108,6 +108,14 @@ REST_FRAMEWORK = {
     "JSON_UNDERSCOREIZE": {
         "ignore_fields": ("site_data_export",),
     },
+    "DEFAULT_THROTTLE_CLASSES": [
+        "backend.views.utils.BurstRateThrottle",
+        "backend.views.utils.SustainedRateThrottle",
+    ],
+    "DEFAULT_THROTTLE_RATES": {
+        "burst": os.getenv("BURST_THROTTLE_RATE", "60/min"),
+        "sustained": os.getenv("SUSTAINED_THROTTLE_RATE", "1000/day"),
+    },
 }
 
 # LOGGERS
@@ -120,7 +128,11 @@ if DEBUG:
             "DEFAULT_RENDERER_CLASSES": (
                 "djangorestframework_camel_case.render.CamelCaseJSONRenderer",
                 "rest_framework.renderers.BrowsableAPIRenderer",
-            )
+            ),
+            "DEFAULT_THROTTLE_RATES": {
+                "burst": os.getenv("BURST_THROTTLE_RATE", "10000/min"),
+                "sustained": os.getenv("SUSTAINED_THROTTLE_RATE", "100000/day"),
+            },
         }
     )
 
@@ -182,6 +194,10 @@ CACHES = {
     "auth": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "LOCATION": "auth",
+    },
+    "throttle": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "throttle",
     },
 }
 


### PR DESCRIPTION
### Description of Changes
This PR adds usage throttling. 

As a start, there is both a sustained rate and a burst rate which can be set with the environment variables. They are set as strings in the form of "#/time" where # is the number of requests and time is sec/min/hour/day (eg. "60/min" or "1000/day"). The environment variables are `SUSTAINED_THROTTLE_RATE` and `BURST_THROTTLE_RATE`. If no environment variables are set the sustained rate defaults to 1000 requests per day and the burst rate defaults to 60 requests per minute. 

The variables are set to very high numbers by default if debug is enabled (for local development).

Per user role/API throttling can be added after we launch the new version and have detailed usage statistics.

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
