### PR TITLE
FW-3233 Add random sort parameter to search

### DIFF
--- a/firstvoices/backend/search/query_builder.py
+++ b/firstvoices/backend/search/query_builder.py
@@ -1,3 +1,5 @@
+import random
+
 from elasticsearch_dsl import Search
 
 from backend.search.utils.constants import VALID_DOCUMENT_TYPES
@@ -40,11 +42,26 @@ def get_search_query(
     has_video=None,
     has_image=None,
     has_translation=None,
+    random_sort=False,
 ):
     # Building initial query
     indices = get_indices(types)
     search_object = get_search_object(indices)
-    search_query = search_object.query()
+
+    if random_sort:
+        search_query = search_object.query(
+            "function_score",
+            functions=(
+                {
+                    "random_score": {
+                        "seed": random.randint(1000, 9999),
+                        "field": "_seq_no",
+                    },
+                }
+            ),
+        )
+    else:
+        search_query = search_object.query()
 
     permissions_filter = get_view_permissions_filter(user)
     if permissions_filter:

--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -297,6 +297,7 @@ def get_valid_sort(input_sort_by_str):
         input_string[0] == "created"
         or input_string[0] == "modified"
         or input_string[0] == "title"
+        or input_string[0] == "random"
     ):
         return input_string[0], descending
     else:  # if invalid string is passed

--- a/firstvoices/backend/tests/test_search/test_query_builder_utils.py
+++ b/firstvoices/backend/tests/test_search/test_query_builder_utils.py
@@ -115,6 +115,9 @@ class TestValidSort:
             ("crEaTed_desC", ("created", True)),
             ("MODIFIED_DeSc", ("modified", True)),
             ("TiTlE_DESC", ("title", True)),
+            ("random", ("random", False)),
+            ("RANDOM", ("random", False)),
+            ("RaNdOm", ("random", False)),
         ],
     )
     def test_valid_inputs(self, input_sort, expected_sort):

--- a/firstvoices/backend/views/search/base_search_views.py
+++ b/firstvoices/backend/views/search/base_search_views.py
@@ -392,6 +392,11 @@ from backend.views.exceptions import ElasticSearchConnectionError
                         value="modified_desc",
                         description="Returns results ordered by the last modified date and time in descending order.",
                     ),
+                    OpenApiExample(
+                        "Random",
+                        value="random",
+                        description="Returns results in random order.",
+                    ),
                 ],
             ),
         ],

--- a/firstvoices/backend/views/search/base_search_views.py
+++ b/firstvoices/backend/views/search/base_search_views.py
@@ -521,6 +521,7 @@ class BaseSearchViewSet(
             has_video=search_params["has_video"],
             has_image=search_params["has_image"],
             has_translation=search_params["has_translation"],
+            random_sort=search_params["sort"] == "random",
         )
 
         # Pagination


### PR DESCRIPTION
### Description of Changes
This PR adds the `sort=random` parameter to the search API. When used, results are returned in a random order using the Elastic Search `function_score` and `random_score` functionality (see [the docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#function-random) for more info).

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
