### PR TITLE
FW-4521 Add Stats API

### DIFF
--- a/firstvoices/backend/serializers/site_serializers.py
+++ b/firstvoices/backend/serializers/site_serializers.py
@@ -85,6 +85,7 @@ class SiteDetailSerializer(UpdateSerializerMixin, SiteSummarySerializer):
     pages = SiteViewLinkField(view_name="api:sitepage-list")
     people = SiteViewLinkField(view_name="api:person-list")
     songs = SiteViewLinkField(view_name="api:song-list")
+    stats = SiteViewLinkField(view_name="api:stats-list")
     stories = SiteViewLinkField(view_name="api:story-list")
     videos = SiteViewLinkField(view_name="api:video-list")
     widgets = SiteViewLinkField(view_name="api:sitewidget-list")
@@ -118,6 +119,7 @@ class SiteDetailSerializer(UpdateSerializerMixin, SiteSummarySerializer):
             "pages",
             "people",
             "songs",
+            "stats",
             "stories",
             "videos",
             "widgets",

--- a/firstvoices/backend/serializers/stats_serializers.py
+++ b/firstvoices/backend/serializers/stats_serializers.py
@@ -1,0 +1,55 @@
+from rest_framework import serializers
+
+"""
+The serializers in this file are only used in the API docs for site statistics. They are not used in the actual
+view.
+"""
+
+
+class AggregateItemSerializer(serializers.Serializer):
+    total = serializers.IntegerField()
+    availableInChildrensArchive = serializers.IntegerField()
+    public = serializers.IntegerField()
+
+
+class AggregateSerializer(serializers.Serializer):
+    words = AggregateItemSerializer()
+    phrases = AggregateItemSerializer()
+    songs = AggregateItemSerializer()
+    stories = AggregateItemSerializer()
+    images = AggregateItemSerializer()
+    audio = AggregateItemSerializer()
+    video = AggregateItemSerializer()
+
+
+class TemporalItemSerializer(serializers.Serializer):
+    created = serializers.IntegerField()
+    lastModified = serializers.IntegerField()
+    public = serializers.IntegerField()
+    members = serializers.IntegerField()
+    team = serializers.IntegerField()
+
+
+class TemporalTimeSerializer(serializers.Serializer):
+    lastYear = TemporalItemSerializer()
+    last6Months = TemporalItemSerializer()
+    last3Months = TemporalItemSerializer()
+    lastMonth = TemporalItemSerializer()
+    lastWeek = TemporalItemSerializer()
+    last3Days = TemporalItemSerializer()
+    today = TemporalItemSerializer()
+
+
+class TemporalSerializer(serializers.Serializer):
+    words = TemporalTimeSerializer()
+    phrases = TemporalTimeSerializer()
+    songs = TemporalTimeSerializer()
+    stories = TemporalTimeSerializer()
+    images = TemporalTimeSerializer()
+    audio = TemporalTimeSerializer()
+    video = TemporalTimeSerializer()
+
+
+class SiteStatsSerializer(serializers.Serializer):
+    aggregate = AggregateSerializer()
+    temporal = TemporalSerializer()

--- a/firstvoices/backend/tests/test_apis/test_sites_api.py
+++ b/firstvoices/backend/tests/test_apis/test_sites_api.py
@@ -258,6 +258,7 @@ class TestSitesEndpoints(MediaTestMixin, BaseApiTest):
             "pages": f"{site_url}/pages",
             "people": f"{site_url}/people",
             "songs": f"{site_url}/songs",
+            "stats": f"{site_url}/stats",
             "stories": f"{site_url}/stories",
             "videos": f"{site_url}/videos",
             "widgets": f"{site_url}/widgets",

--- a/firstvoices/backend/tests/test_apis/test_stats_api.py
+++ b/firstvoices/backend/tests/test_apis/test_stats_api.py
@@ -20,337 +20,55 @@ class TestStatsEndpoint(SiteContentListApiTestMixin, BaseSiteContentApiTest):
 
     @staticmethod
     def get_empty_stats_page():
