### PR TITLE
FW-5032 Add row skipping and tests for partial export models

### DIFF
--- a/firstvoices/backend/resources/join_requests.py
+++ b/firstvoices/backend/resources/join_requests.py
@@ -61,21 +61,21 @@ class JoinRequestResource(SiteContentResource):
 
     def after_import_row(self, row, row_result, row_number=None, **kwargs):
         # add join request reasons
-        if not row_result.import_type == RowResult.IMPORT_TYPE_SKIP:
-            if (
-                JoinRequest.objects.filter(id=row["id"]).exists()
-                and row["reasons"] != ""
-            ):
-                join_request = JoinRequest.objects.get(id=row["id"])
-                reasons = row["reasons"].strip().split(",")
+        if (
+            row_result.import_type != RowResult.IMPORT_TYPE_SKIP
+            and JoinRequest.objects.filter(id=row["id"]).exists()
+            and row["reasons"] != ""
+        ):
+            join_request = JoinRequest.objects.get(id=row["id"])
+            reasons = row["reasons"].strip().split(",")
 
-                for reason in reasons:
-                    reason = reason.strip('"').strip()
-                    join_request_reason = JoinRequestReason.objects.create(
-                        join_request=join_request,
-                        reason=JoinRequestReasonChoices[reason].value,
-                    )
-                    join_request_reason.save()
+            for reason in reasons:
+                reason = reason.strip('"').strip()
+                join_request_reason = JoinRequestReason.objects.create(
+                    join_request=join_request,
+                    reason=JoinRequestReasonChoices[reason].value,
+                )
+                join_request_reason.save()
 
     def skip_row(self, instance, original, row, import_validation_errors=None):
         """Skip join requests that already exist."""

--- a/firstvoices/backend/resources/sites.py
+++ b/firstvoices/backend/resources/sites.py
@@ -80,3 +80,12 @@ class MembershipResource(SiteContentResource):
 
     class Meta:
         model = Membership
+
+    def skip_row(self, instance, original, row, import_validation_errors=None):
+        """Skip memberships that already exist."""
+        membership_exists = Membership.objects.filter(
+            user=instance.user, site=instance.site
+        ).exists()
+        if membership_exists:
+            return True
+        return super().skip_row(instance, original, row, import_validation_errors)

--- a/firstvoices/backend/tests/test_resources/test_join_request_resource.py
+++ b/firstvoices/backend/tests/test_resources/test_join_request_resource.py
@@ -87,3 +87,23 @@ class TestJoinRequestImport:
         assert not result.has_validation_errors()
         assert result.totals["skip"] == len(data)
         assert JoinRequest.objects.count() == 0
+
+    @pytest.mark.django_db
+    def test_skip_existing_join_requests(self):
+        """Import JoinRequest object with existing join request, should skip row"""
+        site = factories.SiteFactory.create()
+        user = factories.UserFactory.create()
+        factories.JoinRequestFactory.create(site=site, user=user)
+        data = [
+            f"{site.id},2021-04-09 22:52:17.460,{user.email},2021-04-09 22:52:17.460,{user.email},"
+            f"{site.id},"
+            f'{user.email},reason note,PENDING,"LANGUAGE_LEARNER"',
+        ]
+        table = self.build_table(data)
+
+        result = JoinRequestResource().import_data(dataset=table)
+
+        assert not result.has_errors()
+        assert not result.has_validation_errors()
+        assert result.totals["skip"] == len(data)
+        assert JoinRequest.objects.count() == 1


### PR DESCRIPTION
### Description of Changes
This PR ensures that existing memberships and join requests are skipped during the import process, to allow for partial exports in the nuxeo export script to be imported without errors/having to clear certain models in the db.

This change is implemented for the benefit of testing the remaining migrations on dev/preprod.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
