### PR TITLE
Fw 5284 language api

### DIFF
--- a/firstvoices/backend/tests/test_apis/test_languages_api.py
+++ b/firstvoices/backend/tests/test_apis/test_languages_api.py
@@ -1,0 +1,235 @@
+import json
+
+import pytest
+
+import backend.tests.factories.access
+from backend.models.constants import AppRole, Role, Visibility
+from backend.models.sites import Language
+from backend.tests import factories
+from backend.tests.factories.access import get_anonymous_user, get_non_member_user
+
+from .base_api_test import BaseApiTest, ReadOnlyApiTests
+from .base_media_test import MediaTestMixin
+
+
+class TestLanguagesEndpoints(MediaTestMixin, ReadOnlyApiTests, BaseApiTest):
+    """
+    End-to-end tests that the languages endpoints have the expected behaviour.
+    """
+
+    API_LIST_VIEW = "api:language-list"
+    API_DETAIL_VIEW = "api:language-detail"
+
+    model = Language
+
+    content_type = "application/json"
+
+    def create_minimal_instance(self, visibility):
+        return factories.LanguageFactory.create()
+
+    @pytest.mark.django_db
+    def test_list_empty(self):
+        """Overriding the base test due to lack of pagination"""
+        response = self.client.get(self.get_list_endpoint())
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+        assert len(response_data) == 0
+
+    @pytest.mark.django_db
+    def test_list_minimal(self):
+        """
+        Overriding the base test to check custom permissions and the "other" language grouping
+        """
+        user = factories.get_non_member_user()
+        self.client.force_authenticate(user=user)
+
+        language0 = backend.tests.factories.access.LanguageFactory.create(
+            title="Language 0"
+        )
+        site = factories.SiteFactory(language=language0, visibility=Visibility.PUBLIC)
+        factories.SiteFactory(language=language0, visibility=Visibility.MEMBERS)
+
+        language1 = backend.tests.factories.access.LanguageFactory.create(
+            title="Language 1"
+        )
+        factories.SiteFactory(language=language1, visibility=Visibility.MEMBERS)
+
+        # sites with no language set
+        factories.SiteFactory(language=None, visibility=Visibility.PUBLIC)
+        factories.SiteFactory(language=None, visibility=Visibility.MEMBERS)
+
+        backend.tests.factories.access.LanguageFactory.create()
+
+        response = self.client.get(self.get_list_endpoint())
+
+        assert response.status_code == 200
+
+        response_data = json.loads(response.content)
+        assert len(response_data) == 3
+
+        assert response_data[0]["language"] == language0.title
+        assert response_data[0]["languageCode"] == language0.language_code
+        assert len(response_data[0]["sites"]) == 2
+
+        assert response_data[1]["language"] == language1.title
+        assert response_data[1]["languageCode"] == language1.language_code
+        assert len(response_data[1]["sites"]) == 1
+
+        assert response_data[2]["language"] == "More FirstVoices Sites"
+        assert response_data[2]["languageCode"] == ""
+        assert len(response_data[2]["sites"]) == 2
+
+        site_json = response_data[0]["sites"][0]
+        assert site_json == {
+            "id": str(site.id),
+            "title": site.title,
+            "slug": site.slug,
+            "language": language0.title,
+            "visibility": "public",
+            "logo": None,
+            "url": f"http://testserver/api/1.0/sites/{site.slug}",
+            "enabledFeatures": [],
+        }
+
+    def get_expected_response(self, instance):
+        sites_json = [self.get_expected_site_response(s) for s in instance.sites.all()]
+
+        return {
+            "language": instance.title,
+            "languageCode": instance.language_code,
+            "sites": sites_json,
+        }
+
+    def get_expected_site_response(self, site):
+        return {
+            "id": str(site.id),
+            "title": site.title,
+            "slug": site.slug,
+            "language": site.language.title,
+            "visibility": "public",
+            "logo": None,
+            "url": f"http://testserver/api/1.0/sites/{site.slug}",
+            "enabledFeatures": [],
+        }
+
+    def generate_test_sites(self):
+        # a language with sites of all visibilities
+        all_vis_language = backend.tests.factories.access.LanguageFactory.create()
+        team_site0 = factories.SiteFactory(
+            language=all_vis_language, visibility=Visibility.TEAM
+        )
+        member_site0 = factories.SiteFactory(
+            language=all_vis_language, visibility=Visibility.MEMBERS
+        )
+        public_site0 = factories.SiteFactory(
+            language=all_vis_language, visibility=Visibility.PUBLIC
+        )
+
+        # languages with one site each
+        team_language = backend.tests.factories.access.LanguageFactory.create()
+        team_site1 = factories.SiteFactory(
+            language=team_language, visibility=Visibility.TEAM
+        )
+
+        member_language = backend.tests.factories.access.LanguageFactory.create()
+        member_site1 = factories.SiteFactory(
+            language=member_language, visibility=Visibility.MEMBERS
+        )
+
+        public_language = backend.tests.factories.access.LanguageFactory.create()
+        public_site1 = factories.SiteFactory(
+            language=public_language, visibility=Visibility.PUBLIC
+        )
+
+        # sites with no language
+        team_site2 = factories.SiteFactory(language=None, visibility=Visibility.TEAM)
+        member_site2 = factories.SiteFactory(
+            language=None, visibility=Visibility.MEMBERS
+        )
+        public_site2 = factories.SiteFactory(
+            language=None, visibility=Visibility.PUBLIC
+        )
+
+        return {
+            "public": [public_site0, public_site1, public_site2],
+            "members": [member_site0, member_site1, member_site2],
+            "team": [team_site0, team_site1, team_site2],
+        }
+
+    def assert_visible_sites(self, response, sites):
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+
+        response_sites = [
+            site["id"] for language in response_data for site in language["sites"]
+        ]
+
+        assert len(response_sites) == 6, "included extra sites"
+
+        assert str(sites["members"][0].id) in response_sites
+        assert str(sites["members"][1].id) in response_sites
+        assert str(sites["members"][2].id) in response_sites
+
+        assert str(sites["public"][0].id) in response_sites
+        assert str(sites["public"][1].id) in response_sites
+        assert str(sites["public"][2].id) in response_sites
+
+    @pytest.mark.parametrize("get_user", [get_anonymous_user, get_non_member_user])
+    @pytest.mark.django_db
+    def test_list_permissions_for_non_members(self, get_user):
+        sites = self.generate_test_sites()
+
+        user = get_user()
+        self.client.force_authenticate(user=user)
+
+        response = self.client.get(self.get_list_endpoint())
+        self.assert_visible_sites(response, sites)
+
+    @pytest.mark.parametrize(
+        "role", [Role.MEMBER, Role.ASSISTANT, Role.EDITOR, Role.LANGUAGE_ADMIN]
+    )
+    @pytest.mark.django_db
+    def test_list_permissions_for_members(self, role):
+        sites = self.generate_test_sites()
+
+        user = factories.get_non_member_user()
+        factories.MembershipFactory.create(user=user, site=sites["team"][0], role=role)
+        self.client.force_authenticate(user=user)
+
+        response = self.client.get(self.get_list_endpoint())
+        self.assert_visible_sites(response, sites)
+
+    @pytest.mark.parametrize(
+        "role", [Role.MEMBER, Role.ASSISTANT, Role.EDITOR, Role.LANGUAGE_ADMIN]
+    )
+    @pytest.mark.django_db
+    def test_list_permissions_for_superadmins(self, role):
+        sites = self.generate_test_sites()
+
+        user = factories.get_app_admin(AppRole.SUPERADMIN)
+        self.client.force_authenticate(user=user)
+
+        response = self.client.get(self.get_list_endpoint())
+        self.assert_visible_sites(response, sites)
+
+    @pytest.mark.parametrize("visibility", [Visibility.PUBLIC, Visibility.MEMBERS])
+    @pytest.mark.django_db
+    def test_list_logo_from_same_site(self, visibility):
+        user = factories.get_non_member_user()
+        self.client.force_authenticate(user=user)
+
+        site = factories.SiteFactory.create(visibility=visibility)
+        image = factories.ImageFactory(site=site)
+        site.logo = image
+        site.save()
+
+        response = self.client.get(f"{self.get_list_endpoint()}")
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+        assert len(response_data) == 1
+        assert len(response_data[0]["sites"]) == 1
+        assert response_data[0]["sites"][0]["logo"] == self.get_expected_image_data(
+            image
+        )

