### PR TITLE
FW-5165 Casing on visibility values returned by my-sites should be all lowercase

### DIFF
--- a/firstvoices/backend/serializers/membership_serializers.py
+++ b/firstvoices/backend/serializers/membership_serializers.py
@@ -34,6 +34,12 @@ class MembershipSiteSummarySerializer(serializers.HyperlinkedModelSerializer):
             request=self.context["request"],
         )
 
+    def to_representation(self, instance):
+        """Covert visibility to lowercase"""
+        site = super().to_representation(instance)
+        site["visibility"] = site["visibility"].lower()
+        return site
+
     class Meta:
         model = Membership
         fields = ("role",) + SiteSummarySerializer.Meta.fields

--- a/firstvoices/backend/tests/test_apis/test_my_sites_api.py
+++ b/firstvoices/backend/tests/test_apis/test_my_sites_api.py
@@ -30,7 +30,7 @@ class TestMySitesEndpoint(ReadOnlyApiTests):
             "title": instance.site.title,
             "slug": instance.site.slug,
             "language": instance.site.language.title,
-            "visibility": instance.site.get_visibility_display(),
+            "visibility": instance.site.get_visibility_display().lower(),
             "logo": None,
             "url": f"http://testserver/api/1.0/my-sites/{instance.site.slug}",
             "features": [],
@@ -75,8 +75,13 @@ class TestMySitesEndpoint(ReadOnlyApiTests):
         assert response.status_code == 200
         response_data = json.loads(response.content)
         assert response_data["count"] == 2
-        assert response_data["results"][0]["visibility"] == Visibility.MEMBERS.label
-        assert response_data["results"][1]["visibility"] == Visibility.PUBLIC.label
+        assert (
+            response_data["results"][0]["visibility"]
+            == Visibility.MEMBERS.label.lower()
+        )
+        assert (
+            response_data["results"][1]["visibility"] == Visibility.PUBLIC.label.lower()
+        )
 
     @pytest.mark.django_db
     def test_assistant_role(self):


### PR DESCRIPTION
### Description of Changes
my-sites API now returns lowercase visibility value

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
