### PR TITLE
FW-5136 Add visibility parameter to the search API

### DIFF
--- a/firstvoices/backend/search/query_builder.py
+++ b/firstvoices/backend/search/query_builder.py
@@ -12,6 +12,7 @@ from backend.search.utils.query_builder_utils import (
     get_starts_with_query,
     get_types_query,
     get_view_permissions_filter,
+    get_visibility_query,
 )
 from backend.search.utils.search_term_query import get_search_term_query
 
@@ -31,6 +32,7 @@ def get_search_query(
     category_id="",
     kids=False,
     games=False,
+    visibility="",
 ):
     # Building initial query
     indices = get_indices(types)
@@ -74,5 +76,8 @@ def get_search_query(
 
     if games:
         search_query = search_query.query(get_games_query(games))
+
+    if visibility != "":
+        search_query = search_query.query(get_visibility_query(visibility))
 
     return search_query

--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -179,6 +179,10 @@ def get_games_query(games):
     return Q("bool", filter=[Q("term", exclude_from_games=not games)])
 
 
+def get_visibility_query(visibility):
+    return Q("bool", filter=[Q("terms", visibility=visibility)])
+
+
 # Search params validation
 def get_valid_document_types(input_types, allowed_values=VALID_DOCUMENT_TYPES):
     if not input_types:
@@ -241,3 +245,24 @@ def get_valid_boolean(input_val):
         return True
     else:
         return False
+
+
+def get_valid_visibility(input_visibility_str):
+    if not input_visibility_str:
+        return ""
+
+    input_visibility = input_visibility_str.split(",")
+    selected_values = []
+
+    for value in input_visibility:
+        string_upper = value.strip().upper()
+        if (
+            string_upper == Visibility.TEAM.label.upper()
+            or string_upper == Visibility.MEMBERS.label.upper()
+            or string_upper == Visibility.PUBLIC.label.upper()
+        ) and Visibility[string_upper] not in selected_values:
+            selected_values.append(Visibility[string_upper])
+
+    if len(selected_values) == 0:
+        return None
+    return selected_values

--- a/firstvoices/backend/tests/test_search/test_filters.py
+++ b/firstvoices/backend/tests/test_search/test_filters.py
@@ -1,7 +1,7 @@
 import pytest
 
 import backend.tests.factories as factories
-from backend.models.constants import AppRole, Role
+from backend.models.constants import AppRole, Role, Visibility
 from backend.search.query_builder import get_search_query
 
 
@@ -207,3 +207,35 @@ class TestSearchPermissions:
         search_query = search_query.to_dict()
 
         assert self.public_permissions_filter not in str(search_query)
+
+
+class TestVisibilityParam:
+    def test_default(self):
+        search_query = get_search_query()
+        search_query = search_query.to_dict()
+
+        assert "filter" not in search_query["query"]["bool"] or "visibility" not in str(
+            search_query["query"]["bool"]["filter"]
+        )
+
+    @pytest.mark.parametrize(
+        "visibility",
+        [
+            [Visibility.PUBLIC],
+            [Visibility.MEMBERS],
+            [Visibility.TEAM],
+            [Visibility.PUBLIC, Visibility.MEMBERS],
+            [Visibility.PUBLIC, Visibility.TEAM],
+            [Visibility.MEMBERS, Visibility.TEAM],
+            [Visibility.PUBLIC, Visibility.MEMBERS, Visibility.TEAM],
+        ],
+    )
+    def test_team(self, visibility):
+        search_query = get_search_query(visibility=visibility)
+        search_query = search_query.to_dict()
+
+        filtered_terms = search_query["query"]["bool"]["filter"][0]["terms"]
+        assert "visibility" in filtered_terms
+
+        for value in visibility:
+            assert value in filtered_terms["visibility"]

--- a/firstvoices/backend/tests/test_search/test_filters.py
+++ b/firstvoices/backend/tests/test_search/test_filters.py
@@ -236,6 +236,7 @@ class TestVisibilityParam:
 
         filtered_terms = search_query["query"]["bool"]["filter"][0]["terms"]
         assert "visibility" in filtered_terms
+        assert len(filtered_terms["visibility"]) == len(visibility)
 
         for value in visibility:
             assert value in filtered_terms["visibility"]

--- a/firstvoices/backend/tests/test_search/test_query_builder_utils.py
+++ b/firstvoices/backend/tests/test_search/test_query_builder_utils.py
@@ -1,10 +1,12 @@
 import pytest
 
+from backend.models.constants import Visibility
 from backend.search.utils.constants import VALID_DOCUMENT_TYPES
 from backend.search.utils.query_builder_utils import (
     get_valid_category_id,
     get_valid_document_types,
     get_valid_domain,
+    get_valid_visibility,
 )
 from backend.tests import factories
 
@@ -67,3 +69,30 @@ class TestValidCategory:
         actual_category_id = get_valid_category_id(self.site, "not_real_category")
 
         assert actual_category_id is None
+
+
+class TestValidVisibility:
+    @pytest.mark.parametrize(
+        "input_visibility, expected_visibility",
+        [
+            ("Team", [Visibility.TEAM]),
+            ("TeAm", [Visibility.TEAM]),
+            ("Members", [Visibility.MEMBERS]),
+            ("members", [Visibility.MEMBERS]),
+            ("Public", [Visibility.PUBLIC]),
+            ("invalid, Team", [Visibility.TEAM]),
+            ("Team, Members", [Visibility.TEAM, Visibility.MEMBERS]),
+            (
+                "Team, Members, Public",
+                [Visibility.TEAM, Visibility.MEMBERS, Visibility.PUBLIC],
+            ),
+        ],
+    )
+    def test_valid_inputs(self, input_visibility, expected_visibility):
+        actual_visibility = get_valid_visibility(input_visibility)
+        for value in actual_visibility:
+            assert value in expected_visibility
+
+    def test_invalid_input(self):
+        actual_visibility = get_valid_visibility("bananas")
+        assert actual_visibility is None

--- a/firstvoices/backend/views/search/base_search_views.py
+++ b/firstvoices/backend/views/search/base_search_views.py
@@ -18,6 +18,7 @@ from backend.search.utils.query_builder_utils import (
     get_valid_boolean,
     get_valid_document_types,
     get_valid_domain,
+    get_valid_visibility,
 )
 from backend.views.base_views import ThrottlingMixin
 from backend.views.exceptions import ElasticSearchConnectionError
@@ -214,6 +215,46 @@ from backend.views.exceptions import ElasticSearchConnectionError
                     ),
                 ],
             ),
