### PR TITLE
FW-4347 enhance site data export API

### DIFF
--- a/firstvoices/backend/models/characters.py
+++ b/firstvoices/backend/models/characters.py
@@ -263,7 +263,7 @@ class Alphabet(BaseSiteContentModel):
         """
         return IgnoredCharacter.objects.filter(site=self.site)
 
-    @property
+    @cached_property
     def default_g2p_config(self):
         """
         Returns default G2P configurations for required mappers, customized with site name and slug.

--- a/firstvoices/backend/serializers/site_data_serializers.py
+++ b/firstvoices/backend/serializers/site_data_serializers.py
@@ -36,7 +36,6 @@ class CategoriesDataSerializer(serializers.ModelSerializer):
 class SiteDataSerializer(SiteContentLinkedTitleSerializer):
     config = serializers.SerializerMethodField()
     categories = CategoriesDataSerializer(source="category_set", many=True)
-    data = serializers.SerializerMethodField()
 
     def get_config(self, site):
         request = self.context.get("request")
@@ -57,33 +56,11 @@ class SiteDataSerializer(SiteContentLinkedTitleSerializer):
         }
         return config
 
-    def get_data(self, site):
-        dict_set = site.dictionaryentry_set
-        queryset = dict_set if site is not None and dict_set is not None else None
-        request = self.context.get("request")
-        serializer = DictionaryEntryDataSerializer(
-            queryset, many=True, context={"request": request}
-        )
-        paginator = DictionaryEntryPaginator()
-        paginated_data = paginator.paginate_queryset(
-            queryset=serializer.data, request=request
-        )
-        dictionary_entries = paginator.get_paginated_response(paginated_data)
-        return dictionary_entries
-
-    def to_representation(self, instance):
-        output = super().to_representation(instance)
-        data = output.pop("data", None)
-        for key, value in data.items():
-            output[key] = value
-        return output
-
     class Meta:
         model = Site
         fields = (
             "config",
             "categories",
-            "data",
         )
 
 
@@ -216,7 +193,7 @@ class DictionaryEntryPaginator(pagination.PageNumberPagination):
     django_paginator_class = Paginator
     page_size = 50
 
