### PR TITLE
FW-5111 Add additional error handling to media metadata update command

### DIFF
--- a/firstvoices/backend/tasks/update_metadata_tasks.py
+++ b/firstvoices/backend/tasks/update_metadata_tasks.py
@@ -20,6 +20,10 @@ def update_missing_media_metadata(missing_media_files):
             logger.warning(
                 f"File not found for {file.__class__.__name__} - {file.id}. Error: {e}"
             )
+        except Exception as e:
+            logger.warning(
+                f"File could not be updated for {file.__class__.__name__} - {file.id}. Error: {e}"
+            )
         else:
             logger.debug(
                 f"Successfully updated metadata for {file.__class__.__name__} - {file.id} with path {file.content}."

--- a/firstvoices/backend/tests/test_tasks/test_update_metadata_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_update_metadata_tasks.py
@@ -3,6 +3,9 @@ from unittest.mock import patch
 
 import pytest
 from django.core import management
+from django.core.exceptions import BadRequest
+from django.db import DataError
+from PIL import UnidentifiedImageError
 
 from backend.models.media import File, ImageFile, VideoFile
 from backend.tasks.update_metadata_tasks import (
@@ -143,6 +146,46 @@ class TestUpdateMetadataTasks:
         with patch("backend.models.media.File.save", side_effect=FileNotFoundError()):
             update_missing_audio_metadata()
             assert f"File not found for File - {audio.id}." in caplog.text
+
+    @pytest.mark.parametrize("exception", [Exception(), UnidentifiedImageError()])
+    @pytest.mark.django_db
+    def test_image_exception(self, caplog, exception):
+        caplog.set_level(logging.WARNING)
+        site = factories.SiteFactory.create()
+        image = factories.ImageFileFactory.create(site=site)
+        ImageFile.objects.filter(pk=image.pk).update(mimetype=None)
+
+        with patch("backend.models.media.ImageFile.save", side_effect=exception):
+            update_missing_image_metadata()
+            assert (
+                f"File could not be updated for ImageFile - {image.id}." in caplog.text
+            )
+
+    @pytest.mark.parametrize("exception", [Exception(), DataError()])
+    @pytest.mark.django_db
+    def test_video_exception(self, caplog, exception):
+        caplog.set_level(logging.WARNING)
+        site = factories.SiteFactory.create()
+        video = factories.VideoFileFactory.create(site=site)
+        VideoFile.objects.filter(pk=video.pk).update(mimetype=None)
+
+        with patch("backend.models.media.VideoFile.save", side_effect=exception):
+            update_missing_video_metadata()
+            assert (
+                f"File could not be updated for VideoFile - {video.id}." in caplog.text
+            )
+
+    @pytest.mark.parametrize("exception", [Exception(), BadRequest()])
+    @pytest.mark.django_db
+    def test_audio_exception(self, caplog, exception):
+        caplog.set_level(logging.WARNING)
+        site = factories.SiteFactory.create()
+        audio = factories.FileFactory.create(site=site)
+        File.objects.filter(pk=audio.pk).update(mimetype=None)
+
+        with patch("backend.models.media.File.save", side_effect=exception):
+            update_missing_audio_metadata()
+            assert f"File could not be updated for File - {audio.id}." in caplog.text
 
     def test_command(self):
         with patch(

--- a/firstvoices/backend/tests/test_tasks/test_update_metadata_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_update_metadata_tasks.py
@@ -15,6 +15,12 @@ from backend.tasks.update_metadata_tasks import (
 )
 from backend.tests import factories
 
+audio_file_save_function = "backend.models.media.File.save"
+
+video_file_save_function = "backend.models.media.VideoFile.save"
+
+image_file_save_function = "backend.models.media.ImageFile.save"
+
 
 class TestUpdateMetadataTasks:
     @pytest.mark.parametrize(
@@ -84,7 +90,7 @@ class TestUpdateMetadataTasks:
 
         assert ImageFile.objects.count() == 1
 
-        with patch("backend.models.media.ImageFile.save") as mock_save:
+        with patch(image_file_save_function) as mock_save:
             update_missing_image_metadata()
             assert not mock_save.called
 
@@ -95,7 +101,7 @@ class TestUpdateMetadataTasks:
 
         assert VideoFile.objects.count() == 1
 
-        with patch("backend.models.media.VideoFile.save") as mock_save:
+        with patch(video_file_save_function) as mock_save:
             update_missing_video_metadata()
             assert not mock_save.called
 
@@ -106,7 +112,7 @@ class TestUpdateMetadataTasks:
 
         assert File.objects.count() == 1
 
-        with patch("backend.models.media.File.save") as mock_save:
+        with patch(audio_file_save_function) as mock_save:
             update_missing_audio_metadata()
             assert not mock_save.called
 
@@ -117,9 +123,7 @@ class TestUpdateMetadataTasks:
         image = factories.ImageFileFactory.create(site=site)
         ImageFile.objects.filter(pk=image.pk).update(mimetype=None)
 
-        with patch(
-            "backend.models.media.ImageFile.save", side_effect=FileNotFoundError()
-        ):
+        with patch(image_file_save_function, side_effect=FileNotFoundError()):
             update_missing_image_metadata()
             assert f"File not found for ImageFile - {image.id}." in caplog.text
 
@@ -130,9 +134,7 @@ class TestUpdateMetadataTasks:
         video = factories.VideoFileFactory.create(site=site)
         VideoFile.objects.filter(pk=video.pk).update(mimetype=None)
 
-        with patch(
-            "backend.models.media.VideoFile.save", side_effect=FileNotFoundError()
-        ):
+        with patch(video_file_save_function, side_effect=FileNotFoundError()):
             update_missing_video_metadata()
             assert f"File not found for VideoFile - {video.id}." in caplog.text
 
@@ -143,7 +145,7 @@ class TestUpdateMetadataTasks:
         audio = factories.FileFactory.create(site=site)
         File.objects.filter(pk=audio.pk).update(mimetype=None)
 
-        with patch("backend.models.media.File.save", side_effect=FileNotFoundError()):
+        with patch(audio_file_save_function, side_effect=FileNotFoundError()):
             update_missing_audio_metadata()
             assert f"File not found for File - {audio.id}." in caplog.text
 
@@ -155,7 +157,7 @@ class TestUpdateMetadataTasks:
         image = factories.ImageFileFactory.create(site=site)
         ImageFile.objects.filter(pk=image.pk).update(mimetype=None)
 
-        with patch("backend.models.media.ImageFile.save", side_effect=exception):
+        with patch(image_file_save_function, side_effect=exception):
             update_missing_image_metadata()
             assert (
                 f"File could not be updated for ImageFile - {image.id}." in caplog.text
@@ -169,7 +171,7 @@ class TestUpdateMetadataTasks:
         video = factories.VideoFileFactory.create(site=site)
         VideoFile.objects.filter(pk=video.pk).update(mimetype=None)
 
-        with patch("backend.models.media.VideoFile.save", side_effect=exception):
+        with patch(video_file_save_function, side_effect=exception):
             update_missing_video_metadata()
             assert (
                 f"File could not be updated for VideoFile - {video.id}." in caplog.text
@@ -183,7 +185,7 @@ class TestUpdateMetadataTasks:
         audio = factories.FileFactory.create(site=site)
         File.objects.filter(pk=audio.pk).update(mimetype=None)
 
-        with patch("backend.models.media.File.save", side_effect=exception):
+        with patch(audio_file_save_function, side_effect=exception):
             update_missing_audio_metadata()
             assert f"File could not be updated for File - {audio.id}." in caplog.text
 


### PR DESCRIPTION
### Description of Changes
This PR adds additional error handling to ensure the media metadata update command can continue through all of the files without throwing an uncaught exception.

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
