### PR TITLE
FW-5182 Add validation to ensure existing members can't create a join…

### DIFF
--- a/firstvoices/backend/serializers/join_request_serializers.py
+++ b/firstvoices/backend/serializers/join_request_serializers.py
@@ -76,6 +76,9 @@ class JoinRequestDetailSerializer(WritableSiteContentSerializer):
                 "A join request for this site and user already exists."
             )
 
+        if site.membership_set.filter(user=user).exists():
+            raise serializers.ValidationError("User is already a member of this site.")
+
         if not attrs["reasons_set"]:
             raise serializers.ValidationError(
                 "A join request must have at least one reason."

--- a/firstvoices/backend/tests/test_apis/test_join_request_api.py
+++ b/firstvoices/backend/tests/test_apis/test_join_request_api.py
@@ -742,8 +742,6 @@ class TestJoinRequestEndpoints(
         user = factories.UserFactory.create()
         self.client.force_authenticate(user=user)
 
-        self.client.force_authenticate(user=user)
-
         data = {
             "reasons": [{"reason": "other"}],
             "reason_note": self.REASON_NOTE,
@@ -770,8 +768,6 @@ class TestJoinRequestEndpoints(
         site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
         user = factories.UserFactory.create()
         factories.MembershipFactory.create(user=user, site=site, role=role)
-        self.client.force_authenticate(user=user)
-
         self.client.force_authenticate(user=user)
 
         data = {


### PR DESCRIPTION
… request

### Description of Changes
This PR adds validation ensuring users can't create a join request for a site they are already a member of.

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
