### PR TITLE
FW-5138 Add order by search parameter

### DIFF
--- a/firstvoices/backend/management/commands/utils/iterators.py
+++ b/firstvoices/backend/management/commands/utils/iterators.py
@@ -30,6 +30,8 @@ def media_doc_generator(instance, media_type):
         type=media_type,
         filename=instance.original.content.name,
         description=instance.description,
+        created=instance.created,
+        last_modified=instance.last_modified,
     )
 
 
@@ -108,6 +110,8 @@ def dictionary_entry_iterator():
             has_audio=entry.related_audio.exists(),
             has_video=entry.related_videos.exists(),
             has_image=entry.related_images.exists(),
+            created=entry.created,
+            last_modified=entry.last_modified,
         )
         yield index_entry.to_dict(True)
 

--- a/firstvoices/backend/search/documents/base_document.py
+++ b/firstvoices/backend/search/documents/base_document.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import Boolean, Document, Integer, Keyword, Text
+from elasticsearch_dsl import Boolean, Date, Document, Integer, Keyword, Text
 
 
 class BaseDocument(Document):
@@ -9,6 +9,8 @@ class BaseDocument(Document):
     visibility = Integer()
     exclude_from_games = Boolean()
     exclude_from_kids = Boolean()
+    created = Date()
+    last_modified = Date()
 
     # combined text search fields
     # for boost values for following fields refer search/utils/search_term_query.py

--- a/firstvoices/backend/search/tasks/dictionary_entry_tasks.py
+++ b/firstvoices/backend/search/tasks/dictionary_entry_tasks.py
@@ -56,6 +56,8 @@ def update_dictionary_entry_index(instance_id, **kwargs):
                 has_audio=instance.related_audio.exists(),
                 has_video=instance.related_videos.exists(),
                 has_image=instance.related_images.exists(),
+                created=instance.created,
+                last_modified=instance.last_modified,
             )
         else:
             # Create new entry if it doesn't exist
@@ -76,6 +78,8 @@ def update_dictionary_entry_index(instance_id, **kwargs):
                 has_audio=instance.related_audio.exists(),
                 has_video=instance.related_videos.exists(),
                 has_image=instance.related_images.exists(),
+                created=instance.created,
+                last_modified=instance.last_modified,
             )
             index_entry.save()
         # Refresh the index to ensure the index is up-to-date for related field signals

--- a/firstvoices/backend/search/tasks/media_tasks.py
+++ b/firstvoices/backend/search/tasks/media_tasks.py
@@ -51,6 +51,8 @@ def update_media_index(instance_id, media_type, **kwargs):
                 filename=instance.original.content.name,
                 description=instance.description,
                 retry_on_conflict=RETRY_ON_CONFLICT,
+                created=instance.created,
+                last_modified=instance.last_modified,
             )
         else:
             index_entry = MediaDocument(
@@ -64,6 +66,8 @@ def update_media_index(instance_id, media_type, **kwargs):
                 type=media_type,
                 filename=instance.original.content.name,
                 description=instance.description,
+                created=instance.created,
+                last_modified=instance.last_modified,
             )
             index_entry.save()
         # Refresh the index to ensure the index is up-to-date for related field signals

--- a/firstvoices/backend/search/tasks/song_tasks.py
+++ b/firstvoices/backend/search/tasks/song_tasks.py
@@ -49,6 +49,8 @@ def update_song_index(instance_id, **kwargs):
                 has_audio=instance.related_audio.exists(),
                 has_video=instance.related_videos.exists(),
                 has_image=instance.related_images.exists(),
+                created=instance.created,
+                last_modified=instance.last_modified,
             )
         else:
             index_entry = create_song_index_document(

--- a/firstvoices/backend/search/tasks/story_tasks.py
+++ b/firstvoices/backend/search/tasks/story_tasks.py
@@ -49,6 +49,8 @@ def update_story_index(instance_id, **kwargs):
                 has_audio=instance.related_audio.exists(),
                 has_video=instance.related_videos.exists(),
                 has_image=instance.related_images.exists(),
+                created=instance.created,
+                last_modified=instance.last_modified,
             )
         else:
             index_entry = create_story_index_document(

--- a/firstvoices/backend/search/utils/get_index_documents.py
+++ b/firstvoices/backend/search/utils/get_index_documents.py
@@ -21,6 +21,8 @@ def create_story_index_document(instance, page_text, page_translation):
         has_audio=instance.related_audio.exists(),
         has_video=instance.related_videos.exists(),
         has_image=instance.related_images.exists(),
+        created=instance.created,
+        last_modified=instance.last_modified,
     )
 
 