--- a/firstvoices/backend/urls.py
+++ b/firstvoices/backend/urls.py
@@ -16,6 +16,7 @@ from backend.views.games_views import WordsyViewSet
 from backend.views.image_views import ImageViewSet
 from backend.views.immersion_label_views import ImmersionLabelViewSet
 from backend.views.join_request_views import JoinRequestViewSet
+from backend.views.language_views import LanguageViewSet
 from backend.views.page_views import SitePageViewSet
 from backend.views.parts_of_speech_views import PartsOfSpeechViewSet
 from backend.views.person_views import PersonViewSet
@@ -34,6 +35,7 @@ from backend.views.word_of_the_day_views import WordOfTheDayView
 # app-level APIs
 
 ROUTER = CustomRouter()
+ROUTER.register(r"languages", LanguageViewSet, basename="language")
 ROUTER.register(r"my-sites", MySitesViewSet, basename="my-sites")
 ROUTER.register(r"parts-of-speech", PartsOfSpeechViewSet, basename="partofspeech")
 ROUTER.register(r"search", BaseSearchViewSet, basename="search")

--- a/firstvoices/backend/views/language_views.py
+++ b/firstvoices/backend/views/language_views.py
@@ -1,0 +1,163 @@
+from django.db.models import Prefetch
+from django.db.models.functions import Upper
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
+from rest_framework.response import Response
+from rest_framework.viewsets import ModelViewSet
+
+from backend.models.constants import Visibility
+from backend.models.sites import Language, Membership, Site, SiteFeature
+from backend.serializers.membership_serializers import MembershipSiteSummarySerializer
+from backend.serializers.site_serializers import (
+    LanguageSerializer,
+    SiteSummarySerializer,
+)
+from backend.views import doc_strings
+from backend.views.api_doc_variables import inline_site_doc_detail_serializer
+from backend.views.base_views import FVPermissionViewSetMixin
+
+from .utils import get_select_related_media_fields
+
+
+@extend_schema_view(
+    list=extend_schema(
+        description="A public list of available language sites, grouped by language. "
+        "Public and member sites are included, as well as any team sites the user has access to. If there "
+        "are no accessible sites the list will be empty. Sites with no specified language will be grouped "
+        "under 'More FirstVoices Sites'.",
+        responses={200: LanguageSerializer},
+    ),
+    retrieve=extend_schema(
+        description="Basic information about a language.",
+        responses={
+            200: inline_site_doc_detail_serializer,
+            403: OpenApiResponse(description=doc_strings.error_403),
+            404: OpenApiResponse(description=doc_strings.error_404),
+        },
+    ),
+)
+class LanguageViewSet(FVPermissionViewSetMixin, ModelViewSet):
+    """
+    Summary information about languages.
+    """
+
+    http_method_names = ["get"]
+    serializer_class = LanguageSerializer
+    pagination_class = None
+    model = Language
+
+    def get_detail_queryset(self):
+        return (
+            Language.objects.all()
+            .order_by(Upper("title"))
+            .prefetch_related(
+                Prefetch(
+                    "sites",
+                    queryset=Site.objects.visible(user=self.request.user)
+                    .order_by(Upper("title"))
+                    .select_related(*get_select_related_media_fields("logo")),
+                ),
+                Prefetch(
+                    "sites__sitefeature_set",
+                    queryset=SiteFeature.objects.filter(is_enabled=True),
+                ),
+            )
+        )
+
+    def get_list_queryset(self):
+        return Language.objects.none()  # not used-- see the list method instead
+
+    def list(self, request, *args, **kwargs):
+        """
+        Return a list of sites grouped by language.
+        """
+        # retrieve visible sites in order to filter out empty languages
+        sites = Site.objects.filter(visibility__gte=Visibility.MEMBERS)
+        ids_of_languages_with_sites = sites.values_list("language_id", flat=True)
+
+        # then retrieve the desired data as a Language queryset
+        # sorting note: titles are converted to uppercase and then sorted which will put custom characters at the end
+        languages = (
+            Language.objects.filter(id__in=ids_of_languages_with_sites)
+            .order_by(Upper("title"))
+            .prefetch_related(
+                Prefetch(
+                    "sites",
+                    queryset=sites.order_by(Upper("title")).select_related(
+                        *get_select_related_media_fields("logo")
+                    ),
+                ),
+                Prefetch(
+                    "sites__sitefeature_set",
+                    queryset=SiteFeature.objects.filter(is_enabled=True),
+                ),
+            )
+        )
+
+        data = [
+            LanguageSerializer(language, context={"request": request}).data
+            for language in languages
+        ]
+
+        # add "other" sites
+        other_sites = (
+            sites.filter(language=None)
+            .order_by(Upper("title"))
+            .select_related(*get_select_related_media_fields("logo"))
+            .prefetch_related(
+                Prefetch(
+                    "sitefeature_set",
+                    queryset=SiteFeature.objects.filter(is_enabled=True),
+                ),
+            )
+        )
+
+        if other_sites:
+            other_site_json = {
+                "language": "More FirstVoices Sites",
+                "languageCode": "",
+                "sites": [
+                    SiteSummarySerializer(site, context={"request": request}).data
+                    for site in other_sites
+                ],
+            }
+
+            data.append(other_site_json)
+
+        return Response(data)
+
+
+@extend_schema_view(
+    list=extend_schema(
+        description="A list of language sites that the current user is a member of. May be empty.",
+        responses={
+            200: MembershipSiteSummarySerializer,
+        },
+    ),
+)
+class MySitesViewSet(FVPermissionViewSetMixin, ModelViewSet):
+    """
+    Information about language sites the current user is a member of.
+    """
+
+    http_method_names = ["get"]
+    lookup_field = "site__slug"
+    serializer_class = MembershipSiteSummarySerializer
+
+    def get_queryset(self):
+        if self.request.user.is_anonymous:
+            return Membership.objects.none()
+
+        # note that the titles are converted to uppercase and then sorted which will put custom characters at the end
+        return (
+            Membership.objects.filter(user=self.request.user)
+            .select_related(
+                "site", "site__language", *get_select_related_media_fields("site__logo")
+            )
+            .prefetch_related(
+                Prefetch(
+                    "site__sitefeature_set",
+                    queryset=SiteFeature.objects.filter(is_enabled=True),
+                ),
+            )
+            .order_by(Upper("site__title"))
+        )


### PR DESCRIPTION
### Description of Changes
* Adds a read-only languages api. This currently duplicates the sites api list view, and then has a detail view that shows one language with its site list. Eventually the sites api list can be switched to a plain list of all sites.

### Checklist
- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
