### PR TITLE
FW-5223 Add optional variable to set the Sentry error sample rate

### DIFF
--- a/firstvoices/firstvoices/settings.py
+++ b/firstvoices/firstvoices/settings.py
@@ -283,6 +283,9 @@ sentry_sdk.init(
     traces_sample_rate=os.getenv(
         "SENTRY_TRACES_SAMPLE_RATE", 1.0
     ),  # The percentage of traces to send to sentry (min 0.0, max 1.0)
+    sample_rate=os.getenv(
+        "SENTRY_ERROR_SAMPLE_RATE", 1.0
+    ),  # The percentage of errors to send to sentry (min 0.0, max 1.0)
     send_default_pii=False,  # Disables the sending of personally identifiable information (see
     # https://docs.sentry.io/platforms/python/guides/django/data-collected/)
     request_bodies="never",  # Disables the sending of request bodies


### PR DESCRIPTION
### Description of Changes
This PR adds an optional environment variable to allow the sentry error sample rate and the sentry transaction sample rate to be set separately. The environment variable is `SENTRY_ERROR_SAMPLE_RATE`  and is defaulted to 1.0 or 100% of the transactions. See [the sentry docs](https://docs.sentry.io/platforms/python/configuration/options/?original_referrer=https%3A%2F%2Fwww.google.com%2F#sample-rate) for more info.

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