@@ -43,4 +45,6 @@ def create_song_index_document(instance, lyrics_text, lyrics_translation_text):
         has_audio=instance.related_audio.exists(),
         has_video=instance.related_videos.exists(),
         has_image=instance.related_images.exists(),
+        created=instance.created,
+        last_modified=instance.last_modified,
     )

--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -281,7 +281,7 @@ def get_valid_visibility(input_visibility_str):
 
 
 def get_valid_sort(input_sort_by_str):
-    input_string = input_sort_by_str.strip().split("_")
+    input_string = input_sort_by_str.lower().strip().split("_")
 
     descending = len(input_string) > 1 and input_string[1] == "desc"
 
@@ -292,4 +292,4 @@ def get_valid_sort(input_sort_by_str):
     ):
         return input_string[0], descending
     else:  # if invalid string is passed
-        return None, descending
+        return None, None

--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -278,3 +278,19 @@ def get_valid_visibility(input_visibility_str):
     if len(selected_values) == 0:
         return None
     return selected_values
+
+
+def get_valid_order_by(input_order_by_str):
+    input_string = input_order_by_str.strip()
+
+    if not input_string:
+        return ""
+
+    if (
+        input_string == "dateCreated"
+        or input_string == "dateModified"
+        or input_string == "alphabet"
+    ):
+        return input_string
+    else:  # if invalid string is passed
+        return None

--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -280,17 +280,16 @@ def get_valid_visibility(input_visibility_str):
     return selected_values
 
 
-def get_valid_order_by(input_order_by_str):
-    input_string = input_order_by_str.strip()
+def get_valid_sort(input_sort_by_str):
+    input_string = input_sort_by_str.strip().split("_")
 
-    if not input_string:
-        return ""
+    descending = len(input_string) > 1 and input_string[1] == "desc"
 