+        data_models = ["words", "phrases", "songs", "stories"]
+        media_models = ["images", "audio", "video"]
+        time_periods = [
+            "lastYear",
+            "last6Months",
+            "last3Months",
+            "lastMonth",
+            "lastWeek",
+            "last3Days",
+            "today",
+        ]
+
+        aggregate_data = {}
+        for data_model in data_models:
+            aggregate_data[data_model] = {
+                "total": 0,
+                "availableInChildrensArchive": 0,
+                "public": 0,
+            }
+
+        for media_model in media_models:
+            aggregate_data[media_model] = {
+                "total": 0,
+                "availableInChildrensArchive": 0,
+            }
+
+        temporal_data = {}
+        for data_model in data_models:
+            temporal_data[data_model] = {}
+            for time_period in time_periods:
+                temporal_data[data_model][time_period] = {
+                    "created": 0,
+                    "lastModified": 0,
+                    "public": 0,
+                    "members": 0,
+                    "team": 0,
+                }
+
+        for media_model in media_models:
+            temporal_data[media_model] = {}
+            for time_period in time_periods:
+                temporal_data[media_model][time_period] = {
+                    "created": 0,
+                    "lastModified": 0,
+                }
+
         return {
-            "aggregate": {
-                "words": {
-                    "total": 0,
-                    "availableInChildrensArchive": 0,
-                    "public": 0,
-                },
-                "phrases": {
-                    "total": 0,
-                    "availableInChildrensArchive": 0,
-                    "public": 0,
-                },
-                "songs": {
-                    "total": 0,
-                    "availableInChildrensArchive": 0,
-                    "public": 0,
-                },
-                "stories": {
-                    "total": 0,
-                    "availableInChildrensArchive": 0,
-                    "public": 0,
-                },
-                "images": {
-                    "total": 0,
-                    "availableInChildrensArchive": 0,
-                },
-                "audio": {
-                    "total": 0,
-                    "availableInChildrensArchive": 0,
-                },
-                "video": {
-                    "total": 0,
-                    "availableInChildrensArchive": 0,
-                },
-            },
-            "temporal": {
-                "words": {
-                    "lastYear": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "last6Months": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "last3Months": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "lastMonth": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "lastWeek": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "last3Days": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "today": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                },
-                "phrases": {
-                    "lastYear": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "last6Months": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "last3Months": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "lastMonth": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "lastWeek": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "last3Days": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "today": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                },
-                "songs": {
-                    "lastYear": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "last6Months": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "last3Months": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "lastMonth": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "lastWeek": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "last3Days": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "today": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                },
-                "stories": {
-                    "lastYear": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "last6Months": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "last3Months": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "lastMonth": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "lastWeek": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "last3Days": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                    "today": {
-                        "created": 0,
-                        "lastModified": 0,
-                        "public": 0,
-                        "members": 0,
-                        "team": 0,
-                    },
-                },
-                "images": {
-                    "lastYear": {
-                        "created": 0,
-                        "lastModified": 0,
-                    },
-                    "last6Months": {
-                        "created": 0,
-                        "lastModified": 0,
-                    },
-                    "last3Months": {
-                        "created": 0,
-                        "lastModified": 0,
-                    },
-                    "lastMonth": {
-                        "created": 0,
-                        "lastModified": 0,
-                    },
-                    "lastWeek": {
-                        "created": 0,
-                        "lastModified": 0,
-                    },
-                    "last3Days": {
-                        "created": 0,
-                        "lastModified": 0,
-                    },
-                    "today": {
-                        "created": 0,
-                        "lastModified": 0,
-                    },
-                },
-                "audio": {
-                    "lastYear": {
-                        "created": 0,
-                        "lastModified": 0,
-                    },
-                    "last6Months": {
-                        "created": 0,
-                        "lastModified": 0,
-                    },
-                    "last3Months": {
-                        "created": 0,
-                        "lastModified": 0,
-                    },
-                    "lastMonth": {
-                        "created": 0,
-                        "lastModified": 0,
-                    },
-                    "lastWeek": {
-                        "created": 0,
-                        "lastModified": 0,
-                    },
-                    "last3Days": {
-                        "created": 0,
-                        "lastModified": 0,
-                    },
-                    "today": {
-                        "created": 0,
-                        "lastModified": 0,
-                    },
-                },
-                "video": {
-                    "lastYear": {
-                        "created": 0,
-                        "lastModified": 0,
-                    },
-                    "last6Months": {
-                        "created": 0,
-                        "lastModified": 0,
-                    },
-                    "last3Months": {
-                        "created": 0,
-                        "lastModified": 0,
-                    },
-                    "lastMonth": {
-                        "created": 0,
-                        "lastModified": 0,
-                    },
-                    "lastWeek": {
-                        "created": 0,
-                        "lastModified": 0,
-                    },
-                    "last3Days": {
-                        "created": 0,
-                        "lastModified": 0,
-                    },
-                    "today": {
-                        "created": 0,
-                        "lastModified": 0,
-                    },
-                },
-            },
+            "aggregate": aggregate_data,
+            "temporal": temporal_data,
         }
 
     @pytest.fixture
