### PR TITLE
FW-5171 Fix private join requests

### DIFF
--- a/firstvoices/backend/models/sites.py
+++ b/firstvoices/backend/models/sites.py
@@ -100,6 +100,7 @@ class Site(BaseModel):
             "add": predicates.is_superadmin,
             "change": predicates.is_language_admin_or_super,
             "delete": predicates.is_superadmin,
+            "join": rules.is_authenticated,
         }
 
         constraints = [

--- a/firstvoices/backend/models/sites.py
+++ b/firstvoices/backend/models/sites.py
@@ -100,7 +100,6 @@ class Site(BaseModel):
             "add": predicates.is_superadmin,
             "change": predicates.is_language_admin_or_super,
             "delete": predicates.is_superadmin,
-            "join": rules.is_authenticated,
         }
 
         constraints = [

--- a/firstvoices/backend/views/join_request_views.py
+++ b/firstvoices/backend/views/join_request_views.py
@@ -148,23 +148,21 @@ class JoinRequestViewSet(
         )
 
     def get_validated_site(self):
-        if self.action == "create":
-            site_perm = "join"
-        else:
-            site_perm = "view"
-
         site_slug = self.get_site_slug()
         site = Site.objects.filter(slug=site_slug)
 
         if len(site) == 0:
             raise Http404
 
-        # Check permissions on the site first
-        perm = Site.get_perm(site_perm)
-        if self.request.user.has_perm(perm, site[0]):
-            return site
+        # Check permissions on the site first, skip if the action is create
+        if self.action != "create":
+            perm = Site.get_perm("view")
+            if self.request.user.has_perm(perm, site[0]):
+                return site
+            else:
+                raise PermissionDenied
         else:
-            raise PermissionDenied
+            return site
 
     @action(detail=True, methods=["post"])
     def ignore(self, request, site_slug=None, pk=None):


### PR DESCRIPTION
### Description of Changes
Changes permissions such that join request can be added on private sites.
- Adds "join" permission to sites
- Uses join permission in join request view
- Adjusted tests as necessary 

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
