### PR TITLE
FW-5137 Add media related search parameters

### DIFF
--- a/firstvoices/backend/management/commands/utils/iterators.py
+++ b/firstvoices/backend/management/commands/utils/iterators.py
@@ -96,6 +96,9 @@ def story_iterator():
             author=instance.author,
             page_text=page_text,
             page_translation=page_translation,
+            hasAudio=instance.related_audio.exists(),
+            hasVideo=instance.related_videos.exists(),
+            hasImage=instance.related_images.exists(),
         )
         yield story_doc.to_dict(True)
 
@@ -122,6 +125,9 @@ def dictionary_entry_iterator():
             exclude_from_games=entry.exclude_from_games,
             custom_order=entry.custom_order,
             visibility=entry.visibility,
+            hasAudio=entry.related_audio.exists(),
+            hasVideo=entry.related_videos.exists(),
+            hasImage=entry.related_images.exists(),
         )
         yield index_entry.to_dict(True)
 
@@ -145,5 +151,8 @@ def song_iterator():
             intro_translation=instance.introduction_translation,
             lyrics_text=lyrics_text,
             lyrics_translation=lyrics_translation_text,
+            hasAudio=instance.related_audio.exists(),
+            hasVideo=instance.related_videos.exists(),
+            hasImage=instance.related_images.exists(),
         )
         yield song_doc.to_dict(True)

--- a/firstvoices/backend/management/commands/utils/iterators.py
+++ b/firstvoices/backend/management/commands/utils/iterators.py
@@ -105,9 +105,9 @@ def dictionary_entry_iterator():
             exclude_from_games=entry.exclude_from_games,
             custom_order=entry.custom_order,
             visibility=entry.visibility,
-            hasAudio=entry.related_audio.exists(),
-            hasVideo=entry.related_videos.exists(),
-            hasImage=entry.related_images.exists(),
+            has_audio=entry.related_audio.exists(),
+            has_video=entry.related_videos.exists(),
+            has_image=entry.related_images.exists(),
         )
         yield index_entry.to_dict(True)
 

