### PR TITLE
FW-5313 Fix thumbnail generation mode conversion

### DIFF
--- a/firstvoices/backend/models/media.py
+++ b/firstvoices/backend/models/media.py
@@ -482,16 +482,23 @@ class Image(ThumbnailMixin, MediaBase):
         output_img = BytesIO()
         img.thumbnail(output_size)
         # Remove transparency values if they exist so that the image can be converted to JPEG.
-        if img.mode in ("RGBA", "P"):
-            img = img.convert("RGB")
-        if (
-            output_size[0] == img.width
-            and output_size[1] == img.height
-            and img.format == "JPEG"
-        ):
-            img.save(output_img, format="JPEG", quality="keep")
-        else:
-            img.save(output_img, format="JPEG", quality=80)
+        try:
+            if img.mode != "RGB":
+                img = img.convert("RGB")
+
+            if (
+                output_size[0] == img.width
+                and output_size[1] == img.height
+                and img.format == "JPEG"
+            ):
+                img.save(output_img, format="JPEG", quality="keep")
+            else:
+                img.save(output_img, format="JPEG", quality=80)
+        except OSError as e:
+            self.logger.warning(
+                f"Failed to generate thumbnail for image file [{self.original.content.name}].\n"
+                f"Error: {e}\n"
+            )
         return output_img
 
 


### PR DESCRIPTION
### Description of Changes
This PR adds a check to the thumbnail color space conversion step. If the mode is not RGB the function will attempt to convert to RGB and will catch the exception and log a message if it fails.

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