@@ -404,10 +122,6 @@ class TestStatsEndpoint(SiteContentListApiTestMixin, BaseSiteContentApiTest):
     @pytest.mark.skip(reason="Stats API does not create an instance")
     def test_list_minimal(self):
         pass
-
-    # TODO: Add tests for the following:
-    # - Test each aggregate by model
-    # - Test each temporal by model and time range
 
     @pytest.mark.django_db
     @pytest.mark.parametrize("entry_type", TypeOfDictionaryEntry)

--- a/firstvoices/backend/tests/test_apis/test_stats_api.py
+++ b/firstvoices/backend/tests/test_apis/test_stats_api.py
@@ -1,0 +1,397 @@
+import json
+
+import pytest
+
+from backend.models.constants import Role, Visibility
+from backend.tests import factories
+from backend.tests.test_apis.base_api_test import (
+    BaseSiteContentApiTest,
+    SiteContentListApiTestMixin,
+)
+
+
+class TestStatsEndpoint(SiteContentListApiTestMixin, BaseSiteContentApiTest):
+    """
+    End-to-end tests that the stats endpoint has the expected behaviour.
+    """
+
+    API_LIST_VIEW = "api:stats-list"
+
+    @staticmethod
+    def get_empty_stats_page():
+        return {
+            "aggregate": {
+                "words": {
+                    "total": 0,
+                    "availableInChildrensArchive": 0,
+                    "public": 0,
+                },
+                "phrases": {
+                    "total": 0,
+                    "availableInChildrensArchive": 0,
+                    "public": 0,
+                },
+                "songs": {
+                    "total": 0,
+                    "availableInChildrensArchive": 0,
+                    "public": 0,
+                },
+                "stories": {
+                    "total": 0,
+                    "availableInChildrensArchive": 0,
+                    "public": 0,
+                },
+                "images": {
+                    "total": 0,
+                    "availableInChildrensArchive": 0,
+                },
+                "audio": {
+                    "total": 0,
+                    "availableInChildrensArchive": 0,
+                },
+                "video": {
+                    "total": 0,
+                    "availableInChildrensArchive": 0,
+                },
+            },
+            "temporal": {
+                "words": {
+                    "lastYear": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "last6Months": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "last3Months": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "lastMonth": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "lastWeek": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "last3Days": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "today": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                },
+                "phrases": {
+                    "lastYear": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "last6Months": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "last3Months": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "lastMonth": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "lastWeek": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "last3Days": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "today": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                },
+                "songs": {
+                    "lastYear": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "last6Months": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "last3Months": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "lastMonth": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "lastWeek": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "last3Days": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "today": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                },
+                "stories": {
+                    "lastYear": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "last6Months": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "last3Months": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "lastMonth": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "lastWeek": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "last3Days": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                    "today": {
+                        "created": 0,
+                        "lastModified": 0,
+                        "public": 0,
+                        "members": 0,
+                        "team": 0,
+                    },
+                },
+                "images": {
+                    "lastYear": {
+                        "created": 0,
+                        "lastModified": 0,
+                    },
+                    "last6Months": {
+                        "created": 0,
+                        "lastModified": 0,
+                    },
+                    "last3Months": {
+                        "created": 0,
+                        "lastModified": 0,
+                    },
+                    "lastMonth": {
+                        "created": 0,
+                        "lastModified": 0,
+                    },
+                    "lastWeek": {
+                        "created": 0,
+                        "lastModified": 0,
+                    },
+                    "last3Days": {
+                        "created": 0,
+                        "lastModified": 0,
+                    },
+                    "today": {
+                        "created": 0,
+                        "lastModified": 0,
+                    },
+                },
+                "audio": {
+                    "lastYear": {
+                        "created": 0,
+                        "lastModified": 0,
+                    },
+                    "last6Months": {
+                        "created": 0,
+                        "lastModified": 0,
+                    },
+                    "last3Months": {
+                        "created": 0,
+                        "lastModified": 0,
+                    },
+                    "lastMonth": {
+                        "created": 0,
+                        "lastModified": 0,
+                    },
+                    "lastWeek": {
+                        "created": 0,
+                        "lastModified": 0,
+                    },
+                    "last3Days": {
+                        "created": 0,
+                        "lastModified": 0,
+                    },
+                    "today": {
+                        "created": 0,
+                        "lastModified": 0,
+                    },
+                },
+                "video": {
+                    "lastYear": {
+                        "created": 0,
+                        "lastModified": 0,
+                    },
+                    "last6Months": {
+                        "created": 0,
+                        "lastModified": 0,
+                    },
+                    "last3Months": {
+                        "created": 0,
+                        "lastModified": 0,
+                    },
+                    "lastMonth": {
+                        "created": 0,
+                        "lastModified": 0,
+                    },
+                    "lastWeek": {
+                        "created": 0,
+                        "lastModified": 0,
+                    },
+                    "last3Days": {
+                        "created": 0,
+                        "lastModified": 0,
+                    },
+                    "today": {
+                        "created": 0,
+                        "lastModified": 0,
+                    },
+                },
+            },
+        }
+
+    @pytest.mark.django_db
+    def test_list_empty(self):
+        site = self.create_site_with_non_member(Visibility.PUBLIC)
+        response = self.client.get(self.get_list_endpoint(site_slug=site.slug))
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+        assert response_data == self.get_empty_stats_page()
+
+    @pytest.mark.parametrize("role", Role)
+    @pytest.mark.django_db
+    def test_list_member_access(self, role):
+        site = factories.SiteFactory.create(visibility=Visibility.MEMBERS)
+        user = factories.get_non_member_user()
+        factories.MembershipFactory.create(user=user, site=site, role=role)
+        self.client.force_authenticate(user=user)
+
+        response = self.client.get(self.get_list_endpoint(site.slug))
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+        assert response_data == self.get_empty_stats_page()
+
+    @pytest.mark.django_db
+    def test_list_team_access(self):
+        site = factories.SiteFactory.create(visibility=Visibility.TEAM)
+        user = factories.get_non_member_user()
+        factories.MembershipFactory.create(user=user, site=site, role=Role.ASSISTANT)
+        self.client.force_authenticate(user=user)
+
+        response = self.client.get(self.get_list_endpoint(site.slug))
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+        assert response_data == self.get_empty_stats_page()
+
+    @pytest.mark.skip(reason="Stats API does not create an instance")
+    def test_list_minimal(self):
+        pass
+
+    # TODO: Add tests for the following:
+    # - Test each aggregate by model
+    # - Test each temporal by model and time range

