### PR TITLE
FW-3385 Only exact search for larger queries

### DIFF
--- a/firstvoices/backend/search/utils/constants.py
+++ b/firstvoices/backend/search/utils/constants.py
@@ -4,6 +4,10 @@ from django.utils.translation import gettext as _
 # retry_on_conflict for all update calls
 RETRY_ON_CONFLICT = 10
 
+# Only exact search will be used if the length of
+# search term crosses this threshold
+FUZZY_SEARCH_CUTOFF = 50
+
 # Index names
 ELASTICSEARCH_DICTIONARY_ENTRY_INDEX = "dictionary_entries"
 ELASTICSEARCH_SONG_INDEX = "songs"

--- a/firstvoices/backend/search/utils/search_term_query.py
+++ b/firstvoices/backend/search/utils/search_term_query.py
@@ -174,6 +174,16 @@ def get_search_term_query(search_term, domain):
     subqueries = []
 
     subquery_domains = {
+        "language_exact": [
+            exact_match_primary_language_query,
+            exact_match_secondary_language_query,
+            exact_match_other_language_query,
+        ],
+        "translation_exact": [
+            exact_match_primary_translation_query,
+            exact_match_secondary_translation_query,
+            exact_match_other_translation_query,
+        ],
         "language": [
             exact_match_primary_language_query,
             fuzzy_match_primary_language_query,
@@ -194,8 +204,15 @@ def get_search_term_query(search_term, domain):
     subquery_domains["both"] = (
         subquery_domains["language"] + subquery_domains["translation"]
     )
+    subquery_domains["both_exact"] = (
+        subquery_domains["language_exact"] + subquery_domains["translation_exact"]
+    )
 
-    subqueries += subquery_domains.get(domain, [])
+    if len(search_term) >= 50:
+        # Use only exact field matching, no fuzzy matching
+        subqueries += subquery_domains.get(domain + "_exact", [])
+    else:
+        subqueries += subquery_domains.get(domain, [])
 
     return Q(
         "bool",

--- a/firstvoices/backend/search/utils/search_term_query.py
+++ b/firstvoices/backend/search/utils/search_term_query.py
@@ -1,5 +1,7 @@
 from elasticsearch_dsl import Q
 
+from backend.search.utils.constants import FUZZY_SEARCH_CUTOFF
+
 BASE_BOOST = 1.0  # default value of boost
 EXACT_MATCH_PRIMARY_BOOST = 5
 EXACT_MATCH_SECONDARY_BOOST = 4
@@ -208,7 +210,7 @@ def get_search_term_query(search_term, domain):
         subquery_domains["language_exact"] + subquery_domains["translation_exact"]
     )
 
-    if len(search_term) >= 50:
+    if len(search_term) >= FUZZY_SEARCH_CUTOFF:
         # Use only exact field matching, no fuzzy matching
         subqueries += subquery_domains.get(domain + "_exact", [])
     else:

--- a/firstvoices/backend/tests/test_search/test_query_params.py
+++ b/firstvoices/backend/tests/test_search/test_query_params.py
@@ -1,7 +1,9 @@
 import pytest
 
 from backend.search.query_builder import get_search_query
+from backend.search.utils.constants import FUZZY_SEARCH_CUTOFF
 from backend.tests import factories
+from backend.tests.utils import generate_string
 
 
 @pytest.mark.django_db
@@ -192,65 +194,70 @@ class TestQueryParams:
         assert expected_exact_match_other_translation_string in str(search_query)
         assert expected_fuzzy_match_other_translation_string in str(search_query)
 
-    @pytest.mark.parametrize(
-        "q", ["Lorem ipsum dolor sit amet, consectetur adipiscing elit."]
-    )
-    def test_search_term_length_gt_50(self, q):
-        # Testing for search term having length more than 50 characters
-        search_query = get_search_query(q=q)
+    def test_search_term_length_gt_threshold(self):
+        # Testing for search term having length more than the defined fuzzy search cutoff
+        search_term = generate_string(FUZZY_SEARCH_CUTOFF + 5)
+
+        search_query = get_search_query(q=search_term)
         search_query = search_query.to_dict()
 
         expected_exact_match_primary_language_string = (
-            "'match_phrase': {'primary_language_search_fields': {'query': "
-            "'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 'slop': 3, 'boost': 5}}"
+            "'match_phrase': {'primary_language_search_fields': {'query': '"
+            + search_term
+            + "', 'slop': 3, 'boost': 5}}"
         )
         expected_fuzzy_match_primary_language_string = (
-            "'fuzzy': {'primary_language_search_fields': {'value': 'Lorem ipsum dolor sit amet, consectetur "
-            "adipiscing elit.', 'fuzziness': '2', 'boost': 3}}"
+            "'fuzzy': {'primary_language_search_fields': {'value': '"
+            + search_term
+            + "', 'fuzziness': '2', 'boost': 3}}"
         )
         expected_exact_match_primary_translation_string = (
             "'match_phrase': {'primary_translation_search_fields': {"
-            "'query': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 'slop': 3, 'boost': 5}}"
+            "'query': '" + search_term + "', 'slop': 3, 'boost': 5}}"
         )
         expected_fuzzy_match_primary_translation_string = (
-            "'fuzzy': {'primary_translation_search_fields': {'value': "
-            "'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 'fuzziness': '2', 'boost': 3}}"
+            "'fuzzy': {'primary_translation_search_fields': {'value': '"
+            + search_term
+            + "', 'fuzziness': '2', 'boost': 3}}"
         )
 
         # Secondary fields
         expected_exact_match_secondary_language_string = (
             "'match_phrase': {'secondary_language_search_fields': {"
-            "'query': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 'slop': 3, 'boost': 4}}"
+            "'query': '" + search_term + "', 'slop': 3, 'boost': 4}}"
         )
         expected_fuzzy_match_secondary_language_string = (
-            "'fuzzy': {'secondary_language_search_fields': {'value': "
-            "'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 'fuzziness': '2', 'boost': 2}}"
+            "'fuzzy': {'secondary_language_search_fields': {'value': '"
+            + search_term
+            + "', 'fuzziness': '2', 'boost': 2}}"
         )
         expected_exact_match_secondary_translation_string = (
             "'match_phrase': {'secondary_translation_search_fields': "
-            "{'query': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 'slop': 3, 'boost': 4}}"
+            "{'query': '" + search_term + "', 'slop': 3, 'boost': 4}}"
         )
         expected_fuzzy_match_secondary_translation_string = (
             "'fuzzy': {'secondary_translation_search_fields': {"
-            "'value': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 'fuzziness': '2', 'boost': 2}}"
+            "'value': '" + search_term + "', 'fuzziness': '2', 'boost': 2}}"
         )
 
         # Other fields
         expected_exact_match_other_language_string = (
-            "'match_phrase': {'other_language_search_fields': {'query': "
-            "'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 'slop': 3, 'boost': 1.5}}"
+            "'match_phrase': {'other_language_search_fields': {'query': '"
+            + search_term
+            + "', 'slop': 3, 'boost': 1.5}}"
         )
         expected_fuzzy_match_other_language_string = (
-            "'fuzzy': {'other_language_search_fields': {'value': "
-            "'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 'fuzziness': '2', 'boost': 1.0}}"
+            "'fuzzy': {'other_language_search_fields': {'value': '"
+            + search_term
+            + "', 'fuzziness': '2', 'boost': 1.0}}"
         )
         expected_exact_match_other_translation_string = (
             "'match_phrase': {'other_translation_search_fields': "
-            "{'query': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 'slop': 3, 'boost': 1.5}}"
+            "{'query': '" + search_term + "', 'slop': 3, 'boost': 1.5}}"
         )
         expected_fuzzy_match_other_translation_string = (
             "'fuzzy': {'other_translation_search_fields': "
-            "{'value': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 'fuzziness': '2', 'boost': 1.0}}"
+            "{'value': '" + search_term + "', 'fuzziness': '2', 'boost': 1.0}}"
         )
 
         assert expected_exact_match_primary_language_string in str(search_query)

--- a/firstvoices/backend/tests/test_search/test_query_params.py
+++ b/firstvoices/backend/tests/test_search/test_query_params.py
@@ -192,6 +192,84 @@ class TestQueryParams:
         assert expected_exact_match_other_translation_string in str(search_query)
         assert expected_fuzzy_match_other_translation_string in str(search_query)
 
+    @pytest.mark.parametrize(
+        "q", ["Lorem ipsum dolor sit amet, consectetur adipiscing elit."]
+    )
+    def test_search_term_length_gt_50(self, q):
+        # Testing for search term having length more than 50 characters
+        search_query = get_search_query(q=q)
+        search_query = search_query.to_dict()
+
+        expected_exact_match_primary_language_string = (
+            "'match_phrase': {'primary_language_search_fields': {'query': "
+            "'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 'slop': 3, 'boost': 5}}"
+        )
+        expected_fuzzy_match_primary_language_string = (
+            "'fuzzy': {'primary_language_search_fields': {'value': 'Lorem ipsum dolor sit amet, consectetur "
+            "adipiscing elit.', 'fuzziness': '2', 'boost': 3}}"
+        )
+        expected_exact_match_primary_translation_string = (
+            "'match_phrase': {'primary_translation_search_fields': {"
+            "'query': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 'slop': 3, 'boost': 5}}"
+        )
+        expected_fuzzy_match_primary_translation_string = (
+            "'fuzzy': {'primary_translation_search_fields': {'value': "
+            "'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 'fuzziness': '2', 'boost': 3}}"
+        )
+
+        # Secondary fields
+        expected_exact_match_secondary_language_string = (
+            "'match_phrase': {'secondary_language_search_fields': {"
+            "'query': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 'slop': 3, 'boost': 4}}"
+        )
+        expected_fuzzy_match_secondary_language_string = (
+            "'fuzzy': {'secondary_language_search_fields': {'value': "
+            "'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 'fuzziness': '2', 'boost': 2}}"
+        )
+        expected_exact_match_secondary_translation_string = (
+            "'match_phrase': {'secondary_translation_search_fields': "
+            "{'query': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 'slop': 3, 'boost': 4}}"
+        )
+        expected_fuzzy_match_secondary_translation_string = (
+            "'fuzzy': {'secondary_translation_search_fields': {"
+            "'value': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 'fuzziness': '2', 'boost': 2}}"
+        )
+
+        # Other fields
+        expected_exact_match_other_language_string = (
+            "'match_phrase': {'other_language_search_fields': {'query': "
+            "'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 'slop': 3, 'boost': 1.5}}"
+        )
+        expected_fuzzy_match_other_language_string = (
+            "'fuzzy': {'other_language_search_fields': {'value': "
+            "'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 'fuzziness': '2', 'boost': 1.0}}"
+        )
+        expected_exact_match_other_translation_string = (
+            "'match_phrase': {'other_translation_search_fields': "
+            "{'query': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 'slop': 3, 'boost': 1.5}}"
+        )
+        expected_fuzzy_match_other_translation_string = (
+            "'fuzzy': {'other_translation_search_fields': "
+            "{'value': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', 'fuzziness': '2', 'boost': 1.0}}"
+        )
+
+        assert expected_exact_match_primary_language_string in str(search_query)
+        assert expected_fuzzy_match_primary_language_string not in str(search_query)
+        assert expected_exact_match_primary_translation_string in str(search_query)
+        assert expected_fuzzy_match_primary_translation_string not in str(search_query)
+
+        assert expected_exact_match_secondary_language_string in str(search_query)
+        assert expected_fuzzy_match_secondary_language_string not in str(search_query)
+        assert expected_exact_match_secondary_translation_string in str(search_query)
+        assert expected_fuzzy_match_secondary_translation_string not in str(
+            search_query
+        )
+
+        assert expected_exact_match_other_language_string in str(search_query)
+        assert expected_fuzzy_match_other_language_string not in str(search_query)
+        assert expected_exact_match_other_translation_string in str(search_query)
+        assert expected_fuzzy_match_other_translation_string not in str(search_query)
+
 
 @pytest.mark.django_db
 class TestDomain:

--- a/firstvoices/backend/tests/test_search/test_query_params.py
+++ b/firstvoices/backend/tests/test_search/test_query_params.py
@@ -2,8 +2,24 @@ import pytest
 
 from backend.search.query_builder import get_search_query
 from backend.search.utils.constants import FUZZY_SEARCH_CUTOFF
+from backend.search.utils.search_term_query import (
+    EXACT_MATCH_OTHER_BOOST,
+    EXACT_MATCH_PRIMARY_BOOST,
+    EXACT_MATCH_SECONDARY_BOOST,
+    FUZZY_MATCH_OTHER_BOOST,
+    FUZZY_MATCH_PRIMARY_BOOST,
+    FUZZY_MATCH_SECONDARY_BOOST,
+)
 from backend.tests import factories
 from backend.tests.utils import generate_string
+
+
+def get_match_query(field_name, query, boost):
+    return f"'match_phrase': {{'{field_name}': {{'query': '{query}', 'slop': 3, 'boost': {boost}}}}}"
+
+
+def get_fuzzy_query(field_name, query, boost):
+    return f"'fuzzy': {{'{field_name}': {{'value': '{query}', 'fuzziness': '2', 'boost': {boost}}}}}"
 
 
 @pytest.mark.django_db
@@ -21,58 +37,72 @@ class TestQueryParams:
         # relates to: SearchQueryTest.java - testPaddedQuery()
         search_query = get_search_query(q=q)
         search_query = search_query.to_dict()
+        expected_search_term = "test"
 
-        expected_exact_match_primary_language_string = (
-            "'match_phrase': {'primary_language_search_fields': {'query': "
-            "'test', 'slop': 3, 'boost': 5}}"
+        # Primary fields
+        expected_exact_match_primary_language_string = get_match_query(
+            "primary_language_search_fields",
+            expected_search_term,
+            EXACT_MATCH_PRIMARY_BOOST,
         )
-        expected_fuzzy_match_primary_language_string = (
-            "'fuzzy': {'primary_language_search_fields': {'value': 'test', "
-            "'fuzziness': '2', 'boost': 3}}"
+        expected_fuzzy_match_primary_language_string = get_fuzzy_query(
+            "primary_language_search_fields",
+            expected_search_term,
+            FUZZY_MATCH_PRIMARY_BOOST,
         )
-        expected_exact_match_primary_translation_string = (
-            "'match_phrase': {'primary_translation_search_fields': {"
-            "'query': 'test', 'slop': 3, 'boost': 5}}"
+        expected_exact_match_primary_translation_string = get_match_query(
+            "primary_translation_search_fields",
+            expected_search_term,
+            EXACT_MATCH_PRIMARY_BOOST,
         )
-        expected_fuzzy_match_primary_translation_string = (
-            "'fuzzy': {'primary_translation_search_fields': {'value': "
-            "'test', 'fuzziness': '2', 'boost': 3}}"
+        expected_fuzzy_match_primary_translation_string = get_fuzzy_query(
+            "primary_translation_search_fields",
+            expected_search_term,
+            FUZZY_MATCH_PRIMARY_BOOST,
         )
 
         # Secondary fields
-        expected_exact_match_secondary_language_string = (
-            "'match_phrase': {'secondary_language_search_fields': {"
-            "'query': 'test', 'slop': 3, 'boost': 4}}"
+        expected_exact_match_secondary_language_string = get_match_query(
+            "secondary_language_search_fields",
+            expected_search_term,
+            EXACT_MATCH_SECONDARY_BOOST,
         )
-        expected_fuzzy_match_secondary_language_string = (
-            "'fuzzy': {'secondary_language_search_fields': {'value': "
-            "'test', 'fuzziness': '2', 'boost': 2}}"
+        expected_fuzzy_match_secondary_language_string = get_fuzzy_query(
+            "secondary_language_search_fields",
+            expected_search_term,
+            FUZZY_MATCH_SECONDARY_BOOST,
         )
-        expected_exact_match_secondary_translation_string = (
-            "'match_phrase': {'secondary_translation_search_fields': "
-            "{'query': 'test', 'slop': 3, 'boost': 4}}"
+        expected_exact_match_secondary_translation_string = get_match_query(
+            "secondary_translation_search_fields",
+            expected_search_term,
+            EXACT_MATCH_SECONDARY_BOOST,
         )
-        expected_fuzzy_match_secondary_translation_string = (
-            "'fuzzy': {'secondary_translation_search_fields': {"
-            "'value': 'test', 'fuzziness': '2', 'boost': 2}}"
+        expected_fuzzy_match_secondary_translation_string = get_fuzzy_query(
+            "secondary_translation_search_fields",
+            expected_search_term,
+            FUZZY_MATCH_SECONDARY_BOOST,
         )
 
         # Other fields
-        expected_exact_match_other_language_string = (
-            "'match_phrase': {'other_language_search_fields': {'query': "
-            "'test', 'slop': 3, 'boost': 1.5}}"
+        expected_exact_match_other_language_string = get_match_query(
+            "other_language_search_fields",
+            expected_search_term,
+            EXACT_MATCH_OTHER_BOOST,
         )
-        expected_fuzzy_match_other_language_string = (
-            "'fuzzy': {'other_language_search_fields': {'value': "
-            "'test', 'fuzziness': '2', 'boost': 1.0}}"
+        expected_fuzzy_match_other_language_string = get_fuzzy_query(
+            "other_language_search_fields",
+            expected_search_term,
+            FUZZY_MATCH_OTHER_BOOST,
         )
-        expected_exact_match_other_translation_string = (
-            "'match_phrase': {'other_translation_search_fields': "
-            "{'query': 'test', 'slop': 3, 'boost': 1.5}}"
+        expected_exact_match_other_translation_string = get_match_query(
+            "other_translation_search_fields",
+            expected_search_term,
+            EXACT_MATCH_OTHER_BOOST,
         )
-        expected_fuzzy_match_other_translation_string = (
-            "'fuzzy': {'other_translation_search_fields': "
-            "{'value': 'test', 'fuzziness': '2', 'boost': 1.0}}"
+        expected_fuzzy_match_other_translation_string = get_fuzzy_query(
+            "other_translation_search_fields",
+            expected_search_term,
+            FUZZY_MATCH_OTHER_BOOST,
         )
 
         assert expected_exact_match_primary_language_string in str(search_query)
@@ -105,78 +135,54 @@ class TestQueryParams:
         search_query = get_search_query(q=input_str)
         search_query = search_query.to_dict()
 
-        expected_exact_match_primary_language_string = (
-            "'match_phrase': {'primary_language_search_fields': {'query': '"
-            + expected_str
-            + "', "
-            "'slop': 3, 'boost': 5}}"
+        # Primary fields
+        expected_exact_match_primary_language_string = get_match_query(
+            "primary_language_search_fields", expected_str, EXACT_MATCH_PRIMARY_BOOST
         )
-        expected_fuzzy_match_primary_language_string = (
-            "'fuzzy': {'primary_language_search_fields': {'value': '"
-            + expected_str
-            + "', "
-            "'fuzziness': '2', 'boost': 3}}"
+        expected_fuzzy_match_primary_language_string = get_fuzzy_query(
+            "primary_language_search_fields", expected_str, FUZZY_MATCH_PRIMARY_BOOST
         )
-        expected_exact_match_primary_translation_string = (
-            "'match_phrase': {'primary_translation_search_fields': {'query': '"
-            + expected_str
-            + "', 'slop': 3, 'boost': 5}}"
+        expected_exact_match_primary_translation_string = get_match_query(
+            "primary_translation_search_fields", expected_str, EXACT_MATCH_PRIMARY_BOOST
         )
-        expected_fuzzy_match_primary_translation_string = (
-            "'fuzzy': {'primary_translation_search_fields': {'value': '"
-            + expected_str
-            + "', "
-            "'fuzziness': '2', 'boost': 3}}"
+        expected_fuzzy_match_primary_translation_string = get_fuzzy_query(
+            "primary_translation_search_fields", expected_str, FUZZY_MATCH_PRIMARY_BOOST
         )
 
         # Secondary fields
-        expected_exact_match_secondary_language_string = (
-            "'match_phrase': {'secondary_language_search_fields': {'query': '"
-            + expected_str
-            + "', 'slop': 3, 'boost': 4}}"
+        expected_exact_match_secondary_language_string = get_match_query(
+            "secondary_language_search_fields",
+            expected_str,
+            EXACT_MATCH_SECONDARY_BOOST,
         )
-        expected_fuzzy_match_secondary_language_string = (
-            "'fuzzy': {'secondary_language_search_fields': {'value': '"
-            + expected_str
-            + "', "
-            "'fuzziness': '2', 'boost': 2}}"
+        expected_fuzzy_match_secondary_language_string = get_fuzzy_query(
+            "secondary_language_search_fields",
+            expected_str,
+            FUZZY_MATCH_SECONDARY_BOOST,
         )
-        expected_exact_match_secondary_translation_string = (
-            "'match_phrase': {'secondary_translation_search_fields': {'query': '"
-            + expected_str
-            + "', 'slop': 3, 'boost': 4}}"
+        expected_exact_match_secondary_translation_string = get_match_query(
+            "secondary_translation_search_fields",
+            expected_str,
+            EXACT_MATCH_SECONDARY_BOOST,
         )
-        expected_fuzzy_match_secondary_translation_string = (
-            "'fuzzy': {'secondary_translation_search_fields': {'value': '"
-            + expected_str
-            + "', "
-            "'fuzziness': '2', 'boost': 2}}"
+        expected_fuzzy_match_secondary_translation_string = get_fuzzy_query(
+            "secondary_translation_search_fields",
+            expected_str,
+            FUZZY_MATCH_SECONDARY_BOOST,
         )
 
         # Other fields
-        expected_exact_match_other_language_string = (
-            "'match_phrase': {'other_language_search_fields': {'query': '"
-            + expected_str
-            + "', "
-            "'slop': 3, 'boost': 1.5}}"
+        expected_exact_match_other_language_string = get_match_query(
+            "other_language_search_fields", expected_str, EXACT_MATCH_OTHER_BOOST
         )
-        expected_fuzzy_match_other_language_string = (
-            "'fuzzy': {'other_language_search_fields': {'value': '"
-            + expected_str
-            + "', "
-            "'fuzziness': '2', 'boost': 1.0}}"
+        expected_fuzzy_match_other_language_string = get_fuzzy_query(
+            "other_language_search_fields", expected_str, FUZZY_MATCH_OTHER_BOOST
         )
-        expected_exact_match_other_translation_string = (
-            "'match_phrase': {'other_translation_search_fields': {'query': '"
-            + expected_str
-            + "', "
-            "'slop': 3, 'boost': 1.5}}"
+        expected_exact_match_other_translation_string = get_match_query(
+            "other_translation_search_fields", expected_str, EXACT_MATCH_OTHER_BOOST
         )
-        expected_fuzzy_match_other_translation_string = (
-            "'fuzzy': {'other_translation_search_fields': {'value': '"
-            + expected_str
-            + "', "
-            "'fuzziness': '2', 'boost': 1.0}}"
+        expected_fuzzy_match_other_translation_string = get_fuzzy_query(
+            "other_translation_search_fields", expected_str, FUZZY_MATCH_OTHER_BOOST
         )
 
         assert expected_exact_match_primary_language_string in str(search_query)
@@ -201,63 +207,49 @@ class TestQueryParams:
         search_query = get_search_query(q=search_term)
         search_query = search_query.to_dict()
 
-        expected_exact_match_primary_language_string = (
-            "'match_phrase': {'primary_language_search_fields': {'query': '"
-            + search_term
-            + "', 'slop': 3, 'boost': 5}}"
+        expected_exact_match_primary_language_string = get_match_query(
+            "primary_language_search_fields", search_term, EXACT_MATCH_PRIMARY_BOOST
         )
-        expected_fuzzy_match_primary_language_string = (
-            "'fuzzy': {'primary_language_search_fields': {'value': '"
-            + search_term
-            + "', 'fuzziness': '2', 'boost': 3}}"
+        expected_fuzzy_match_primary_language_string = get_fuzzy_query(
+            "primary_language_search_fields", search_term, FUZZY_MATCH_PRIMARY_BOOST
         )
-        expected_exact_match_primary_translation_string = (
-            "'match_phrase': {'primary_translation_search_fields': {"
-            "'query': '" + search_term + "', 'slop': 3, 'boost': 5}}"
+        expected_exact_match_primary_translation_string = get_match_query(
+            "primary_translation_search_fields", search_term, EXACT_MATCH_PRIMARY_BOOST
         )
-        expected_fuzzy_match_primary_translation_string = (
-            "'fuzzy': {'primary_translation_search_fields': {'value': '"
-            + search_term
-            + "', 'fuzziness': '2', 'boost': 3}}"
+        expected_fuzzy_match_primary_translation_string = get_fuzzy_query(
+            "primary_translation_search_fields", search_term, FUZZY_MATCH_PRIMARY_BOOST
         )
 
         # Secondary fields
-        expected_exact_match_secondary_language_string = (
-            "'match_phrase': {'secondary_language_search_fields': {"
-            "'query': '" + search_term + "', 'slop': 3, 'boost': 4}}"
+        expected_exact_match_secondary_language_string = get_match_query(
+            "secondary_language_search_fields", search_term, EXACT_MATCH_SECONDARY_BOOST
         )
-        expected_fuzzy_match_secondary_language_string = (
-            "'fuzzy': {'secondary_language_search_fields': {'value': '"
-            + search_term
-            + "', 'fuzziness': '2', 'boost': 2}}"
+        expected_fuzzy_match_secondary_language_string = get_fuzzy_query(
+            "secondary_language_search_fields", search_term, FUZZY_MATCH_SECONDARY_BOOST
         )
-        expected_exact_match_secondary_translation_string = (
-            "'match_phrase': {'secondary_translation_search_fields': "
-            "{'query': '" + search_term + "', 'slop': 3, 'boost': 4}}"
+        expected_exact_match_secondary_translation_string = get_match_query(
+            "secondary_translation_search_fields",
+            search_term,
+            EXACT_MATCH_SECONDARY_BOOST,
         )
-        expected_fuzzy_match_secondary_translation_string = (
-            "'fuzzy': {'secondary_translation_search_fields': {"
-            "'value': '" + search_term + "', 'fuzziness': '2', 'boost': 2}}"
+        expected_fuzzy_match_secondary_translation_string = get_fuzzy_query(
+            "secondary_translation_search_fields",
+            search_term,
+            FUZZY_MATCH_SECONDARY_BOOST,
         )
 
         # Other fields
-        expected_exact_match_other_language_string = (
-            "'match_phrase': {'other_language_search_fields': {'query': '"
-            + search_term
-            + "', 'slop': 3, 'boost': 1.5}}"
+        expected_exact_match_other_language_string = get_match_query(
+            "other_language_search_fields", search_term, EXACT_MATCH_OTHER_BOOST
         )
-        expected_fuzzy_match_other_language_string = (
-            "'fuzzy': {'other_language_search_fields': {'value': '"
-            + search_term
-            + "', 'fuzziness': '2', 'boost': 1.0}}"
+        expected_fuzzy_match_other_language_string = get_fuzzy_query(
+            "other_language_search_fields", search_term, FUZZY_MATCH_OTHER_BOOST
         )
-        expected_exact_match_other_translation_string = (
-            "'match_phrase': {'other_translation_search_fields': "
-            "{'query': '" + search_term + "', 'slop': 3, 'boost': 1.5}}"
+        expected_exact_match_other_translation_string = get_match_query(
+            "other_translation_search_fields", search_term, EXACT_MATCH_OTHER_BOOST
         )
-        expected_fuzzy_match_other_translation_string = (
-            "'fuzzy': {'other_translation_search_fields': "
-            "{'value': '" + search_term + "', 'fuzziness': '2', 'boost': 1.0}}"
+        expected_fuzzy_match_other_translation_string = get_fuzzy_query(
+            "other_translation_search_fields", search_term, FUZZY_MATCH_OTHER_BOOST
         )
 
         assert expected_exact_match_primary_language_string in str(search_query)

--- a/firstvoices/backend/tests/test_search/test_query_params.py
+++ b/firstvoices/backend/tests/test_search/test_query_params.py
@@ -272,58 +272,64 @@ class TestQueryParams:
 
 @pytest.mark.django_db
 class TestDomain:
+    search_term = "test_query"
+
     # Primary language fields
-    expected_exact_match_primary_language_string = (
-        "'match_phrase': {'primary_language_search_fields': "
-        "{'query': 'test_query', 'slop': 3, 'boost': 5}}"
+    expected_exact_match_primary_language_string = get_match_query(
+        "primary_language_search_fields",
+        search_term,
+        EXACT_MATCH_PRIMARY_BOOST,
     )
-    expected_fuzzy_match_primary_language_string = (
-        "'fuzzy': {'primary_language_search_fields': "
-        "{'value': 'test_query', 'fuzziness': '2', 'boost': 3}}"
+    expected_fuzzy_match_primary_language_string = get_fuzzy_query(
+        "primary_language_search_fields",
+        search_term,
+        FUZZY_MATCH_PRIMARY_BOOST,
     )
-    expected_exact_match_primary_translation_string = (
-        "'match_phrase': {'primary_translation_search_fields': "
-        "{'query': 'test_query', 'slop': 3, 'boost': 5}}"
+    expected_exact_match_primary_translation_string = get_match_query(
+        "primary_translation_search_fields",
+        search_term,
+        EXACT_MATCH_PRIMARY_BOOST,
     )
-    expected_fuzzy_match_primary_translation_string = (
-        "'fuzzy': {'primary_translation_search_fields': "
-        "{'value': 'test_query', 'fuzziness': '2', 'boost': 3}}"
+    expected_fuzzy_match_primary_translation_string = get_fuzzy_query(
+        "primary_translation_search_fields",
+        search_term,
+        FUZZY_MATCH_PRIMARY_BOOST,
     )
 
     # Secondary fields
-    expected_exact_match_secondary_language_string = (
-        "'match_phrase': {'secondary_language_search_fields': "
-        "{'query': 'test_query', 'slop': 3, 'boost': 4}}"
+    expected_exact_match_secondary_language_string = get_match_query(
+        "secondary_language_search_fields",
+        search_term,
+        EXACT_MATCH_SECONDARY_BOOST,
     )
-    expected_fuzzy_match_secondary_language_string = (
-        "'fuzzy': {'secondary_language_search_fields': "
-        "{'value': 'test_query', 'fuzziness': '2', 'boost': 2}}"
+    expected_fuzzy_match_secondary_language_string = get_fuzzy_query(
+        "secondary_language_search_fields",
+        search_term,
+        FUZZY_MATCH_SECONDARY_BOOST,
     )
-    expected_exact_match_secondary_translation_string = (
-        "'match_phrase': {'secondary_translation_search_fields': "
-        "{'query': 'test_query', 'slop': 3, 'boost': 4}}"
+    expected_exact_match_secondary_translation_string = get_match_query(
+        "secondary_translation_search_fields",
+        search_term,
+        EXACT_MATCH_SECONDARY_BOOST,
     )
-    expected_fuzzy_match_secondary_translation_string = (
-        "'fuzzy': {'secondary_translation_search_fields': "
-        "{'value': 'test_query', 'fuzziness': '2', 'boost': 2}}"
+    expected_fuzzy_match_secondary_translation_string = get_fuzzy_query(
+        "secondary_translation_search_fields",
+        search_term,
+        FUZZY_MATCH_SECONDARY_BOOST,
     )
 
     # Other fields
-    expected_exact_match_other_language_string = (
-        "'match_phrase': {'other_language_search_fields': "
-        "{'query': 'test_query', 'slop': 3, 'boost': 1.5}}"
+    expected_exact_match_other_language_string = get_match_query(
+        "other_language_search_fields", search_term, EXACT_MATCH_OTHER_BOOST
     )
-    expected_fuzzy_match_other_language_string = (
-        "'fuzzy': {'other_language_search_fields': "
-        "{'value': 'test_query', 'fuzziness': '2', 'boost': 1.0}}"
+    expected_fuzzy_match_other_language_string = get_fuzzy_query(
+        "other_language_search_fields", search_term, FUZZY_MATCH_OTHER_BOOST
     )
-    expected_exact_match_other_translation_string = (
-        "'match_phrase': {'other_translation_search_fields': "
-        "{'query': 'test_query', 'slop': 3, 'boost': 1.5}}"
+    expected_exact_match_other_translation_string = get_match_query(
+        "other_translation_search_fields", search_term, EXACT_MATCH_OTHER_BOOST
     )
-    expected_fuzzy_match_other_translation_string = (
-        "'fuzzy': {'other_translation_search_fields': "
-        "{'value': 'test_query', 'fuzziness': '2', 'boost': 1.0}}"
+    expected_fuzzy_match_other_translation_string = get_fuzzy_query(
+        "other_translation_search_fields", search_term, FUZZY_MATCH_OTHER_BOOST
     )
 
     def test_english(self):


### PR DESCRIPTION
### Description of Changes
- Fuzzy match subqueries will not be added in case of search term having a length of more than **50 characters.**
- Refactored query params related tests to use reusable methods for generating matching queries.

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