--- a/firstvoices/backend/management/commands/utils/iterators.py
+++ b/firstvoices/backend/management/commands/utils/iterators.py
@@ -5,8 +5,8 @@ from backend.models.constants import Visibility
 from backend.models.media import Audio, Image, Video
 from backend.search.documents import DictionaryEntryDocument, MediaDocument
 from backend.search.utils.get_index_documents import (
-    get_new_song_index_document,
-    get_new_story_index_document,
+    create_song_index_document,
+    create_story_index_document,
 )
 from backend.search.utils.object_utils import (
     get_acknowledgements_text,
@@ -79,7 +79,7 @@ def story_iterator():
     queryset = Story.objects.all()
     for instance in queryset:
         page_text, page_translation = get_page_info(instance)
-        story_doc = get_new_story_index_document(instance, page_text, page_translation)
+        story_doc = create_story_index_document(instance, page_text, page_translation)
         yield story_doc.to_dict(True)
 
 
@@ -116,7 +116,7 @@ def song_iterator():
     queryset = Song.objects.all()
     for instance in queryset:
         lyrics_text, lyrics_translation_text = get_lyrics(instance)
-        song_doc = get_new_song_index_document(
+        song_doc = create_song_index_document(
             instance, lyrics_text, lyrics_translation_text
         )
         yield song_doc.to_dict(True)

--- a/firstvoices/backend/management/commands/utils/iterators.py
+++ b/firstvoices/backend/management/commands/utils/iterators.py
@@ -3,11 +3,10 @@ import logging
 from backend.models import DictionaryEntry, Song, Story
 from backend.models.constants import Visibility
 from backend.models.media import Audio, Image, Video
-from backend.search.documents import (
-    DictionaryEntryDocument,
-    MediaDocument,
-    SongDocument,
-    StoryDocument,
+from backend.search.documents import DictionaryEntryDocument, MediaDocument
+from backend.search.utils.get_index_documents import (
+    get_new_song_index_document,
+    get_new_story_index_document,
 )
 from backend.search.utils.object_utils import (
     get_acknowledgements_text,
@@ -80,26 +79,7 @@ def story_iterator():
     queryset = Story.objects.all()
     for instance in queryset:
         page_text, page_translation = get_page_info(instance)
-        story_doc = StoryDocument(
-            document_id=str(instance.id),
-            site_id=str(instance.site.id),
-            site_visibility=instance.site.visibility,
-            exclude_from_games=instance.exclude_from_games,
-            exclude_from_kids=instance.exclude_from_kids,
-            visibility=instance.visibility,
-            title=instance.title,
-            title_translation=instance.title_translation,
-            note=instance.notes,
-            acknowledgement=instance.acknowledgements,
-            introduction=instance.introduction,
-            introduction_translation=instance.introduction_translation,
-            author=instance.author,
-            page_text=page_text,
-            page_translation=page_translation,
-            hasAudio=instance.related_audio.exists(),
-            hasVideo=instance.related_videos.exists(),
-            hasImage=instance.related_images.exists(),
-        )
+        story_doc = get_new_story_index_document(instance, page_text, page_translation)
         yield story_doc.to_dict(True)
 
 
@@ -136,23 +116,7 @@ def song_iterator():
     queryset = Song.objects.all()
     for instance in queryset:
         lyrics_text, lyrics_translation_text = get_lyrics(instance)
-        song_doc = SongDocument(
-            document_id=str(instance.id),
-            site_id=str(instance.site.id),
-            site_visibility=instance.site.visibility,
-            exclude_from_games=instance.exclude_from_games,
-            exclude_from_kids=instance.exclude_from_kids,
-            visibility=instance.visibility,
-            title=instance.title,
-            title_translation=instance.title_translation,
-            note=instance.notes,
-            acknowledgement=instance.acknowledgements,
-            intro_title=instance.introduction,
-            intro_translation=instance.introduction_translation,
-            lyrics_text=lyrics_text,
-            lyrics_translation=lyrics_translation_text,
-            hasAudio=instance.related_audio.exists(),
-            hasVideo=instance.related_videos.exists(),
-            hasImage=instance.related_images.exists(),
+        song_doc = get_new_song_index_document(
+            instance, lyrics_text, lyrics_translation_text
         )
         yield song_doc.to_dict(True)

--- a/firstvoices/backend/search/documents/base_document.py
+++ b/firstvoices/backend/search/documents/base_document.py
@@ -22,6 +22,6 @@ class BaseDocument(Document):
 
 class MediaReportingDocumentMixin:
     # fields for media filtering/reporting
-    hasAudio = Boolean()
-    hasVideo = Boolean()
-    hasImage = Boolean()
+    has_audio = Boolean()
+    has_video = Boolean()
+    has_image = Boolean()

--- a/firstvoices/backend/search/documents/base_document.py
+++ b/firstvoices/backend/search/documents/base_document.py
@@ -18,3 +18,10 @@ class BaseDocument(Document):
     secondary_translation_search_fields = Text()
     other_language_search_fields = Text()
     other_translation_search_fields = Text()
+
+
+class MediaReportingDocumentMixin:
+    # fields for media filtering/reporting
+    hasAudio = Boolean()
+    hasVideo = Boolean()
+    hasImage = Boolean()

--- a/firstvoices/backend/search/documents/dictionary_entry_document.py
+++ b/firstvoices/backend/search/documents/dictionary_entry_document.py
@@ -1,10 +1,13 @@
 from elasticsearch_dsl import Keyword, Text
 
-from backend.search.documents.base_document import BaseDocument
+from backend.search.documents.base_document import (
+    BaseDocument,
+    MediaReportingDocumentMixin,
+)
 from backend.search.utils.constants import ELASTICSEARCH_DICTIONARY_ENTRY_INDEX
 
 
-class DictionaryEntryDocument(BaseDocument):
+class DictionaryEntryDocument(MediaReportingDocumentMixin, BaseDocument):
     # text search fields
     title = Text(fields={"raw": Keyword()}, copy_to="primary_language_search_fields")
     translation = Text(copy_to="primary_translation_search_fields")
@@ -15,9 +18,6 @@ class DictionaryEntryDocument(BaseDocument):
     type = Keyword()
     custom_order = Keyword()
     categories = Keyword()
-    hasAudio = Keyword()
-    hasVideo = Keyword()
-    hasImage = Keyword()
 
     class Index:
         name = ELASTICSEARCH_DICTIONARY_ENTRY_INDEX

--- a/firstvoices/backend/search/documents/dictionary_entry_document.py
+++ b/firstvoices/backend/search/documents/dictionary_entry_document.py
@@ -15,6 +15,9 @@ class DictionaryEntryDocument(BaseDocument):
     type = Keyword()
     custom_order = Keyword()
     categories = Keyword()
+    hasAudio = Keyword()
+    hasVideo = Keyword()
+    hasImage = Keyword()
 
     class Index:
         name = ELASTICSEARCH_DICTIONARY_ENTRY_INDEX

--- a/firstvoices/backend/search/documents/song_document.py
+++ b/firstvoices/backend/search/documents/song_document.py
@@ -1,10 +1,13 @@
 from elasticsearch_dsl import Keyword, Text
 
-from backend.search.documents.base_document import BaseDocument
+from backend.search.documents.base_document import (
+    BaseDocument,
+    MediaReportingDocumentMixin,
+)
 from backend.search.utils.constants import ELASTICSEARCH_SONG_INDEX
 
 
-class SongDocument(BaseDocument):
+class SongDocument(MediaReportingDocumentMixin, BaseDocument):
     # text search fields
     title = Text(fields={"raw": Keyword()}, copy_to="primary_language_search_fields")
     title_translation = Text(copy_to="primary_translation_search_fields")
@@ -14,11 +17,6 @@ class SongDocument(BaseDocument):
     lyrics_translation = Text(copy_to="secondary_translation_search_fields")
     note = Text(copy_to="other_translation_search_fields")
     acknowledgement = Text(copy_to="other_translation_search_fields")
-
-    # filter and sorting
-    hasAudio = Keyword()
-    hasVideo = Keyword()
-    hasImage = Keyword()
 
     class Index:
         name = ELASTICSEARCH_SONG_INDEX

--- a/firstvoices/backend/search/documents/song_document.py
+++ b/firstvoices/backend/search/documents/song_document.py
@@ -15,5 +15,10 @@ class SongDocument(BaseDocument):
     note = Text(copy_to="other_translation_search_fields")
     acknowledgement = Text(copy_to="other_translation_search_fields")
 
+    # filter and sorting
+    hasAudio = Keyword()
+    hasVideo = Keyword()
+    hasImage = Keyword()
+
     class Index:
         name = ELASTICSEARCH_SONG_INDEX

--- a/firstvoices/backend/search/documents/story_document.py
+++ b/firstvoices/backend/search/documents/story_document.py
@@ -1,10 +1,13 @@
 from elasticsearch_dsl import Keyword, Text
 
-from backend.search.documents.base_document import BaseDocument
+from backend.search.documents.base_document import (
+    BaseDocument,
+    MediaReportingDocumentMixin,
+)
 from backend.search.utils.constants import ELASTICSEARCH_STORY_INDEX
 
 
-class StoryDocument(BaseDocument):
+class StoryDocument(MediaReportingDocumentMixin, BaseDocument):
     # text search fields
     title = Text(fields={"raw": Keyword()}, copy_to="primary_language_search_fields")
     title_translation = Text(copy_to="primary_translation_search_fields")
@@ -15,11 +18,6 @@ class StoryDocument(BaseDocument):
     acknowledgement = Text(copy_to="other_translation_search_fields")
     note = Text(copy_to="other_translation_search_fields")
     author = Text(copy_to="other_translation_search_fields")
-
-    # filter and sorting
-    hasAudio = Keyword()
-    hasVideo = Keyword()
-    hasImage = Keyword()
 
     class Index:
         name = ELASTICSEARCH_STORY_INDEX

--- a/firstvoices/backend/search/documents/story_document.py
+++ b/firstvoices/backend/search/documents/story_document.py
@@ -16,7 +16,10 @@ class StoryDocument(BaseDocument):
     note = Text(copy_to="other_translation_search_fields")
     author = Text(copy_to="other_translation_search_fields")
 
-    # Author to be added
+    # filter and sorting
+    hasAudio = Keyword()
+    hasVideo = Keyword()
+    hasImage = Keyword()
 
     class Index:
         name = ELASTICSEARCH_STORY_INDEX

--- a/firstvoices/backend/search/query_builder.py
+++ b/firstvoices/backend/search/query_builder.py
@@ -86,13 +86,13 @@ def get_search_query(
     if visibility != "":
         search_query = search_query.query(get_visibility_query(visibility))
 
-    if has_audio != "":
+    if has_audio:
         search_query = search_query.query(get_has_audio_query(has_audio))
 
-    if has_video != "":
+    if has_video:
         search_query = search_query.query(get_has_video_query(has_video))
 
-    if has_image != "":
+    if has_image:
         search_query = search_query.query(get_has_image_query(has_image))
 
     return search_query

--- a/firstvoices/backend/search/query_builder.py
+++ b/firstvoices/backend/search/query_builder.py
@@ -6,6 +6,9 @@ from backend.search.utils.query_builder_utils import (
     get_category_query,
     get_cleaned_search_term,
     get_games_query,
+    get_has_audio_query,
+    get_has_image_query,
+    get_has_video_query,
     get_indices,
     get_kids_query,
     get_site_filter_query,
@@ -33,6 +36,9 @@ def get_search_query(
     kids=False,
     games=False,
     visibility="",
+    has_audio="",
+    has_video="",
+    has_image="",
 ):
     # Building initial query
     indices = get_indices(types)
@@ -79,5 +85,14 @@ def get_search_query(
 
     if visibility != "":
         search_query = search_query.query(get_visibility_query(visibility))
+
+    if has_audio != "":
+        search_query = search_query.query(get_has_audio_query(has_audio))
+
+    if has_video != "":
+        search_query = search_query.query(get_has_video_query(has_video))
+
+    if has_image != "":
+        search_query = search_query.query(get_has_image_query(has_image))
 
     return search_query

--- a/firstvoices/backend/search/tasks/dictionary_entry_tasks.py
+++ b/firstvoices/backend/search/tasks/dictionary_entry_tasks.py
@@ -53,9 +53,9 @@ def update_dictionary_entry_index(instance_id, **kwargs):
                 exclude_from_kids=instance.exclude_from_kids,
                 visibility=instance.visibility,
                 retry_on_conflict=RETRY_ON_CONFLICT,
-                hasAudio=instance.related_audio.exists(),
-                hasVideo=instance.related_videos.exists(),
-                hasImage=instance.related_images.exists(),
+                has_audio=instance.related_audio.exists(),
+                has_video=instance.related_videos.exists(),
+                has_image=instance.related_images.exists(),
             )
         else:
             # Create new entry if it doesn't exist
@@ -73,9 +73,9 @@ def update_dictionary_entry_index(instance_id, **kwargs):
                 exclude_from_games=instance.exclude_from_games,
                 exclude_from_kids=instance.exclude_from_kids,
                 visibility=instance.visibility,
-                hasAudio=instance.related_audio.exists(),
-                hasVideo=instance.related_videos.exists(),
-                hasImage=instance.related_images.exists(),
+                has_audio=instance.related_audio.exists(),
+                has_video=instance.related_videos.exists(),
+                has_image=instance.related_images.exists(),
             )
             index_entry.save()
         # Refresh the index to ensure the index is up-to-date for related field signals

--- a/firstvoices/backend/search/tasks/dictionary_entry_tasks.py
+++ b/firstvoices/backend/search/tasks/dictionary_entry_tasks.py
@@ -53,6 +53,9 @@ def update_dictionary_entry_index(instance_id, **kwargs):
                 exclude_from_kids=instance.exclude_from_kids,
                 visibility=instance.visibility,
                 retry_on_conflict=RETRY_ON_CONFLICT,
+                hasAudio=instance.related_audio.exists(),
+                hasVideo=instance.related_videos.exists(),
+                hasImage=instance.related_images.exists(),
             )
         else:
             # Create new entry if it doesn't exist
@@ -70,6 +73,9 @@ def update_dictionary_entry_index(instance_id, **kwargs):
                 exclude_from_games=instance.exclude_from_games,
                 exclude_from_kids=instance.exclude_from_kids,
                 visibility=instance.visibility,
+                hasAudio=instance.related_audio.exists(),
+                hasVideo=instance.related_videos.exists(),
+                hasImage=instance.related_images.exists(),
             )
             index_entry.save()
         # Refresh the index to ensure the index is up-to-date for related field signals

--- a/firstvoices/backend/search/tasks/song_tasks.py
+++ b/firstvoices/backend/search/tasks/song_tasks.py
@@ -46,9 +46,9 @@ def update_song_index(instance_id, **kwargs):
                 lyrics_text=lyrics_text,
                 lyrics_translation=lyrics_translation_text,
                 retry_on_conflict=RETRY_ON_CONFLICT,
-                hasAudio=instance.related_audio.exists(),
-                hasVideo=instance.related_videos.exists(),
-                hasImage=instance.related_images.exists(),
+                has_audio=instance.related_audio.exists(),
+                has_video=instance.related_videos.exists(),
+                has_image=instance.related_images.exists(),
             )
         else:
             index_entry = create_song_index_document(

--- a/firstvoices/backend/search/tasks/song_tasks.py
+++ b/firstvoices/backend/search/tasks/song_tasks.py
@@ -45,6 +45,9 @@ def update_song_index(instance_id, **kwargs):
                 lyrics_text=lyrics_text,
                 lyrics_translation=lyrics_translation_text,
                 retry_on_conflict=RETRY_ON_CONFLICT,
+                hasAudio=instance.related_audio.exists(),
+                hasVideo=instance.related_videos.exists(),
+                hasImage=instance.related_images.exists(),
             )
         else:
             index_entry = SongDocument(
@@ -62,6 +65,9 @@ def update_song_index(instance_id, **kwargs):
                 intro_translation=instance.introduction_translation,
                 lyrics_text=lyrics_text,
                 lyrics_translation=lyrics_translation_text,
+                hasAudio=instance.related_audio.exists(),
+                hasVideo=instance.related_videos.exists(),
+                hasImage=instance.related_images.exists(),
             )
             index_entry.save()
         # Refresh the index to ensure the index is up-to-date for related field signals

--- a/firstvoices/backend/search/tasks/song_tasks.py
+++ b/firstvoices/backend/search/tasks/song_tasks.py
@@ -13,6 +13,7 @@ from backend.search.utils.constants import (
     RETRY_ON_CONFLICT,
     SearchIndexEntryTypes,
 )
+from backend.search.utils.get_index_documents import get_new_song_index_document
 from backend.search.utils.object_utils import get_lyrics, get_object_from_index
 from firstvoices.settings import ELASTICSEARCH_LOGGER
 
@@ -50,24 +51,8 @@ def update_song_index(instance_id, **kwargs):
                 hasImage=instance.related_images.exists(),
             )
         else:
-            index_entry = SongDocument(
-                document_id=str(instance.id),
-                site_id=str(instance.site.id),
-                site_visibility=instance.site.visibility,
-                exclude_from_games=instance.exclude_from_games,
-                exclude_from_kids=instance.exclude_from_kids,
-                visibility=instance.visibility,
-                title=instance.title,
-                title_translation=instance.title_translation,
-                note=instance.notes,
-                acknowledgement=instance.acknowledgements,
-                intro_title=instance.introduction,
-                intro_translation=instance.introduction_translation,
-                lyrics_text=lyrics_text,
-                lyrics_translation=lyrics_translation_text,
-                hasAudio=instance.related_audio.exists(),
-                hasVideo=instance.related_videos.exists(),
-                hasImage=instance.related_images.exists(),
+            index_entry = get_new_song_index_document(
+                instance, lyrics_text, lyrics_translation_text
             )
             index_entry.save()
         # Refresh the index to ensure the index is up-to-date for related field signals

--- a/firstvoices/backend/search/tasks/song_tasks.py
+++ b/firstvoices/backend/search/tasks/song_tasks.py
@@ -13,7 +13,7 @@ from backend.search.utils.constants import (
     RETRY_ON_CONFLICT,
     SearchIndexEntryTypes,
 )
-from backend.search.utils.get_index_documents import get_new_song_index_document
+from backend.search.utils.get_index_documents import create_song_index_document
 from backend.search.utils.object_utils import get_lyrics, get_object_from_index
 from firstvoices.settings import ELASTICSEARCH_LOGGER
 
@@ -51,7 +51,7 @@ def update_song_index(instance_id, **kwargs):
                 hasImage=instance.related_images.exists(),
             )
         else:
-            index_entry = get_new_song_index_document(
+            index_entry = create_song_index_document(
                 instance, lyrics_text, lyrics_translation_text
             )
             index_entry.save()

--- a/firstvoices/backend/search/tasks/story_tasks.py
+++ b/firstvoices/backend/search/tasks/story_tasks.py
@@ -46,9 +46,9 @@ def update_story_index(instance_id, **kwargs):
                 page_text=page_text,
                 page_translation=page_translation,
                 retry_on_conflict=RETRY_ON_CONFLICT,
-                hasAudio=instance.related_audio.exists(),
-                hasVideo=instance.related_videos.exists(),
-                hasImage=instance.related_images.exists(),
+                has_audio=instance.related_audio.exists(),
+                has_video=instance.related_videos.exists(),
+                has_image=instance.related_images.exists(),
             )
         else:
             index_entry = create_story_index_document(

--- a/firstvoices/backend/search/tasks/story_tasks.py
+++ b/firstvoices/backend/search/tasks/story_tasks.py
@@ -13,7 +13,7 @@ from backend.search.utils.constants import (
     RETRY_ON_CONFLICT,
     SearchIndexEntryTypes,
 )
-from backend.search.utils.get_index_documents import get_new_story_index_document
+from backend.search.utils.get_index_documents import create_story_index_document
 from backend.search.utils.object_utils import get_object_from_index, get_page_info
 from firstvoices.settings import ELASTICSEARCH_LOGGER
 
@@ -51,7 +51,7 @@ def update_story_index(instance_id, **kwargs):
                 hasImage=instance.related_images.exists(),
             )
         else:
-            index_entry = get_new_story_index_document(
+            index_entry = create_story_index_document(
                 instance, page_text, page_translation
             )
             index_entry.save()

--- a/firstvoices/backend/search/tasks/story_tasks.py
+++ b/firstvoices/backend/search/tasks/story_tasks.py
@@ -13,6 +13,7 @@ from backend.search.utils.constants import (
     RETRY_ON_CONFLICT,
     SearchIndexEntryTypes,
 )
+from backend.search.utils.get_index_documents import get_new_story_index_document
 from backend.search.utils.object_utils import get_object_from_index, get_page_info
 from firstvoices.settings import ELASTICSEARCH_LOGGER
 
@@ -50,25 +51,8 @@ def update_story_index(instance_id, **kwargs):
                 hasImage=instance.related_images.exists(),
             )
         else:
-            index_entry = StoryDocument(
-                document_id=str(instance.id),
-                site_id=str(instance.site.id),
-                site_visibility=instance.site.visibility,
-                exclude_from_games=instance.exclude_from_games,
-                exclude_from_kids=instance.exclude_from_kids,
-                visibility=instance.visibility,
-                title=instance.title,
-                title_translation=instance.title_translation,
-                note=instance.notes,
-                acknowledgement=instance.acknowledgements,
-                introduction=instance.introduction,
-                introduction_translation=instance.introduction_translation,
-                author=instance.author,
-                page_text=page_text,
-                page_translation=page_translation,
-                hasAudio=instance.related_audio.exists(),
-                hasVideo=instance.related_videos.exists(),
-                hasImage=instance.related_images.exists(),
+            index_entry = get_new_story_index_document(
+                instance, page_text, page_translation
             )
             index_entry.save()
         # Refresh the index to ensure the index is up-to-date for related field signals

--- a/firstvoices/backend/search/tasks/story_tasks.py
+++ b/firstvoices/backend/search/tasks/story_tasks.py
@@ -45,6 +45,9 @@ def update_story_index(instance_id, **kwargs):
                 page_text=page_text,
                 page_translation=page_translation,
                 retry_on_conflict=RETRY_ON_CONFLICT,
+                hasAudio=instance.related_audio.exists(),
+                hasVideo=instance.related_videos.exists(),
+                hasImage=instance.related_images.exists(),
             )
         else:
             index_entry = StoryDocument(
@@ -63,6 +66,9 @@ def update_story_index(instance_id, **kwargs):
                 author=instance.author,
                 page_text=page_text,
                 page_translation=page_translation,
+                hasAudio=instance.related_audio.exists(),
+                hasVideo=instance.related_videos.exists(),
+                hasImage=instance.related_images.exists(),
             )
             index_entry.save()
         # Refresh the index to ensure the index is up-to-date for related field signals

--- a/firstvoices/backend/search/utils/get_index_documents.py
+++ b/firstvoices/backend/search/utils/get_index_documents.py
@@ -18,9 +18,9 @@ def create_story_index_document(instance, page_text, page_translation):
         author=instance.author,
         page_text=page_text,
         page_translation=page_translation,
-        hasAudio=instance.related_audio.exists(),
-        hasVideo=instance.related_videos.exists(),
-        hasImage=instance.related_images.exists(),
+        has_audio=instance.related_audio.exists(),
+        has_video=instance.related_videos.exists(),
+        has_image=instance.related_images.exists(),
     )
 
 
@@ -40,7 +40,7 @@ def create_song_index_document(instance, lyrics_text, lyrics_translation_text):
         intro_translation=instance.introduction_translation,
         lyrics_text=lyrics_text,
         lyrics_translation=lyrics_translation_text,
-        hasAudio=instance.related_audio.exists(),
-        hasVideo=instance.related_videos.exists(),
-        hasImage=instance.related_images.exists(),
+        has_audio=instance.related_audio.exists(),
+        has_video=instance.related_videos.exists(),
+        has_image=instance.related_images.exists(),
     )