--- a/firstvoices/backend/tests/test_apis/test_stats_api.py
+++ b/firstvoices/backend/tests/test_apis/test_stats_api.py
@@ -71,6 +71,15 @@ class TestStatsEndpoint(SiteContentListApiTestMixin, BaseSiteContentApiTest):
             "temporal": temporal_data,
         }
 
+    @staticmethod
+    def assert_temporal_stats(response_data, model, time_deltas):
+        for time in time_deltas:
+            assert response_data["temporal"][model][time]["created"] == 3
+            assert response_data["temporal"][model][time]["lastModified"] == 3
+            assert response_data["temporal"][model][time]["public"] == 1
+            assert response_data["temporal"][model][time]["members"] == 1
+            assert response_data["temporal"][model][time]["team"] == 1
+
     @pytest.fixture
     def time_deltas(self):
         return [
@@ -121,6 +130,7 @@ class TestStatsEndpoint(SiteContentListApiTestMixin, BaseSiteContentApiTest):
 
     @pytest.mark.skip(reason="Stats API does not create an instance")
     def test_list_minimal(self):
+        # Stats API does not create a model instance
         pass
 
     @pytest.mark.django_db
@@ -216,12 +226,7 @@ class TestStatsEndpoint(SiteContentListApiTestMixin, BaseSiteContentApiTest):
         assert response.status_code == 200
         response_data = json.loads(response.content)
 
-        for time in time_deltas:
-            assert response_data["temporal"][key][time]["created"] == 3
-            assert response_data["temporal"][key][time]["lastModified"] == 3
-            assert response_data["temporal"][key][time]["public"] == 1
-            assert response_data["temporal"][key][time]["members"] == 1
-            assert response_data["temporal"][key][time]["team"] == 1
+        self.assert_temporal_stats(response_data, key, time_deltas)
 
     @pytest.mark.django_db
     @pytest.mark.parametrize(
@@ -239,12 +244,7 @@ class TestStatsEndpoint(SiteContentListApiTestMixin, BaseSiteContentApiTest):
         assert response.status_code == 200
         response_data = json.loads(response.content)
 
-        for time in time_deltas:
-            assert response_data["temporal"][key][time]["created"] == 3
-            assert response_data["temporal"][key][time]["lastModified"] == 3
-            assert response_data["temporal"][key][time]["public"] == 1
-            assert response_data["temporal"][key][time]["members"] == 1
-            assert response_data["temporal"][key][time]["team"] == 1
+        self.assert_temporal_stats(response_data, key, time_deltas)
 
     @pytest.mark.django_db
     @pytest.mark.parametrize(

--- a/firstvoices/backend/urls.py
+++ b/firstvoices/backend/urls.py
@@ -20,6 +20,7 @@ from backend.views.search.base_search_views import BaseSearchViewSet
 from backend.views.search.site_search_views import SiteSearchViewsSet
 from backend.views.sites_views import MySitesViewSet, SiteViewSet
 from backend.views.song_views import SongViewSet
+from backend.views.stats_views import StatsViewSet
 from backend.views.story_views import StoryViewSet
 from backend.views.storypage_views import StoryPageViewSet
 from backend.views.video_views import VideoViewSet
@@ -65,6 +66,7 @@ sites_router.register(r"pages", SitePageViewSet, basename="sitepage")
 sites_router.register(r"songs", SongViewSet, basename="song")
 sites_router.register(r"videos", VideoViewSet, basename="video")
 sites_router.register(r"widgets", SiteWidgetViewSet, basename="sitewidget")
+sites_router.register(r"stats", StatsViewSet, basename="stats")
 
 # stories and pages
 sites_router.register(r"stories", StoryViewSet, basename="story")

--- a/firstvoices/backend/views/stats_views.py
+++ b/firstvoices/backend/views/stats_views.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from django.utils import timezone
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import viewsets
 from rest_framework.response import Response
 
@@ -8,9 +9,22 @@ from backend.models import DictionaryEntry, Song, Story
 from backend.models.constants import Visibility
 from backend.models.dictionary import TypeOfDictionaryEntry
 from backend.models.media import Audio, Image, Video
+from backend.views import doc_strings
+from backend.views.api_doc_variables import site_slug_parameter
 from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSetMixin
 
 
+@extend_schema_view(
+    list=extend_schema(
+        description="A list of statistics about a given site.",
+        responses={
+            200: Response,
+            403: OpenApiResponse(description=doc_strings.error_403),
+            404: OpenApiResponse(description=doc_strings.error_404),
+        },
+        parameters=[site_slug_parameter],
+    ),
+)
 class StatsViewSet(SiteContentViewSetMixin, FVPermissionViewSetMixin, viewsets.ViewSet):
     """API endpoint that returns statistics about the specified site."""
 

--- a/firstvoices/backend/views/stats_views.py
+++ b/firstvoices/backend/views/stats_views.py
@@ -9,6 +9,7 @@ from backend.models import DictionaryEntry, Song, Story
 from backend.models.constants import Visibility
 from backend.models.dictionary import TypeOfDictionaryEntry
 from backend.models.media import Audio, Image, Video
+from backend.serializers.stats_serializers import SiteStatsSerializer
 from backend.views import doc_strings
 from backend.views.api_doc_variables import site_slug_parameter
 from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSetMixin
@@ -18,7 +19,7 @@ from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSe
     list=extend_schema(
         description="A list of statistics about a given site.",
         responses={
-            200: Response,
+            200: SiteStatsSerializer,
             403: OpenApiResponse(description=doc_strings.error_403),
             404: OpenApiResponse(description=doc_strings.error_404),
         },

--- a/firstvoices/backend/views/stats_views.py
+++ b/firstvoices/backend/views/stats_views.py
@@ -1,0 +1,143 @@
+from datetime import timedelta
+
+from django.utils import timezone
+from rest_framework import viewsets
+from rest_framework.response import Response
+
+from backend.models import DictionaryEntry, Song, Story
+from backend.models.constants import Visibility
+from backend.models.dictionary import TypeOfDictionaryEntry
+from backend.models.media import Audio, Image, Video
+from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSetMixin
+
+
+class StatsViewSet(SiteContentViewSetMixin, FVPermissionViewSetMixin, viewsets.ViewSet):
+    """API endpoint that returns statistics about the specified site."""
+
+    def list(self, request, *args, **kwargs):
+        """Return a list of statistics about the specified site."""
+        site_stats = self.calculate_site_stats()
+        return Response(site_stats)
+
+    @staticmethod
+    def calculate_aggregate_stats(queryset):
+        """Calculate aggregate statistics for a given queryset of objects"""
+        aggregate_stats = {
+            "total": queryset.count(),
+            "available_in_childrens_archive": queryset.filter(
+                exclude_from_kids=False
+            ).count(),
+        }
+
+        # check if visibility field is present on queryset model
+        if hasattr(queryset.model, "visibility"):
+            aggregate_stats["public"] = queryset.filter(
+                visibility=Visibility.PUBLIC
+            ).count()
+
+        return aggregate_stats
+
+    @staticmethod
+    def calculate_individual_temporal_stats(queryset, time_range):
+        """Calculate temporal statistics for a given queryset of objects from a specified time range"""
+
+        individual_temporal_stats = {
+            "created": queryset.filter(created__range=time_range).count(),
+            "last_modified": queryset.filter(last_modified__range=time_range).count(),
+        }
+
+        if hasattr(queryset.model, "visibility"):
+            individual_temporal_stats["public"] = queryset.filter(
+                visibility=Visibility.PUBLIC, created__range=time_range
+            ).count()
+            individual_temporal_stats["members"] = queryset.filter(
+                visibility=Visibility.MEMBERS, created__range=time_range
+            ).count()
+            individual_temporal_stats["team"] = queryset.filter(
+                visibility=Visibility.TEAM, created__range=time_range
+            ).count()
+
+        return individual_temporal_stats
+
+    def calculate_temporal_stats(self, queryset):
+        """Calculate temporal statistics for a given queryset of objects"""
+        # Calculate time deltas
+        now = timezone.now()
+        last_year = now - timedelta(days=365)
+        last_6_months = now - timedelta(days=183)
+        last_3_months = now - timedelta(days=91)
+        last_month = now - timedelta(days=30)
+        last_week = now - timedelta(days=7)
+        last_3_days = now - timedelta(days=3)
+        today = now - timedelta(days=1)
+
+        temporal_stats = {
+            "last_year": self.calculate_individual_temporal_stats(
+                queryset, (last_year, now)
+            ),
+            "last_6_months": self.calculate_individual_temporal_stats(
+                queryset, (last_6_months, now)
+            ),
+            "last_3_months": self.calculate_individual_temporal_stats(
+                queryset, (last_3_months, now)
+            ),
+            "last_month": self.calculate_individual_temporal_stats(
+                queryset, (last_month, now)
+            ),
+            "last_week": self.calculate_individual_temporal_stats(
+                queryset, (last_week, now)
+            ),
+            "last_3_days": self.calculate_individual_temporal_stats(
+                queryset, (last_3_days, now)
+            ),
+            "today": self.calculate_individual_temporal_stats(queryset, (today, now)),
+        }
+
+        return temporal_stats
+
+    def calculate_site_stats(self):
+        """Calculate statistics for the specified site."""
+        site = self.get_validated_site()
+        site_slug = site[0].slug
+
+        # Model query sets
+        words_qs = DictionaryEntry.objects.filter(
+            site__slug=site_slug, type=TypeOfDictionaryEntry.WORD
+        )
+        phrases_qs = DictionaryEntry.objects.filter(
+            site__slug=site_slug, type=TypeOfDictionaryEntry.PHRASE
+        )
+        songs_qs = Song.objects.filter(site__slug=site_slug)
+        stories_qs = Story.objects.filter(site__slug=site_slug)
+        images_qs = Image.objects.filter(site__slug=site_slug)
+        audio_qs = Audio.objects.filter(site__slug=site_slug)
+        video_qs = Video.objects.filter(site__slug=site_slug)
+
+        # Calculate aggregate stats from site models
+        site_aggregate_stats = {
+            "words": self.calculate_aggregate_stats(words_qs),
+            "phrases": self.calculate_aggregate_stats(phrases_qs),
+            "songs": self.calculate_aggregate_stats(songs_qs),
+            "stories": self.calculate_aggregate_stats(stories_qs),
+            "images": self.calculate_aggregate_stats(images_qs),
+            "audio": self.calculate_aggregate_stats(audio_qs),
+            "video": self.calculate_aggregate_stats(video_qs),
+        }
+
+        # Calculate temporal stats from site models
+        site_temporal_stats = {
+            "words": self.calculate_temporal_stats(words_qs),
+            "phrases": self.calculate_temporal_stats(phrases_qs),
+            "songs": self.calculate_temporal_stats(songs_qs),
+            "stories": self.calculate_temporal_stats(stories_qs),
+            "images": self.calculate_temporal_stats(images_qs),
+            "audio": self.calculate_temporal_stats(audio_qs),
+            "video": self.calculate_temporal_stats(video_qs),
+        }
+
+        site_stats = {
+            "aggregate": site_aggregate_stats,
+            "temporal": site_temporal_stats,
+        }
+
+        return site_stats


### PR DESCRIPTION
### Description of Changes
Adds a stats API to `/api/1.0/sites/<slug>/stats`
This stats API returns all aggregate and temporal stats provided by the Nuxeo REST API > Statistics endpoint in a very similar format. Also adds tests for these statistics.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
Suggestions for data formatting/ quick wins for optimization would be much appreciated, thanks!