-    def get_paginated_response(self, data):
+    def get_paginated_data(self, data):
         return OrderedDict(
             [
                 ("count", self.page.paginator.count),

--- a/firstvoices/backend/serializers/site_data_serializers.py
+++ b/firstvoices/backend/serializers/site_data_serializers.py
@@ -19,9 +19,10 @@ def dict_entry_type_mtd_conversion(type):
 
 
 class SiteDataSerializer(SiteContentLinkedTitleSerializer):
-    site_data_export = serializers.SerializerMethodField()
+    config = serializers.SerializerMethodField()
+    data = serializers.SerializerMethodField()
 
-    def get_site_data_export(self, site):
+    def get_config(self, site):
         request = self.context.get("request")
         characters_list = [
             character
@@ -38,6 +39,9 @@ class SiteDataSerializer(SiteContentLinkedTitleSerializer):
             "L2": {"name": "English"},
             "build": datetime.now().strftime("%Y%m%d%H%M"),
         }
+        return config
+
+    def get_data(self, site):
         queryset = (
             site.dictionaryentry_set
             if site is not None and site.dictionaryentry_set is not None
@@ -47,12 +51,11 @@ class SiteDataSerializer(SiteContentLinkedTitleSerializer):
         dictionary_entries = DictionaryEntryDataSerializer(
             queryset, many=True, context={"request": request}
         ).data
-
-        return {"config": config, "data": dictionary_entries}
+        return dictionary_entries
 
     class Meta:
         model = Site
-        fields = ("site_data_export",)
+        fields = ("config", "data")
 
 
 class CategoriesDataSerializer(serializers.ModelSerializer):

--- a/firstvoices/backend/serializers/site_data_serializers.py
+++ b/firstvoices/backend/serializers/site_data_serializers.py
@@ -97,7 +97,7 @@ class DictionaryEntryDataSerializer(serializers.ModelSerializer):
     definition = serializers.SerializerMethodField()
     audio = serializers.SerializerMethodField()
     img = serializers.SerializerMethodField()
-    theme = CategoriesDataSerializer(source="categories", many=True)
+    theme = serializers.SerializerMethodField()
     secondary_theme = serializers.SerializerMethodField()
     optional = serializers.SerializerMethodField()
     compare_form = serializers.CharField(source="title")
@@ -124,8 +124,20 @@ class DictionaryEntryDataSerializer(serializers.ModelSerializer):
         return ImageDataSerializer(dictionaryentry.related_images, many=True).data
 
     @staticmethod
+    def get_theme(dictionaryentry):
+        return [
+            entry.title
+            for entry in dictionaryentry.categories.all()
+            if entry.parent is None
+        ]
+
+    @staticmethod
     def get_secondary_theme(dictionaryentry):
-        return None
+        return [
+            entry.title
+            for entry in dictionaryentry.categories.all()
+            if entry.parent is not None
+        ]
 
     @staticmethod
     def get_optional(dictionaryentry):

--- a/firstvoices/backend/serializers/site_data_serializers.py
+++ b/firstvoices/backend/serializers/site_data_serializers.py
@@ -1,12 +1,12 @@
 from collections import OrderedDict
 from datetime import datetime
 
-from django.core.paginator import Paginator
 from rest_framework import pagination, serializers
 
 from backend.models import Category, Site
 from backend.models.dictionary import DictionaryEntry, TypeOfDictionaryEntry
 from backend.models.media import Audio, Image
+from backend.pagination import FasterCountPagination
 from backend.permissions import utils
 from backend.serializers.base_serializers import SiteContentLinkedTitleSerializer
 
@@ -202,8 +202,8 @@ class DictionaryEntryDataSerializer(serializers.ModelSerializer):
 
 
 class DictionaryEntryPaginator(pagination.PageNumberPagination):
-    django_paginator_class = Paginator
-    page_size = 50
+    django_paginator_class = FasterCountPagination
+    page_size = 20
 
     def get_paginated_data(self, data):
         return OrderedDict(
@@ -215,14 +215,14 @@ class DictionaryEntryPaginator(pagination.PageNumberPagination):
                     "next",
                     self.page.next_page_number() if self.page.has_next() else None,
                 ),
-                ("next_url", self.get_next_link()),
+                ("nextUrl", self.get_next_link()),
                 (
                     "previous",
                     self.page.previous_page_number()
                     if self.page.has_previous()
                     else None,
                 ),
-                ("previous_url", self.get_previous_link()),
+                ("previousUrl", self.get_previous_link()),
                 ("data", data),
             ]
         )

--- a/firstvoices/backend/tests/test_apis/test_sites_data_api.py
+++ b/firstvoices/backend/tests/test_apis/test_sites_data_api.py
@@ -31,6 +31,12 @@ class TestSitesDataEndpoint:
 
     client = None
 
+    optional_constants = {
+        "PART_OF_SPEECH": "Part of Speech",
+        "REFERENCE": "Reference",
+        "NOTE": "Note",
+    }
+
     def get_list_endpoint(self, site_slug):
         return reverse(self.API_LIST_VIEW, current_app=self.APP_NAME, args=[site_slug])
 
@@ -220,7 +226,13 @@ class TestSitesDataEndpoint:
             ],
             "theme": [parent_category.title],
             "secondary_theme": [child_category.title],