--- a/firstvoices/backend/search/utils/get_index_documents.py
+++ b/firstvoices/backend/search/utils/get_index_documents.py
@@ -1,0 +1,46 @@
+from backend.search.documents import SongDocument, StoryDocument
+
+
+def get_new_story_index_document(instance, page_text, page_translation):
+    return StoryDocument(
+        document_id=str(instance.id),
+        site_id=str(instance.site.id),
+        site_visibility=instance.site.visibility,
+        exclude_from_games=instance.exclude_from_games,
+        exclude_from_kids=instance.exclude_from_kids,
+        visibility=instance.visibility,
+        title=instance.title,
+        title_translation=instance.title_translation,
+        note=instance.notes,
+        acknowledgement=instance.acknowledgements,
+        introduction=instance.introduction,
+        introduction_translation=instance.introduction_translation,
+        author=instance.author,
+        page_text=page_text,
+        page_translation=page_translation,
+        hasAudio=instance.related_audio.exists(),
+        hasVideo=instance.related_videos.exists(),
+        hasImage=instance.related_images.exists(),
+    )
+
+
+def get_new_song_index_document(instance, lyrics_text, lyrics_translation_text):
+    return SongDocument(
+        document_id=str(instance.id),
+        site_id=str(instance.site.id),
+        site_visibility=instance.site.visibility,
+        exclude_from_games=instance.exclude_from_games,
+        exclude_from_kids=instance.exclude_from_kids,
+        visibility=instance.visibility,
+        title=instance.title,
+        title_translation=instance.title_translation,
+        note=instance.notes,
+        acknowledgement=instance.acknowledgements,
+        intro_title=instance.introduction,
+        intro_translation=instance.introduction_translation,
+        lyrics_text=lyrics_text,
+        lyrics_translation=lyrics_translation_text,
+        hasAudio=instance.related_audio.exists(),
+        hasVideo=instance.related_videos.exists(),
+        hasImage=instance.related_images.exists(),
+    )

