### PR TITLE
FW-5210 Order join request list view by reverse created date

### DIFF
--- a/firstvoices/backend/admin/join_request_admin.py
+++ b/firstvoices/backend/admin/join_request_admin.py
@@ -8,4 +8,5 @@ from .base_admin import BaseSiteContentAdmin
 @admin.register(JoinRequest)
 class JoinRequestAdmin(BaseSiteContentAdmin):
     list_display = ("user", "status") + BaseSiteContentAdmin.list_display
-    search_fields = ("user__email",)
+    search_fields = ("user__email", "site__title")
+    autocomplete_fields = ("site", "user")

--- a/firstvoices/backend/views/join_request_views.py
+++ b/firstvoices/backend/views/join_request_views.py
@@ -143,10 +143,14 @@ class JoinRequestViewSet(
 
     def get_queryset(self):
         site = self.get_validated_site()
-        return JoinRequest.objects.filter(
-            site__slug=site[0].slug, status=JoinRequestStatus.PENDING
-        ).select_related(
-            "site", "site__language", "created_by", "last_modified_by", "user"
+        return (
+            JoinRequest.objects.filter(
+                site__slug=site[0].slug, status=JoinRequestStatus.PENDING
+            )
+            .order_by("-created")
+            .select_related(
+                "site", "site__language", "created_by", "last_modified_by", "user"
+            )
         )
 
     def get_validated_site(self):


### PR DESCRIPTION
### Description of Changes
This PR updates the join request list view to order requests by reverse created date (newest first).

Additionally, the admin view for join requests has been updated to add a search field to the sites and users (reducing the number of queries as a bonus).

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
