### PR TITLE
FW-5139 Recalculate task no longer affects lastModified field

### DIFF
--- a/firstvoices/backend/tasks/alphabet_tasks.py
+++ b/firstvoices/backend/tasks/alphabet_tasks.py
@@ -68,11 +68,14 @@ def recalculate_custom_order(site_slug: str):
         original_title = entry.title
         original_custom_order = entry.custom_order
 
-        # Save the entry to recalculate custom order and clean title
-        entry.save()
+        cleaned_title = alphabet.clean_confusables(entry.title)
+        new_order = alphabet.get_custom_order(cleaned_title)
 
-        cleaned_title = entry.title
-        new_order = entry.custom_order
+        # Save the entry to recalculate custom order and clean title
+        DictionaryEntry.objects.filter(id=entry.id).update(
+            title=cleaned_title,
+            custom_order=new_order,
+        )
 
         append_updated_entry(
             updated_entries,
@@ -84,7 +87,7 @@ def recalculate_custom_order(site_slug: str):
 
         # Count unknown characters remaining in each entry, first split by character, then apply custom order
         if "⚑" in new_order:
-            chars = alphabet.get_character_list(entry.title)
+            chars = alphabet.get_character_list(cleaned_title)
             for char in chars:
                 custom_order = alphabet.get_custom_order(char)
                 if "⚑" in custom_order:

--- a/firstvoices/backend/tests/test_tasks/test_alphabet_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_alphabet_tasks.py
@@ -288,3 +288,26 @@ class TestAlphabetTasks:
                 }
             ],
         }
+
+    @pytest.mark.django_db
+    def test_last_modified_not_updated(self, site, alphabet):
+        factories.CharacterFactory.create(site=site, title="a")
+        factories.CharacterFactory.create(site=site, title="b")
+        entry = factories.DictionaryEntryFactory.create(site=site, title="abc")
+        entry_last_modified = entry.last_modified
+        factories.CharacterFactory.create(site=site, title="c")
+
+        result = recalculate_custom_order(site_slug=site.slug)
+        assert result == {
+            "unknown_character_count": {},
+            "updated_entries": [
+                {
+                    "title": "abc",
+                    "cleaned_title": "",
+                    "is_title_updated": False,
+                    "previous_custom_order": "!#⚑c",
+                    "new_custom_order": "!#$",
+                }
+            ],
+        }
+        assert entry.last_modified == entry_last_modified


### PR DESCRIPTION
### Description of Changes
Please briefly explain the changes here.

### Checklist
- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
