### PR TITLE
FW-5230 Modify alphabet get to get_or_create during recalc

### DIFF
--- a/firstvoices/backend/tasks/alphabet_tasks.py
+++ b/firstvoices/backend/tasks/alphabet_tasks.py
@@ -16,7 +16,7 @@ def recalculate_custom_order_preview(site_slug: str):
     """
 
     site = Site.objects.get(slug=site_slug)
-    alphabet = Alphabet.objects.get(site=site)
+    alphabet = Alphabet.objects.get_or_create(site=site)
     preview = {}
     task_id = current_task.request.id
 
@@ -83,7 +83,7 @@ def recalculate_custom_order(site_slug: str):
     """
 
     site = Site.objects.get(slug=site_slug)
-    alphabet = Alphabet.objects.get(site=site)
+    alphabet = Alphabet.objects.get_or_create(site=site)
     results = {}
     task_id = current_task.request.id
 

--- a/firstvoices/backend/tests/test_tasks/test_alphabet_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_alphabet_tasks.py
@@ -1,6 +1,6 @@
 import pytest
 
-from backend.models import DictionaryEntry
+from backend.models import Alphabet, DictionaryEntry
 from backend.tasks.alphabet_tasks import (
     recalculate_custom_order,
     recalculate_custom_order_preview,
@@ -341,3 +341,23 @@ class TestAlphabetTasks:
             ],
         }
         assert entry.last_modified == entry_last_modified
+
+    @pytest.mark.django_db
+    def test_recalculate_preview_alphabet_missing(self, site):
+        assert Alphabet.objects.count() == 0
+        result = recalculate_custom_order_preview(site_slug=site.slug)
+        assert result == {
+            "unknown_character_count": {},
+            "updated_entries": [],
+        }
+        assert Alphabet.objects.count() == 1
+
+    @pytest.mark.django_db
+    def test_recalculate_alphabet_missing(self, site):
+        assert Alphabet.objects.count() == 0
+        result = recalculate_custom_order(site_slug=site.slug)
+        assert result == {
+            "unknown_character_count": {},
+            "updated_entries": [],
+        }
+        assert Alphabet.objects.count() == 1


### PR DESCRIPTION
### Description of Changes
This PR fixes a bug when performing the recalculation task where if a site didn't have an alphabet the task would fail.

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