--- a/firstvoices/backend/search/utils/get_index_documents.py
+++ b/firstvoices/backend/search/utils/get_index_documents.py
@@ -1,7 +1,7 @@
 from backend.search.documents import SongDocument, StoryDocument
 
 
-def get_new_story_index_document(instance, page_text, page_translation):
+def create_story_index_document(instance, page_text, page_translation):
     return StoryDocument(
         document_id=str(instance.id),
         site_id=str(instance.site.id),
@@ -24,7 +24,7 @@ def get_new_story_index_document(instance, page_text, page_translation):
     )
 
 
-def get_new_song_index_document(instance, lyrics_text, lyrics_translation_text):
+def create_song_index_document(instance, lyrics_text, lyrics_translation_text):
     return SongDocument(
         document_id=str(instance.id),
         site_id=str(instance.site.id),

--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -183,6 +183,18 @@ def get_visibility_query(visibility):
     return Q("bool", filter=[Q("terms", visibility=visibility)])
 
 
+def get_has_audio_query(has_audio):
+    return Q("bool", filter=[Q("term", hasAudio=has_audio)])
+
+
+def get_has_video_query(has_video):
+    return Q("bool", filter=[Q("term", hasVideo=has_video)])
+
+
+def get_has_image_query(has_image):
+    return Q("bool", filter=[Q("term", hasImage=has_image)])
+
+
 # Search params validation
 def get_valid_document_types(input_types, allowed_values=VALID_DOCUMENT_TYPES):
     if not input_types:
@@ -245,6 +257,17 @@ def get_valid_boolean(input_val):
         return True
     else:
         return False
+
+
+def get_valid_has_media(input_val):
+    if input_val == "":
+        return ""
+    elif str(input_val).strip().lower() in ["true"]:
+        return True
+    elif str(input_val).strip().lower() in ["false"]:
+        return False
+    else:
+        return None
 
 
 def get_valid_visibility(input_visibility_str):

--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -259,17 +259,6 @@ def get_valid_boolean(input_val):
         return False
 
 
-def get_valid_has_media(input_val):
-    if input_val == "":
-        return ""
-    elif str(input_val).strip().lower() in ["true"]:
-        return True
-    elif str(input_val).strip().lower() in ["false"]:
-        return False
-    else:
-        return None
-
-
 def get_valid_visibility(input_visibility_str):
     if not input_visibility_str:
         return ""

--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -184,15 +184,15 @@ def get_visibility_query(visibility):
 
 
 def get_has_audio_query(has_audio):
-    return Q("bool", filter=[Q("term", hasAudio=has_audio)])
+    return Q("bool", filter=[Q("term", has_audio=has_audio)])
 
 
 def get_has_video_query(has_video):
-    return Q("bool", filter=[Q("term", hasVideo=has_video)])
+    return Q("bool", filter=[Q("term", has_video=has_video)])
 
 
 def get_has_image_query(has_image):
-    return Q("bool", filter=[Q("term", hasImage=has_image)])
+    return Q("bool", filter=[Q("term", has_image=has_image)])
 
 
 # Search params validation

--- a/firstvoices/backend/tests/test_search/test_filters.py
+++ b/firstvoices/backend/tests/test_search/test_filters.py
@@ -243,28 +243,18 @@ class TestVisibilityParam:
 
 
 class TestHasMediaParams:
-    @staticmethod
-    def snake_case_to_camel_case(snake_str):
-        temp = snake_str.split("_")
-        result = temp[0] + "".join(ele.title() for ele in temp[1:])
-        return result
-
     @pytest.mark.parametrize("has_media", ["has_video", "has_audio", "has_image"])
     def test_default(self, has_media):
         search_query = get_search_query()
         search_query = search_query.to_dict()
 
-        assert "filter" not in search_query["query"][
-            "bool"
-        ] or self.snake_case_to_camel_case(has_media) not in str(
+        assert "filter" not in search_query["query"]["bool"] or has_media not in str(
             search_query["query"]["bool"]["filter"]
         )
 
     @pytest.mark.parametrize("has_media", ["has_video", "has_audio", "has_image"])
     def test_has_media_true(self, has_media):
-        expected_true_filter = (
-            f"{{'term': {{'{self.snake_case_to_camel_case(has_media)}': True}}}}"
-        )
+        expected_true_filter = f"{{'term': {{'{has_media}': True}}}}"
         search_query = get_search_query(**{has_media: True})
         search_query = search_query.to_dict()
 
@@ -272,9 +262,7 @@ class TestHasMediaParams:
 
     @pytest.mark.parametrize("has_media", ["has_video", "has_audio", "has_image"])
     def test_has_media_false(self, has_media):
-        expected_true_filter = (
-            f"{{'term': {{'{self.snake_case_to_camel_case(has_media)}': False}}}}"
-        )
+        expected_true_filter = f"{{'term': {{'{has_media}': False}}}}"
         search_query = get_search_query(**{has_media: False})
         search_query = search_query.to_dict()
 

--- a/firstvoices/backend/tests/test_search/test_filters.py
+++ b/firstvoices/backend/tests/test_search/test_filters.py
@@ -278,4 +278,4 @@ class TestHasMediaParams:
         search_query = get_search_query(**{has_media: False})
         search_query = search_query.to_dict()
 
-        assert expected_true_filter in str(search_query)
+        assert expected_true_filter not in str(search_query)

--- a/firstvoices/backend/tests/test_search/test_filters.py
+++ b/firstvoices/backend/tests/test_search/test_filters.py
@@ -240,3 +240,42 @@ class TestVisibilityParam:
 
         for value in visibility:
             assert value in filtered_terms["visibility"]
+
+
+class TestHasMediaParams:
+    @staticmethod
+    def snake_case_to_camel_case(snake_str):
+        temp = snake_str.split("_")
+        result = temp[0] + "".join(ele.title() for ele in temp[1:])
+        return result
+
+    @pytest.mark.parametrize("has_media", ["has_video", "has_audio", "has_image"])
+    def test_default(self, has_media):
+        search_query = get_search_query()
+        search_query = search_query.to_dict()
+
+        assert "filter" not in search_query["query"][
+            "bool"
+        ] or self.snake_case_to_camel_case(has_media) not in str(
+            search_query["query"]["bool"]["filter"]
+        )
+
+    @pytest.mark.parametrize("has_media", ["has_video", "has_audio", "has_image"])
+    def test_has_media_true(self, has_media):
+        expected_true_filter = (
+            f"{{'term': {{'{self.snake_case_to_camel_case(has_media)}': True}}}}"
+        )
+        search_query = get_search_query(**{has_media: True})
+        search_query = search_query.to_dict()
+
+        assert expected_true_filter in str(search_query)
+
+    @pytest.mark.parametrize("has_media", ["has_video", "has_audio", "has_image"])
+    def test_has_media_false(self, has_media):
+        expected_true_filter = (
+            f"{{'term': {{'{self.snake_case_to_camel_case(has_media)}': False}}}}"
+        )
+        search_query = get_search_query(**{has_media: False})
+        search_query = search_query.to_dict()
+
+        assert expected_true_filter in str(search_query)

--- a/firstvoices/backend/tests/test_search/test_query_builder_utils.py
+++ b/firstvoices/backend/tests/test_search/test_query_builder_utils.py
@@ -6,6 +6,7 @@ from backend.search.utils.query_builder_utils import (
     get_valid_category_id,
     get_valid_document_types,
     get_valid_domain,
+    get_valid_has_media,
     get_valid_visibility,
 )
 from backend.tests import factories
@@ -96,3 +97,21 @@ class TestValidVisibility:
     def test_invalid_input(self):
         actual_visibility = get_valid_visibility("bananas")
         assert actual_visibility is None
+
+
+class TestValidHasMedia:
+    @pytest.mark.parametrize(
+        "input_has_media, expected_has_media",
+        [
+            ("True", True),
+            ("False", False),
+            ("", ""),
+        ],
+    )
+    def test_valid_inputs(self, input_has_media, expected_has_media):
+        actual_has_media = get_valid_has_media(input_has_media)
+        assert actual_has_media == expected_has_media
+
+    def test_invalid_input(self):
+        actual_has_media = get_valid_has_media("bananas")
+        assert actual_has_media is None

--- a/firstvoices/backend/tests/test_search/test_query_builder_utils.py
+++ b/firstvoices/backend/tests/test_search/test_query_builder_utils.py
@@ -6,7 +6,6 @@ from backend.search.utils.query_builder_utils import (
     get_valid_category_id,
     get_valid_document_types,
     get_valid_domain,
-    get_valid_has_media,
     get_valid_visibility,
 )
 from backend.tests import factories
@@ -97,21 +96,3 @@ class TestValidVisibility:
     def test_invalid_input(self):
         actual_visibility = get_valid_visibility("bananas")
         assert actual_visibility is None
-
-
-class TestValidHasMedia:
-    @pytest.mark.parametrize(
-        "input_has_media, expected_has_media",
-        [
-            ("True", True),
-            ("False", False),
-            ("", ""),
-        ],
-    )
-    def test_valid_inputs(self, input_has_media, expected_has_media):
-        actual_has_media = get_valid_has_media(input_has_media)
-        assert actual_has_media == expected_has_media
-
-    def test_invalid_input(self):
-        actual_has_media = get_valid_has_media("bananas")
-        assert actual_has_media is None

--- a/firstvoices/backend/views/search/base_search_views.py
+++ b/firstvoices/backend/views/search/base_search_views.py
@@ -18,7 +18,6 @@ from backend.search.utils.query_builder_utils import (
     get_valid_boolean,
     get_valid_document_types,
     get_valid_domain,
-    get_valid_has_media,
     get_valid_visibility,
 )
 from backend.views.base_views import ThrottlingMixin
@@ -289,14 +288,14 @@ class BaseSearchViewSet(
         visibility = self.request.GET.get("visibility", "")
         valid_visibility = get_valid_visibility(visibility)
 
-        has_audio = self.request.GET.get("hasAudio", "")
-        valid_has_audio = get_valid_has_media(has_audio)
+        has_audio = self.request.GET.get("hasAudio", False)
+        has_audio = get_valid_boolean(has_audio)
 
-        has_video = self.request.GET.get("hasVideo", "")
-        valid_has_video = get_valid_has_media(has_video)
+        has_video = self.request.GET.get("hasVideo", False)
+        has_video = get_valid_boolean(has_video)
 
-        has_image = self.request.GET.get("hasImage", "")
-        valid_has_image = get_valid_has_media(has_image)
+        has_image = self.request.GET.get("hasImage", False)
+        has_image = get_valid_boolean(has_image)
 
         search_params = {
             "q": input_q,
@@ -309,9 +308,9 @@ class BaseSearchViewSet(
             "starts_with_char": "",  # used in site-search
             "category_id": "",  # used in site-search
             "visibility": valid_visibility,
-            "has_audio": valid_has_audio,
-            "has_video": valid_has_video,
-            "has_image": valid_has_image,
+            "has_audio": has_audio,
+            "has_video": has_video,
+            "has_image": has_image,
         }
 
         return search_params
@@ -356,14 +355,6 @@ class BaseSearchViewSet(
 
         # If invalid visibility is passed, return empty list as a response
         if search_params["visibility"] is None:
-            return Response(data=[])
-
-        # If invalid has_media is passed, return empty list as a response
-        if (
-            search_params["has_audio"] is None
-            or search_params["has_video"] is None
-            or search_params["has_image"] is None
-        ):
             return Response(data=[])
 
         # Get search query

--- a/firstvoices/backend/views/search/base_search_views.py
+++ b/firstvoices/backend/views/search/base_search_views.py
@@ -18,6 +18,7 @@ from backend.search.utils.query_builder_utils import (
     get_valid_boolean,
     get_valid_document_types,
     get_valid_domain,
+    get_valid_has_media,
     get_valid_visibility,
 )
 from backend.views.base_views import ThrottlingMixin
@@ -288,6 +289,15 @@ class BaseSearchViewSet(
         visibility = self.request.GET.get("visibility", "")
         valid_visibility = get_valid_visibility(visibility)
 
+        has_audio = self.request.GET.get("hasAudio", "")
+        valid_has_audio = get_valid_has_media(has_audio)
+
+        has_video = self.request.GET.get("hasVideo", "")
+        valid_has_video = get_valid_has_media(has_video)
+
+        has_image = self.request.GET.get("hasImage", "")
+        valid_has_image = get_valid_has_media(has_image)
+
         search_params = {
             "q": input_q,
             "user": user,
@@ -299,6 +309,9 @@ class BaseSearchViewSet(
             "starts_with_char": "",  # used in site-search
             "category_id": "",  # used in site-search
             "visibility": valid_visibility,
+            "has_audio": valid_has_audio,
+            "has_video": valid_has_video,
+            "has_image": valid_has_image,
         }
 
         return search_params
@@ -353,6 +366,9 @@ class BaseSearchViewSet(
             starts_with_char=search_params["starts_with_char"],
             category_id=search_params["category_id"],
             visibility=search_params["visibility"],
+            has_audio=search_params["has_audio"],
+            has_video=search_params["has_video"],
+            has_image=search_params["has_image"],
         )
 
         # Pagination

--- a/firstvoices/backend/views/search/base_search_views.py
+++ b/firstvoices/backend/views/search/base_search_views.py
@@ -354,6 +354,18 @@ class BaseSearchViewSet(
         if search_params["category_id"] is None:
             return Response(data=[])
 
+        # If invalid visibility is passed, return empty list as a response
+        if search_params["visibility"] is None:
+            return Response(data=[])
+
+        # If invalid has_media is passed, return empty list as a response
+        if (
+            search_params["has_audio"] is None
+            or search_params["has_video"] is None
+            or search_params["has_image"] is None
+        ):
+            return Response(data=[])
+
         # Get search query
         search_query = get_search_query(
             user=search_params["user"],


### PR DESCRIPTION
### Description of Changes
This PR adds the following changes:
- `has_audio`, `has_video`, and `has_image` added to dictionary, song, and story search indices (a boolean which returns true if an instance has related media of a type)
- `hasAudio`, `hasVideo`, and `hasImage` added to search parameters

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