-            "optional": [{"Part of Speech": entry_one.part_of_speech.title}],
+            "optional": [
+                {
+                    self.optional_constants[
+                        "PART_OF_SPEECH"
+                    ]: entry_one.part_of_speech.title
+                }
+            ],
             "compare_form": entry_one.title,
             "sort_form": entry_one.title,
             "sorting_form": [
@@ -246,7 +258,13 @@ class TestSitesDataEndpoint:
             "img": [],
             "theme": [],
             "secondary_theme": [],
-            "optional": [{"Part of Speech": entry_two.part_of_speech.title}],
+            "optional": [
+                {
+                    self.optional_constants[
+                        "PART_OF_SPEECH"
+                    ]: entry_two.part_of_speech.title
+                }
+            ],
             "compare_form": entry_two.title,
             "sort_form": entry_two.title,
             "sorting_form": [
@@ -363,9 +381,11 @@ class TestSitesDataEndpoint:
 
         assert dictionary_entries[0]["optional"] == [
             {
-                "Reference": acknowledgement.text,
-                "Part of Speech": entry_one.part_of_speech.title,
-                "Note": note.text,
+                self.optional_constants["REFERENCE"]: acknowledgement.text,
+                self.optional_constants[
+                    "PART_OF_SPEECH"
+                ]: entry_one.part_of_speech.title,
+                self.optional_constants["NOTE"]: note.text,
             }
         ]
         assert len(dictionary_entries[0]["optional"][0]) == 3

--- a/firstvoices/backend/views/data_views.py
+++ b/firstvoices/backend/views/data_views.py
@@ -78,6 +78,9 @@ class SitesDataViewSet(
                 "dictionaryentry_set__note_set",
                 "dictionaryentry_set__categories",
                 "dictionaryentry_set__categories__parent",
+                "dictionaryentry_set__related_audio",
+                "dictionaryentry_set__related_videos",
+                "dictionaryentry_set__related_images",
             )
         )
         return sites

--- a/firstvoices/backend/views/data_views.py
+++ b/firstvoices/backend/views/data_views.py
@@ -20,10 +20,7 @@ from backend.views.api_doc_variables import site_slug_parameter
 from backend.views.base_views import SiteContentViewSetMixin, ThrottlingMixin
 
 
-class SnakeCaseJSONRenderer(BrowsableAPIRenderer):
-    def get_default_renderer(self, view):
-        return JSONRenderer()
-
+class SnakeCaseJSONRenderer(JSONRenderer):
     def render(self, data, media_type=None, renderer_context=None):
         # convert data keys to snake_case
         data = json.loads(json.dumps(data, separators=(",", ":")))
@@ -67,7 +64,7 @@ class SitesDataViewSet(
     http_method_names = ["get"]
     serializer_class = DictionaryEntryDataSerializer
     pagination_class = DictionaryEntryPaginator
-    renderer_classes = [SnakeCaseJSONRenderer]
+    renderer_classes = [SnakeCaseJSONRenderer, BrowsableAPIRenderer]
 
     def get_queryset(self):
         site = self.get_validated_site()

--- a/firstvoices/backend/views/data_views.py
+++ b/firstvoices/backend/views/data_views.py
@@ -105,8 +105,7 @@ class SitesDataViewSet(
             site[0], context={"request": request}
         ).data
 
-        for key, value in site_config_and_categories_json.items():
-            data[key] = value
+        data = {**site_config_and_categories_json}
 
         if page is not None:
             paginated_data = paginator.get_paginated_data(serializer.data)

--- a/firstvoices/backend/views/data_views.py
+++ b/firstvoices/backend/views/data_views.py
@@ -4,12 +4,18 @@ from django.db.models import Prefetch
 from drf_spectacular.utils import extend_schema, extend_schema_view, inline_serializer
 from rest_framework import mixins, serializers, viewsets
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
+from rest_framework.response import Response
 from rules.contrib.rest_framework import AutoPermissionViewSetMixin
 
 from backend.models import Alphabet, Site
 from backend.models.dictionary import DictionaryEntry
 from backend.models.media import Audio, Image
-from backend.serializers.site_data_serializers import SiteDataSerializer
+from backend.permissions import utils
+from backend.serializers.site_data_serializers import (
+    DictionaryEntryDataSerializer,
+    DictionaryEntryPaginator,
+    SiteDataSerializer,
+)
 from backend.views.api_doc_variables import site_slug_parameter
 from backend.views.base_views import SiteContentViewSetMixin, ThrottlingMixin
 
@@ -59,48 +65,76 @@ class SitesDataViewSet(
     viewsets.GenericViewSet,
 ):
     http_method_names = ["get"]
-    serializer_class = SiteDataSerializer
-    pagination_class = None
+    serializer_class = DictionaryEntryDataSerializer
+    pagination_class = DictionaryEntryPaginator
     renderer_classes = [SnakeCaseJSONRenderer]
 
     def get_queryset(self):
         site = self.get_validated_site()
         if site.count() > 0:
-            return site.select_related(
-                "language", "created_by", "last_modified_by"
-            ).prefetch_related(
-                "category_set__parent",
-                Prefetch(
-                    "dictionaryentry_set",
-                    queryset=DictionaryEntry.objects.all()
-                    .select_related(
-                        "part_of_speech",
-                    )
-                    .prefetch_related(
-                        Prefetch(
-                            "related_audio",
-                            queryset=Audio.objects.all()
-                            .select_related(
-                                "original",
-                            )
-                            .prefetch_related(
-                                "speakers",
-                            ),
+            return (
+                DictionaryEntry.objects.filter(site__id__in=site)
+                .select_related(
+                    "part_of_speech",
+                )
+                .prefetch_related(
+                    Prefetch(
+                        "related_audio",
+                        queryset=Audio.objects.all()
+                        .select_related(
+                            "original",
+                        )
+                        .prefetch_related(
+                            "speakers",
                         ),
-                        Prefetch(
-                            "related_images",
-                            queryset=Image.objects.all().select_related(
-                                "original",
-                            ),
-                        ),
-                        Prefetch("site__alphabet_set", queryset=Alphabet.objects.all()),
-                        "translation_set",
-                        "categories",
-                        "categories__parent",
-                        "acknowledgement_set",
-                        "note_set",
                     ),
-                ),
+                    Prefetch(
+                        "related_images",
+                        queryset=Image.objects.all().select_related(
+                            "original",
+                        ),
+                    ),
+                    Prefetch("site__alphabet_set", queryset=Alphabet.objects.all()),
+                    "translation_set",
+                    "categories",
+                    "categories__parent",
+                    "acknowledgement_set",
+                    "note_set",
+                )
             )
         else:
-            return Site.objects.none()
+            return DictionaryEntry.objects.none()
+
+    def list(self, request, *args, **kwargs):
+        queryset = utils.filter_by_viewable(request.user, self.get_queryset())
+        paginator = DictionaryEntryPaginator()
+        page = paginator.paginate_queryset(queryset, request)
+        serializer = self.get_serializer(page, many=True)
+
+        data = {}
+
+        site = (
+            self.get_validated_site()
+            .select_related("language", "created_by", "last_modified_by")
+            .prefetch_related(
+                "category_set__parent",
+            )
+        )
+        if site.count() > 0:
+            site_config_and_categories_json = SiteDataSerializer(
+                site[0], context={"request": request}
+            ).data
+        else:
+            site_config_and_categories_json = SiteDataSerializer(
+                Site.objects.none(), context={"request": request}
+            ).data
+
+        for key, value in site_config_and_categories_json.items():
+            data[key] = value
+
+        if page is not None:
+            paginated_data = paginator.get_paginated_data(serializer.data)
+            for key, value in paginated_data.items():
+                data[key] = value
+
+        return Response(data)

--- a/firstvoices/backend/views/data_views.py
+++ b/firstvoices/backend/views/data_views.py
@@ -58,35 +58,31 @@ class SitesDataViewSet(
 
     def get_queryset(self):
         site = self.get_validated_site()
-        return (
-            DictionaryEntry.objects.filter(site__id__in=site)
-            .select_related(
-                "part_of_speech",
-            )
-            .prefetch_related(
-                Prefetch(
-                    "related_audio",
-                    queryset=Audio.objects.all()
-                    .select_related(
-                        "original",
-                    )
-                    .prefetch_related(
-                        "speakers",
-                    ),
+        return DictionaryEntry.objects.filter(site__id__in=site).prefetch_related(
+            "part_of_speech",
+            "site",
+            Prefetch(
+                "related_audio",
+                queryset=Audio.objects.all()
+                .select_related(
+                    "original",
+                )
+                .prefetch_related(
+                    "speakers",
                 ),
-                Prefetch(
-                    "related_images",
-                    queryset=Image.objects.all().select_related(
-                        "original",
-                    ),
+            ),
+            Prefetch(
+                "related_images",
+                queryset=Image.objects.all().select_related(
+                    "original",
                 ),
-                Prefetch("site__alphabet_set", queryset=Alphabet.objects.all()),
-                "translation_set",
-                "categories",
-                "categories__parent",
-                "acknowledgement_set",
-                "note_set",
-            )
+            ),
+            Prefetch("site__alphabet_set", queryset=Alphabet.objects.all()),
+            "translation_set",
+            "categories",
+            "categories__parent",
+            "acknowledgement_set",
+            "note_set",
         )
 
     def list(self, request, *args, **kwargs):

--- a/firstvoices/firstvoices/settings.py
+++ b/firstvoices/firstvoices/settings.py
@@ -133,16 +133,18 @@ if DEBUG:
         }
     )
 
-    # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#prerequisites
-    INSTALLED_APPS += ["debug_toolbar"]
-    INSTALLED_APPS += ["django_extensions"]
-    # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#middleware
-    MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]
-    # https://django-debug-toolbar.readthedocs.io/en/latest/configuration.html#debug-toolbar-config
-    DEBUG_TOOLBAR_CONFIG = {
-        "DISABLE_PANELS": ["debug_toolbar.panels.redirects.RedirectsPanel"],
-        "SHOW_TEMPLATE_CONTEXT": True,
-    }
+    if not os.getenv("DISABLE_DEBUG_TOOLBAR"):
+        # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#prerequisites
+        INSTALLED_APPS += ["debug_toolbar"]
+        INSTALLED_APPS += ["django_extensions"]
+        # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#middleware
+        MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]
+        # https://django-debug-toolbar.readthedocs.io/en/latest/configuration.html#debug-toolbar-config
+        DEBUG_TOOLBAR_CONFIG = {
+            "DISABLE_PANELS": ["debug_toolbar.panels.redirects.RedirectsPanel"],
+            "SHOW_TEMPLATE_CONTEXT": True,
+        }
+
     # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#internal-ips
     INTERNAL_IPS = ["127.0.0.1", "10.0.2.2"]
     LOGGING = {

--- a/firstvoices/firstvoices/settings.py
+++ b/firstvoices/firstvoices/settings.py
@@ -105,9 +105,6 @@ REST_FRAMEWORK = {
     "UNAUTHENTICATED_USER": "django.contrib.auth.models.AnonymousUser",
     "DEFAULT_PAGINATION_CLASS": "backend.pagination.PageNumberPagination",
     "PAGE_SIZE": 100,
-    "JSON_UNDERSCOREIZE": {
-        "ignore_fields": ("site_data_export",),
-    },
     "DEFAULT_THROTTLE_CLASSES": [
         "backend.views.utils.BurstRateThrottle",
         "backend.views.utils.SustainedRateThrottle",


### PR DESCRIPTION
### Description of Changes
This PR adds the following changes to the site data API at `/api/1.0/sites/<site  slug>/data`:
- Removed nesting of `data` and `config` inside of `siteDataExport` field
- Add categories list
- Updated audio and image data on `data` entries to now hold actual data instead of placeholder data
- Add pagination to `data` field
- Fixed N+1 query issues and optimized endpoint

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
