### PR TITLE
fw-4800, if token is invalid return 401 not 403

### DIFF
--- a/firstvoices/jwt_auth/authentication.py
+++ b/firstvoices/jwt_auth/authentication.py
@@ -18,8 +18,7 @@ def extract_bearer_token(auth):
         raise exceptions.NotAuthenticated("Invalid format for authorization header")
     if scheme != "Bearer":
         raise exceptions.NotAuthenticated("Authorization header invalid")
-    if not token:
-        raise exceptions.NotAuthenticated("No token found")
+
     return token
 
 

--- a/firstvoices/jwt_auth/models.py
+++ b/firstvoices/jwt_auth/models.py
@@ -13,7 +13,6 @@ class User(AbstractUser):
         * email is a required, unique field, so it can be treated like a username
         * sub is a non-required field that holds the unique JWT "sub" (subject) field for token authentication
         * password is not required
-        * name fields are not stored, so we can depend on jwt id tokens instead
 
     Notes:
         * is_staff and is_superuser are included, only because they are used by the admin site

--- a/firstvoices/jwt_auth/tests.py
+++ b/firstvoices/jwt_auth/tests.py
@@ -5,7 +5,7 @@ import factory
 import jwt
 import pytest
 from factory.django import DjangoModelFactory
-from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.exceptions import NotAuthenticated
 
 from . import authentication
 from .authentication import JwtAuthentication
@@ -174,7 +174,7 @@ class TestGetOrCreateUserForToken:
         with patch(request, return_value=mock_userinfo_response(email)):
             token = {"sub": "new-id-xyz"}
 
-            with pytest.raises(AuthenticationFailed):
+            with pytest.raises(NotAuthenticated):
                 authentication.get_or_create_user_for_token(token, None)
 
     @pytest.mark.django_db
@@ -182,7 +182,7 @@ class TestGetOrCreateUserForToken:
         with patch(request, return_value=mock_failed_userinfo_response()):
             token = {"sub": "new-id-xyz"}
 
-            with pytest.raises(AuthenticationFailed):
+            with pytest.raises(NotAuthenticated):
                 authentication.get_or_create_user_for_token(token, None)
 
     @pytest.mark.django_db
@@ -192,7 +192,7 @@ class TestGetOrCreateUserForToken:
             return_value=mock_misconfigured_userinfo_response({}),
         ):
             token = {"sub": "123_new_user"}
-            with pytest.raises(AuthenticationFailed):
+            with pytest.raises(NotAuthenticated):
                 authentication.get_or_create_user_for_token(token, None)
 
     @pytest.mark.django_db
@@ -331,7 +331,7 @@ class TestAuthenticate:
         mock_request = MagicMock()
         type(mock_request).META = {"HTTP_AUTHORIZATION": token}
         auth = JwtAuthentication()
-        with pytest.raises(AuthenticationFailed):
+        with pytest.raises(NotAuthenticated):
             auth.authenticate(mock_request)
 
     def test_expired_token_fails(self):
@@ -342,7 +342,7 @@ class TestAuthenticate:
             mock_request = MagicMock()
             type(mock_request).META = {"HTTP_AUTHORIZATION": "Bearer valid123"}
             auth = JwtAuthentication()
-            with pytest.raises(AuthenticationFailed):
+            with pytest.raises(NotAuthenticated):
                 auth.authenticate(mock_request)
 
     @pytest.mark.parametrize("exception_type", [jwt.InvalidTokenError, jwt.DecodeError])
@@ -353,5 +353,5 @@ class TestAuthenticate:
             mock_request = MagicMock()
             type(mock_request).META = {"HTTP_AUTHORIZATION": "Bearer valid123"}
             auth = JwtAuthentication()
-            with pytest.raises(AuthenticationFailed):
+            with pytest.raises(NotAuthenticated):
                 auth.authenticate(mock_request)


### PR DESCRIPTION
### Description of Changes
* Better http status code for cases of invalid/corrupt tokens, since the problem is a failure to authenticate (401) vs permission denied for a known user (403).

### Checklist
- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
