### PR TITLE
FW-5400-fix-recalculation-optional-metadata-onsave

### DIFF
--- a/firstvoices/backend/models/base.py
+++ b/firstvoices/backend/models/base.py
@@ -63,9 +63,9 @@ class BaseModel(PermissionFilterMixin, RulesModel):
 
     logger = logging.getLogger(__name__)
 
-    def save(self, *args, **kwargs):
+    def save(self, set_modified_date=True, *args, **kwargs):
         """Update last_modified time if updating the model."""
-        if not self._state.adding:
+        if (not self._state.adding) and set_modified_date:
             self.last_modified = timezone.now()
         return super().save(*args, **kwargs)
 

--- a/firstvoices/backend/models/media.py
+++ b/firstvoices/backend/models/media.py
@@ -64,8 +64,8 @@ class FileBase(BaseSiteContentModel):
     def __str__(self):
         return f"{self.content.name} ({self.site})"
 
-    def save(self, update_metadata_command=False, **kwargs):
-        if not self._state.adding and not update_metadata_command:
+    def save(self, update_file_metadata=False, **kwargs):
+        if not self._state.adding and not update_file_metadata:
             raise NotSupportedError(
                 "Editing existing files is not supported at this time. Please create a new file if you would like to "
                 "update a media file."
@@ -140,7 +140,7 @@ class ImageFile(VisualFileBase):
             "height": self.content.file.image.height,
         }
 
-    def save(self, update_metadata_command=False, **kwargs):
+    def save(self, update_file_metadata=False, **kwargs):
         try:
             image_dimensions = get_image_dimensions(self.content)
             self.width = image_dimensions[0]
@@ -152,7 +152,7 @@ class ImageFile(VisualFileBase):
                 f"Error: {e}\n"
             )
 
-        super().save(update_metadata_command, **kwargs)
+        super().save(update_file_metadata, **kwargs)
 
 
 def get_local_video_file(original):
@@ -175,7 +175,7 @@ class VideoFile(VisualFileBase):
             "delete": predicates.can_delete_core_uncontrolled_data,
         }
 
-    def save(self, update_metadata_command=False, **kwargs):
+    def save(self, update_file_metadata=False, **kwargs):
         try:
             with get_local_video_file(self.content) as temp_file:
                 video_info = self.get_video_info(temp_file)
@@ -195,7 +195,7 @@ class VideoFile(VisualFileBase):
                 f"{e.stderr.decode('utf8')}\n"
             )
 
-        super().save(update_metadata_command, **kwargs)
+        super().save(update_file_metadata, **kwargs)
 
     def get_video_info(self, temp_file):
         probe = ffmpeg.probe(temp_file.name)

--- a/firstvoices/backend/tasks/alphabet_tasks.py
+++ b/firstvoices/backend/tasks/alphabet_tasks.py
@@ -107,9 +107,7 @@ def recalculate_custom_order(site_slug: str):
         new_order = alphabet.get_custom_order(cleaned_title)
 
         # Save the entry to recalculate custom order and clean title
-        entry.title = cleaned_title
-        entry.custom_order = new_order
-        entry.save()
+        entry.save(set_modified_date=False)
 
         append_updated_entry(
             updated_entries,

--- a/firstvoices/backend/tasks/update_metadata_tasks.py
+++ b/firstvoices/backend/tasks/update_metadata_tasks.py
@@ -15,7 +15,7 @@ def update_missing_media_metadata(missing_media_files):
     )
     for file in missing_media_files:
         try:
-            file.save(update_metadata_command=True)
+            file.save(update_file_metadata=True)
         except FileNotFoundError as e:
             logger.warning(
                 f"File not found for {file.__class__.__name__} - {file.id}. Error: {e}"

--- a/firstvoices/backend/tests/test_models/test_character_model.py
+++ b/firstvoices/backend/tests/test_models/test_character_model.py
@@ -49,6 +49,15 @@ class TestCharacterModel:
             CharacterFactory(site=ichar.site, title=ichar.title)
 
     @pytest.mark.django_db
+    def test_characters_onsave(self):
+        """Character metadata is set on save"""
+        char = CharacterFactory.create(title="a")
+        char = Character.objects.get(id=char.id)
+        char.title = char.title.upper()
+        char.save()
+        assert char.created != char.last_modified
+
+    @pytest.mark.django_db
     def test_variant_ignorable_same_name(self):
         """Ignorable can't be created with the same name as a character variant"""
         char = CharacterFactory.create()

--- a/firstvoices/backend/tests/test_models/test_dictionary_entry_model.py
+++ b/firstvoices/backend/tests/test_models/test_dictionary_entry_model.py
@@ -114,6 +114,18 @@ class TestDictionaryEntryModel:
         fetched_entry = DictionaryEntry.objects.get(id=entry.id)
         assert fetched_entry.split_chars_base == ["a", "üü", "a"]
 
+    @pytest.mark.django_db
+    def test_metadata_onsave(self):
+        site = SiteFactory.create()
+        entry = DictionaryEntry(title="1", type="WORD", site=site)
+        entry.save()
+
+        entry.title = "2"
+        entry.save()
+
+        fetched_entry = DictionaryEntry.objects.get(id=entry.id)
+        assert fetched_entry.created != fetched_entry.last_modified
+
 
 class TestDictionarySortProcessing:
     @pytest.mark.django_db

--- a/firstvoices/backend/tests/test_models/test_media_models.py
+++ b/firstvoices/backend/tests/test_models/test_media_models.py
@@ -325,7 +325,7 @@ class TestVideoModel(ThumbnailTestMixin):
             "backend.models.media.VideoFile.get_video_info"
         ) as mock_get_video_info:
             mock_get_video_info.return_value = None
-            video.save(update_metadata_command=True)
+            video.save(update_file_metadata=True)
             assert (
                 f"Failed to get video info for [{video.content.name}]. \n"
                 in caplog.text

--- a/firstvoices/backend/tests/test_models/test_site_model.py
+++ b/firstvoices/backend/tests/test_models/test_site_model.py
@@ -67,3 +67,20 @@ class TestSiteModel:
 
         with pytest.raises(IntegrityError):
             site.save()
+
+    @pytest.mark.django_db
+    def test_metadata_onsave(self):
+        admin_user = get_app_admin(AppRole.STAFF)
+        site = Site(
+            title=self.TEST_SITE_TITLE,
+            slug=self.TEST_SITE_SLUG,
+            created_by=admin_user,
+            last_modified_by=admin_user,
+        )
+        site.save()
+
+        site.title = self.TEST_SITE_TITLE * 2
+        site.save()
+
+        fetched_site = Site.objects.get(id=site.id)
+        assert fetched_site.created != fetched_site.last_modified

--- a/firstvoices/backend/tests/test_tasks/test_alphabet_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_alphabet_tasks.py
@@ -340,6 +340,7 @@ class TestAlphabetTasks:
                 }
             ],
         }
+        entry = DictionaryEntry.objects.get(site=site, title="abc")
         assert entry.last_modified == entry_last_modified
 
     @pytest.mark.django_db


### PR DESCRIPTION
### Description of Changes
Added a parameter to the save function which allows skipping of any update to the last_modified property. This is applied to the recalculate custom order task. Also fixes a bug about this in the recalculation tests.

### Checklist
- README / documentation has been updated if needed
- [X] PR title / commit messages contain Jira ticket number if applicable
- [X] Tests have been updated / created if applicable
- Admin Panel has been updated if models have been added or modified
- Migrations have been updated and committed if applicable
- Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