+            OpenApiParameter(
+                name="visibility",
+                description="Filter by document visibility. Possible options are Team, Members, Public",
+                required=False,
+                default="",
+                type=str,
+                examples=[
+                    OpenApiExample(
+                        "",
+                        value="",
+                        description="Retrieves results from documents with any visibility.",
+                    ),
+                    OpenApiExample(
+                        "Team",
+                        value="Team",
+                        description="Searches for documents that are visible to team users on a site.",
+                    ),
+                    OpenApiExample(
+                        "Members",
+                        value="Members",
+                        description="Searches for documents that are visible to members of a site.",
+                    ),
+                    OpenApiExample(
+                        "Public",
+                        value="Public",
+                        description="Searches for documents that are visible to the public.",
+                    ),
+                    OpenApiExample(
+                        "Team, Members",
+                        value="Team, Members",
+                        description="Searches for documents that are visible to team users and members of a site.",
+                    ),
+                    OpenApiExample(
+                        "invalid_type",
+                        value="None",
+                        description="If no valid document types are provided, "
+                        "the API returns an empty set of results.",
+                    ),
+                ],
+            ),
         ],
     ),
 )
@@ -244,6 +285,9 @@ class BaseSearchViewSet(
         games_flag = self.request.GET.get("games", False)
         games_flag = get_valid_boolean(games_flag)
 
+        visibility = self.request.GET.get("visibility", "")
+        valid_visibility = get_valid_visibility(visibility)
+
         search_params = {
             "q": input_q,
             "user": user,
@@ -254,6 +298,7 @@ class BaseSearchViewSet(
             "site_id": "",  # used in site-search
             "starts_with_char": "",  # used in site-search
             "category_id": "",  # used in site-search
+            "visibility": valid_visibility,
         }
 
         return search_params
@@ -307,6 +352,7 @@ class BaseSearchViewSet(
             site_id=search_params["site_id"],
             starts_with_char=search_params["starts_with_char"],
             category_id=search_params["category_id"],
+            visibility=search_params["visibility"],
         )
 
         # Pagination


### PR DESCRIPTION
### Description of Changes
This PR adds a parameter `visibility` to the search API. The parameter adds filtering by document visibility: `Team`, `Members`, and `Public`. 

Note that the results will first be filtered by what the user has permission to view.

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
