### PR TITLE
Fw 5101 fix remaining n 1 query api issues

### DIFF
--- a/firstvoices/backend/models/characters.py
+++ b/firstvoices/backend/models/characters.py
@@ -5,6 +5,7 @@ import yaml
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.utils import IntegrityError
+from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
 
 from backend.permissions import predicates
@@ -239,21 +240,23 @@ class Alphabet(BaseSiteContentModel):
     # JSON representation of a g2p mapping from confusable characters to canonical characters
     input_to_canonical_map = models.JSONField(default=list)
 
-    @property
+    @cached_property
     def base_characters(self):
         """
         Characters for the site in sort order.
         """
         return Character.objects.filter(site=self.site).order_by("sort_order")
 
-    @property
+    @cached_property
     def variant_characters(self):
         """
         All variant characters for the site.
         """
-        return CharacterVariant.objects.filter(site=self.site)
+        return CharacterVariant.objects.filter(site=self.site).select_related(
+            "base_character"
+        )
 
-    @property
+    @cached_property
     def ignorable_characters(self):
         """
         Ignorable characters for the site.

--- a/firstvoices/backend/views/image_views.py
+++ b/firstvoices/backend/views/image_views.py
@@ -81,7 +81,7 @@ class ImageViewSet(
         site = self.get_validated_site()
         return (
             Image.objects.filter(site__slug=site[0].slug)
-            .prefetch_related("site", *get_select_related_media_fields(None))
+            .select_related(*get_select_related_media_fields(None))
             .order_by("-created")
             .defer(
                 "created_by_id",

--- a/firstvoices/backend/views/video_views.py
+++ b/firstvoices/backend/views/video_views.py
@@ -81,7 +81,7 @@ class VideoViewSet(
         site = self.get_validated_site()
         return (
             Video.objects.filter(site__slug=site[0].slug)
-            .prefetch_related("site", *get_select_related_media_fields(None))
+            .select_related(*get_select_related_media_fields(None))
             .order_by("-created")
             .defer(
                 "created_by_id",


### PR DESCRIPTION
### Description of Changes
- Added caching to 3 properties of the Alphabet model.
- Added a select_related for variant_characters property to resolve N+1 query issue.
- Moved the prefetch_related clause to select_related for ImageViewSet and VideoViewSet to resolve N+1 query issue.
- Added a separate ticket to refactor the base_views to further reduce duplicate and similar queries. Ticket: [FW-5208](https://firstvoices.atlassian.net/browse/FW-5208)

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A


[FW-5208]: https://firstvoices.atlassian.net/browse/FW-5208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