-    if (
-        input_string == "dateCreated"
-        or input_string == "dateModified"
-        or input_string == "alphabet"
+    if len(input_string) > 0 and (
+        input_string[0] == "created"
+        or input_string[0] == "modified"
+        or input_string[0] == "title"
     ):
-        return input_string
+        return input_string[0], descending
     else:  # if invalid string is passed
-        return None
+        return None, descending

--- a/firstvoices/backend/serializers/dictionary_serializers.py
+++ b/firstvoices/backend/serializers/dictionary_serializers.py
@@ -383,12 +383,14 @@ class DictionaryEntryMinimalSerializer(
         model = dictionary.DictionaryEntry
         fields = (
             "id",
+            "created",
+            "last_modified",
+            "visibility",
             "title",
             "type",
             "site",
             "translations",
             "related_audio",
             "related_images",
-            "visibility",
         )
         read_only_fields = ("id", "title", "type")

--- a/firstvoices/backend/serializers/media_serializers.py
+++ b/firstvoices/backend/serializers/media_serializers.py
@@ -278,6 +278,8 @@ class AudioMinimalSerializer(serializers.ModelSerializer):
         model = media.Audio
         fields = (
             "id",
+            "created",
+            "last_modified",
             "title",
             "description",
             "acknowledgement",
@@ -305,7 +307,14 @@ class RelatedVideoMinimalSerializer(RelatedImageMinimalSerializer):
 
 class MediaMinimalSerializer(serializers.ModelSerializer):
     class Meta:
-        fields = ("id", "original", "title", "description")
+        fields = (
+            "id",
+            "created",
+            "last_modified",
+            "original",
+            "title",
+            "description",
+        )
         read_only_fields = ("id", "original", "title", "description")
 
 

--- a/firstvoices/backend/serializers/song_serializers.py
+++ b/firstvoices/backend/serializers/song_serializers.py
@@ -121,12 +121,14 @@ class SongMinimalSerializer(ReadOnlyVisibilityFieldMixin, serializers.ModelSeria
         model = Song
         fields = (
             "id",
+            "created",
+            "last_modified",
+            "visibility",
             "title",
             "title_translation",
             "hide_overlay",
             "site",
             "related_images",
             "related_videos",
-            "visibility",
         )
         read_only_fields = ("id", "title", "title_translation", "hide_overlay")

--- a/firstvoices/backend/serializers/story_serializers.py
+++ b/firstvoices/backend/serializers/story_serializers.py
@@ -218,6 +218,9 @@ class StoryMinimalSerializer(ReadOnlyVisibilityFieldMixin, serializers.ModelSeri
         model = Story
         fields = (
             "id",
+            "created",
+            "last_modified",
+            "visibility",
             "title",
             "title_translation",
             "author",
@@ -225,5 +228,4 @@ class StoryMinimalSerializer(ReadOnlyVisibilityFieldMixin, serializers.ModelSeri
             "site",
             "related_images",
             "related_videos",
-            "visibility",
         )

--- a/firstvoices/backend/tests/test_search/test_query_builder_utils.py
+++ b/firstvoices/backend/tests/test_search/test_query_builder_utils.py
@@ -106,9 +106,15 @@ class TestValidSort:
             ("created", ("created", False)),
             ("modified", ("modified", False)),
             ("title", ("title", False)),
+            ("crEaTed", ("created", False)),
+            ("MODIFIED", ("modified", False)),
+            ("TiTlE", ("title", False)),
             ("created_desc", ("created", True)),
             ("modified_desc", ("modified", True)),
             ("title_desc", ("title", True)),
+            ("crEaTed_desC", ("created", True)),
+            ("MODIFIED_DeSc", ("modified", True)),
+            ("TiTlE_DESC", ("title", True)),
         ],
     )
     def test_valid_inputs(self, input_sort, expected_sort):
@@ -118,4 +124,4 @@ class TestValidSort:
     def test_invalid_input(self):
         actual_sort, descending = get_valid_sort("bananas")
         assert actual_sort is None
-        assert descending is False
+        assert descending is None

--- a/firstvoices/backend/tests/test_search/test_query_builder_utils.py
+++ b/firstvoices/backend/tests/test_search/test_query_builder_utils.py
@@ -6,6 +6,7 @@ from backend.search.utils.query_builder_utils import (
     get_valid_category_id,
     get_valid_document_types,
     get_valid_domain,
+    get_valid_order_by,
     get_valid_visibility,
 )
 from backend.tests import factories
@@ -96,3 +97,22 @@ class TestValidVisibility:
     def test_invalid_input(self):
         actual_visibility = get_valid_visibility("bananas")
         assert actual_visibility is None
+
+
+class TestValidOrderBy:
+    @pytest.mark.parametrize(
+        "input_order_by, expected_order_by",
+        [
+            ("dateCreated", "dateCreated"),
+            ("dateModified", "dateModified"),
+            ("alphabet", "alphabet"),
+            ("", ""),
+        ],
+    )
+    def test_valid_inputs(self, input_order_by, expected_order_by):
+        actual_order_by = get_valid_order_by(input_order_by)
+        assert actual_order_by == expected_order_by
+
+    def test_invalid_input(self):
+        actual_order_by = get_valid_order_by("bananas")
+        assert actual_order_by is None

--- a/firstvoices/backend/tests/test_search/test_query_builder_utils.py
+++ b/firstvoices/backend/tests/test_search/test_query_builder_utils.py
@@ -6,7 +6,7 @@ from backend.search.utils.query_builder_utils import (
     get_valid_category_id,
     get_valid_document_types,
     get_valid_domain,
-    get_valid_order_by,
+    get_valid_sort,
     get_valid_visibility,
 )
 from backend.tests import factories
@@ -99,20 +99,23 @@ class TestValidVisibility:
         assert actual_visibility is None
 
 
-class TestValidOrderBy:
+class TestValidSort:
     @pytest.mark.parametrize(
-        "input_order_by, expected_order_by",
+        "input_sort, expected_sort",
         [
-            ("dateCreated", "dateCreated"),
-            ("dateModified", "dateModified"),
-            ("alphabet", "alphabet"),
-            ("", ""),
+            ("created", ("created", False)),
+            ("modified", ("modified", False)),
+            ("title", ("title", False)),
+            ("created_desc", ("created", True)),
+            ("modified_desc", ("modified", True)),
+            ("title_desc", ("title", True)),
         ],
     )
-    def test_valid_inputs(self, input_order_by, expected_order_by):
-        actual_order_by = get_valid_order_by(input_order_by)
-        assert actual_order_by == expected_order_by
+    def test_valid_inputs(self, input_sort, expected_sort):
+        actual_sort = get_valid_sort(input_sort)
+        assert actual_sort == expected_sort
 
     def test_invalid_input(self):
-        actual_order_by = get_valid_order_by("bananas")
-        assert actual_order_by is None
+        actual_sort, descending = get_valid_sort("bananas")
+        assert actual_sort is None
+        assert descending is False

--- a/firstvoices/backend/views/search/base_search_views.py
+++ b/firstvoices/backend/views/search/base_search_views.py
@@ -449,33 +449,38 @@ class BaseSearchViewSet(
             date_order = "asc"
             text_order = "desc"
 
+        custom_order_sort = {
+            "custom_order": {"unmapped_type": "keyword", "order": text_order}
+        }
+        title_order_sort = {"title.raw": {"order": text_order}}
+
         match search_params["order_by"]:
             case "dateCreated":
                 # Sort by created, then by custom sort order, and finally title.
                 search_query = search_query.sort(
                     {"created": {"order": date_order}},
-                    {"custom_order": {"unmapped_type": "keyword", "order": text_order}},
-                    {"title.raw": {"order": text_order}},
+                    custom_order_sort,
+                    title_order_sort,
                 )
             case "dateModified":
                 # Sort by last_modified, then by custom sort order, and finally title.
                 search_query = search_query.sort(
                     {"last_modified": {"order": date_order}},
-                    {"custom_order": {"unmapped_type": "keyword", "order": text_order}},
-                    {"title.raw": {"order": text_order}},
+                    custom_order_sort,
+                    title_order_sort,
                 )
             case "alphabet":
                 # Sort by custom sort order, and finally title. Allows descending order.
                 search_query = search_query.sort(
-                    {"custom_order": {"unmapped_type": "keyword", "order": text_order}},
-                    {"title.raw": {"order": text_order}},
+                    custom_order_sort,
+                    title_order_sort,
                 )
             case _:
                 # No order_by param is passed case. Sort by score, then by custom sort order, and finally title.
                 search_query = search_query.sort(
                     "_score",
-                    {"custom_order": {"unmapped_type": "keyword"}},
-                    "title.raw",
+                    custom_order_sort,
+                    title_order_sort,
                 )
 
         # Get search results

--- a/firstvoices/backend/views/search/base_search_views.py
+++ b/firstvoices/backend/views/search/base_search_views.py
@@ -425,11 +425,7 @@ class BaseSearchViewSet(
             from_=pagination_params["start"], size=pagination_params["page_size"]
         )
 
-        sort_direction = (
-            "desc"
-            if search_params["descending"] and search_params["sort"] is not None
-            else "asc"
-        )
+        sort_direction = "desc" if search_params["descending"] else "asc"
         custom_order_sort = {
             "custom_order": {"unmapped_type": "keyword", "order": sort_direction}
         }


### PR DESCRIPTION
### Description of Changes
This PR adds the ability to order the search results by the following:
- `created`: orders results by the created timestamp
- `modified`: orders results by the last modified timestamp
- `title`: orders results by title based on the alphabet custom order

Results are sorted in ascending order by default and `_desc` can optional get added to the parameter which will sort results in descending order (eg: `sort=created_desc`).

The created and last_modified values have been added to the search index to support these parameters. Additionally, the `created` and `last_modified` values have been added to the serializers used by the search view.

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
