### PR TITLE
FW-5079 and FW-5077 Add join request email notifications

### DIFF
--- a/firstvoices/backend/tasks/send_email_tasks.py
+++ b/firstvoices/backend/tasks/send_email_tasks.py
@@ -15,7 +15,7 @@ def send_email_task(subject, message, to_email_list):
     try:
         message = (
             message
-            + "\nThis is an automated message, please do not reply to this email.\n\n"
+            + "\nThis is an automated message. Please do not reply to this email.\n\n"
         )
         send_mail(
             subject=subject,

--- a/firstvoices/backend/tasks/send_email_tasks.py
+++ b/firstvoices/backend/tasks/send_email_tasks.py
@@ -13,6 +13,10 @@ def send_email_task(subject, message, to_email_list):
     """
     logger = logging.getLogger(__name__)
     try:
+        message = (
+            message
+            + "\nThis is an automated message, please do not reply to this email.\n\n"
+        )
         send_mail(
             subject=subject,
             message=message,

--- a/firstvoices/backend/tests/test_apis/test_join_request_api.py
+++ b/firstvoices/backend/tests/test_apis/test_join_request_api.py
@@ -423,12 +423,18 @@ class TestJoinRequestEndpoints(
         assert response.status_code == 400
         assert len(mail.outbox) == 0
 
+    @pytest.mark.parametrize("create_frontend_base_url", [True, False])
     @pytest.mark.django_db
-    def test_approve_success_admin(self):
+    def test_approve_success_admin(self, create_frontend_base_url):
         site, user = factories.get_site_with_member(
             Visibility.PUBLIC, Role.LANGUAGE_ADMIN
         )
         self.client.force_authenticate(user=user)
+
+        if create_frontend_base_url:
+            factories.AppJsonFactory.create(
+                key="frontend_base_url", json="https://test.com"
+            )
 
         join_request = factories.JoinRequestFactory.create(site=site)
 
@@ -634,13 +640,15 @@ class TestJoinRequestEndpoints(
 
         assert response.status_code == 400
 
+    @pytest.mark.parametrize("create_frontend_base_url", [True, False])
     @pytest.mark.django_db
-    def test_create_language_admin_email_sent(self):
+    def test_create_language_admin_email_sent(self, create_frontend_base_url):
         site, _ = factories.get_site_with_member(Visibility.PUBLIC, Role.LANGUAGE_ADMIN)
 
-        factories.AppJsonFactory.create(
-            key="frontend_base_url", json="https://test.com"
-        )
+        if create_frontend_base_url:
+            factories.AppJsonFactory.create(
+                key="frontend_base_url", json="https://test.com"
+            )
 
         anon_user = factories.UserFactory.create()
         self.client.force_authenticate(user=anon_user)

--- a/firstvoices/backend/tests/test_apis/test_join_request_api.py
+++ b/firstvoices/backend/tests/test_apis/test_join_request_api.py
@@ -129,7 +129,7 @@ class TestJoinRequestEndpoints(
 
     @pytest.fixture(autouse=True)
     def configure_settings(self, settings):
-        # Sets the celery tasks to run synchronously for testing
+        # Runs the email sending celery task synchronously during testing
         settings.CELERY_TASK_ALWAYS_EAGER = True
 
     @pytest.mark.django_db
@@ -635,9 +635,7 @@ class TestJoinRequestEndpoints(
 
     @pytest.mark.django_db
     def test_create_language_admin_email_sent(self):
-        site, user = factories.get_site_with_member(
-            Visibility.PUBLIC, Role.LANGUAGE_ADMIN
-        )
+        site, _ = factories.get_site_with_member(Visibility.PUBLIC, Role.LANGUAGE_ADMIN)
 
         anon_user = factories.UserFactory.create()
         self.client.force_authenticate(user=anon_user)

--- a/firstvoices/backend/views/join_request_views.py
+++ b/firstvoices/backend/views/join_request_views.py
@@ -207,7 +207,7 @@ class JoinRequestViewSet(
         subject = f"Your FirstVoices account has been approved to join {join_request.site.title}."
         message = (
             f"Thank you for your interest in joining the FirstVoices site {join_request.site.title}.\n\n"
-            f"Your account has been approved with the {role.label} role and you can now log in to the site.\n\n"
+            f"Your account has been approved with the {role.label} role and you can now sign in to the site.\n\n"
         )
         send_email_task.apply_async((subject, message, [join_request.user.email]))
 

--- a/firstvoices/backend/views/utils.py
+++ b/firstvoices/backend/views/utils.py
@@ -1,7 +1,10 @@
 from django.core.cache import caches
+import logging
+
 from django.db.models import Prefetch
 from rest_framework.throttling import UserRateThrottle
 
+from backend.models import AppJson
 from backend.models.media import Audio, Image, Video
 
 
@@ -44,6 +47,20 @@ def get_media_prefetch_list(user):
             ),
         ),
     ]
+
+
+def get_site_url_from_appjson(site):
+    logger = logging.getLogger(__name__)
+    base_url = AppJson.objects.filter(key="frontend_base_url")
+    if base_url.count() > 0:
+        return base_url[0].json + "/" + site.slug + "/"
+    else:
+        logger.warning(
+            'No AppJson instance with key "frontend_base_url" found. Site URLs will not be included in join request '
+            'emails. Please add a key "frontend_base_url" to AppJson with the base URL of the frontend as the value '
+            'string (eg: "https://firstvoices.com").'
+        )
+        return None
 
 
 class CustomUserRateThrottle(UserRateThrottle):


### PR DESCRIPTION
### Description of Changes
This PR adds email notifications which are sent as follows:
- when a user creates a join request all language admins of the site are notified
    - if no language admins exist for the site then a warning is logged, no email is sent, and the join request is still created
- when a join request is approved the user is notified
- when a join request is rejected the user is notified

Additionally, this PR adds a message to all outgoing emails noting that the email is automated and should not be replied to.

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
Do not merge this PR until the SMTP server has been disabled on dev and pre-prod environments, as testing is being done on the frontend and we don't want users to accidentally get sent emails. See FW-5075.
