### PR TITLE
FW-5402 Add wordsy endpoint

### DIFF
--- a/firstvoices/backend/tests/test_apis/test_games_api.py
+++ b/firstvoices/backend/tests/test_apis/test_games_api.py
@@ -14,7 +14,7 @@ from backend.tests.test_apis.base_api_test import BaseSiteContentApiTest
 
 class TestWordsyEndpoint(BaseSiteContentApiTest):
     """
-    Tests for games/wordsy API
+    Tests for wordsy endpoint
     """
 
     API_LIST_VIEW = "api:wordsy-list"
@@ -44,7 +44,7 @@ class TestWordsyEndpoint(BaseSiteContentApiTest):
 
     @pytest.mark.django_db
     def test_all_invalid_words(self):
-        invalid_words_list = ["abc ab", "abcabc", "xyzav"]
+        invalid_words_list = ["abc ab", "abcabc", "xyzav", "ab ab"]
         # adding multiple dictionary entries
         for title in invalid_words_list:
             DictionaryEntryFactory(
@@ -64,7 +64,7 @@ class TestWordsyEndpoint(BaseSiteContentApiTest):
     @pytest.mark.django_db
     def test_mixed_words(self):
         # test to verify only valid words show up
-        invalid_words_list = ["abc ab", "abcabc", "xyzav"]
+        invalid_words_list = ["ab ab", "abc ab", "abcabc", "xyzav"]
         valid_words_list = ["ababa", "abcab", "bcbca", "cabca"]
 
         # adding multiple dictionary entries

--- a/firstvoices/backend/tests/test_apis/test_games_api.py
+++ b/firstvoices/backend/tests/test_apis/test_games_api.py
@@ -11,6 +11,7 @@ from backend.tests.factories import (
     get_site_with_member,
 )
 from backend.tests.test_apis.base_api_test import BaseSiteContentApiTest
+from backend.views.games_views import CACHE_KEY_WORDSY
 
 
 class TestWordsyEndpoint(BaseSiteContentApiTest):
@@ -128,7 +129,7 @@ class TestWordsyEndpoint(BaseSiteContentApiTest):
         )
 
         # Manually clearing the cache
-        caches["wordsy"].clear()
+        caches[CACHE_KEY_WORDSY].clear()
 
         # Fetching response again, the new entry should be now present in the words list
         # since cache is cleared, so the db should be accessed again

--- a/firstvoices/backend/tests/test_apis/test_games_api.py
+++ b/firstvoices/backend/tests/test_apis/test_games_api.py
@@ -1,0 +1,84 @@
+import json
+
+import pytest
+from rest_framework.test import APIClient
+
+from backend.models.constants import Role, Visibility
+from backend.tests.factories import (
+    CharacterFactory,
+    DictionaryEntryFactory,
+    get_site_with_member,
+)
+from backend.tests.test_apis.base_api_test import BaseSiteContentApiTest
+
+
+class TestWordsyEndpoint(BaseSiteContentApiTest):
+    """
+    Tests for games/wordsy API
+    """
+
+    API_LIST_VIEW = "api:wordsy-list"
+
+    def setup_method(self):
+        self.client = APIClient()
+        self.site, self.member_user = get_site_with_member(
+            Visibility.PUBLIC, Role.LANGUAGE_ADMIN
+        )
+        self.client.force_authenticate(user=self.member_user)
+        CharacterFactory.create(site=self.site, title="a")
+        CharacterFactory.create(site=self.site, title="b")
+        CharacterFactory.create(site=self.site, title="c")
+
+    @pytest.mark.django_db
+    def test_list_empty(self):
+        # Overriding since there is no pagination class for this view
+        response = self.client.get(self.get_list_endpoint(site_slug=self.site.slug))
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+
+        assert response_data["orthography"] == ["a", "b", "c"]
+        assert response_data["words"] == []
+        assert response_data["validGuesses"] == []
+        assert response_data["solution"] == ""
+
+    @pytest.mark.django_db
+    def test_all_invalid_words(self):
+        invalid_words_list = ["abc ab", "abcabc", "xyzav"]
+        # adding multiple dictionary entries
+        for title in invalid_words_list:
+            DictionaryEntryFactory(
+                site=self.site, visibility=Visibility.PUBLIC, title=title
+            )
+
+        response = self.client.get(self.get_list_endpoint(site_slug=self.site.slug))
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+
+        assert response_data["orthography"] == ["a", "b", "c"]
+        assert response_data["words"] == []
+        assert response_data["validGuesses"] == []
+        assert response_data["solution"] == ""
+
+    @pytest.mark.django_db
+    def test_mixed_words(self):
+        # test to verify only valid words show up
+        invalid_words_list = ["abc ab", "abcabc", "xyzav"]
+        valid_words_list = ["ababa", "abcab", "bcbca", "cabca"]
+
+        # adding multiple dictionary entries
+        for title in invalid_words_list + valid_words_list:
+            DictionaryEntryFactory(
+                site=self.site, visibility=Visibility.PUBLIC, title=title
+            )
+
+        response = self.client.get(self.get_list_endpoint(site_slug=self.site.slug))
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+
+        assert response_data["orthography"] == ["a", "b", "c"]
+        assert response_data["words"] == valid_words_list
+        assert response_data["validGuesses"] == valid_words_list
+        assert response_data["solution"] in valid_words_list

--- a/firstvoices/backend/tests/test_apis/test_games_api.py
+++ b/firstvoices/backend/tests/test_apis/test_games_api.py
@@ -7,6 +7,7 @@ from rest_framework.test import APIClient
 from backend.models.constants import Role, Visibility
 from backend.tests.factories import (
     CharacterFactory,
+    CharacterVariantFactory,
     DictionaryEntryFactory,
     get_site_with_member,
 )
@@ -21,15 +22,20 @@ class TestWordsyEndpoint(BaseSiteContentApiTest):
 
     API_LIST_VIEW = "api:wordsy-list"
 
+    EXPECTED_ORTHOGRAPHY = ["a", "b", "c"]
+
     def setup_method(self):
         self.client = APIClient()
         self.site, self.member_user = get_site_with_member(
             Visibility.PUBLIC, Role.LANGUAGE_ADMIN
         )
         self.client.force_authenticate(user=self.member_user)
-        CharacterFactory.create(site=self.site, title="a")
-        CharacterFactory.create(site=self.site, title="b")
-        CharacterFactory.create(site=self.site, title="c")
+        char_a = CharacterFactory.create(site=self.site, title="a")
+        char_b = CharacterFactory.create(site=self.site, title="b")
+        char_c = CharacterFactory.create(site=self.site, title="c")
+        CharacterVariantFactory.create(title="A", base_character=char_a)
+        CharacterVariantFactory.create(title="B", base_character=char_b)
+        CharacterVariantFactory.create(title="C", base_character=char_c)
 
     @pytest.mark.django_db
     def test_list_empty(self):
@@ -39,7 +45,7 @@ class TestWordsyEndpoint(BaseSiteContentApiTest):
         assert response.status_code == 200
         response_data = json.loads(response.content)
 
-        assert response_data["orthography"] == ["a", "b", "c"]
+        assert response_data["orthography"] == self.EXPECTED_ORTHOGRAPHY
         assert response_data["words"] == []
         assert response_data["validGuesses"] == []
         assert response_data["solution"] == ""
@@ -58,7 +64,7 @@ class TestWordsyEndpoint(BaseSiteContentApiTest):
         assert response.status_code == 200
         response_data = json.loads(response.content)
 
-        assert response_data["orthography"] == ["a", "b", "c"]
+        assert response_data["orthography"] == self.EXPECTED_ORTHOGRAPHY
         assert response_data["words"] == []
         assert response_data["validGuesses"] == []
         assert response_data["solution"] == ""
@@ -66,8 +72,9 @@ class TestWordsyEndpoint(BaseSiteContentApiTest):
     @pytest.mark.django_db
     def test_mixed_words(self):
         # test to verify only valid words show up
-        invalid_words_list = ["ab ab", "abc ab", "abcabc", "xyzav"]
-        valid_words_list = ["ababa", "abcab", "bcbca", "cabca"]
+        invalid_words_list = ["ab Ab", "abC ab", "abCabc", "Xyzav"]
+        valid_words_list = ["ABabA", "BcbCa", "aBcAb", "caBcA"]
+        expected_response = ["ababa", "bcbca", "abcab", "cabca"]  # base character form
 
         # adding multiple dictionary entries
         for title in invalid_words_list + valid_words_list:
@@ -80,14 +87,35 @@ class TestWordsyEndpoint(BaseSiteContentApiTest):
         assert response.status_code == 200
         response_data = json.loads(response.content)
 
-        assert response_data["orthography"] == ["a", "b", "c"]
-        assert response_data["words"] == valid_words_list
-        assert response_data["validGuesses"] == valid_words_list
-        assert response_data["solution"] in valid_words_list
+        assert response_data["words"] == expected_response
+        assert response_data["validGuesses"] == expected_response
+        assert response_data["solution"] in expected_response
 
     @pytest.mark.django_db
-    def test_cache_used(self):
-        # Veriyfing that data is being picked up from cache and not from db.
+    def test_no_duplicate_words(self):
+        DictionaryEntryFactory(
+            site=self.site, visibility=Visibility.PUBLIC, title="AaAaA"
+        )
+        DictionaryEntryFactory(
+            site=self.site, visibility=Visibility.PUBLIC, title="AaAaA"
+        )
+        DictionaryEntryFactory(
+            site=self.site, visibility=Visibility.PUBLIC, title="BbBbB"
+        )
+        DictionaryEntryFactory(
+            site=self.site, visibility=Visibility.PUBLIC, title="BbBbB"
+        )
+
+        # no duplicates should be present
+        expected_words = ["aaaaa", "bbbbb"]
+
+        response = self.client.get(self.get_list_endpoint(site_slug=self.site.slug))
+        response_data = json.loads(response.content)
+        assert response_data["words"] == expected_words
+
+    @pytest.mark.django_db
+    def test_cache_used_word_deleted(self):
+        # Verifying that data is being picked up from cache and not from db.
         dictionary_entry_1 = DictionaryEntryFactory(
             site=self.site, visibility=Visibility.PUBLIC, title="aaaaa"
         )
@@ -136,3 +164,56 @@ class TestWordsyEndpoint(BaseSiteContentApiTest):
         response_new = self.client.get(self.get_list_endpoint(site_slug=self.site.slug))
         response_data_new = json.loads(response_new.content)
         assert new_entry.title in response_data_new["words"]
+
+    @pytest.mark.django_db
+    def test_cache_expiry_visibility_changed(self):
+        # Verifying that data is being picked up from cache and not from db.
+        dictionary_entry_1 = DictionaryEntryFactory(
+            site=self.site, visibility=Visibility.PUBLIC, title="aaaaa"
+        )
+        dictionary_entry_2 = DictionaryEntryFactory(
+            site=self.site, visibility=Visibility.PUBLIC, title="bbbbb"
+        )
+        valid_words_list = [dictionary_entry_1.title, dictionary_entry_2.title]
+
+        response = self.client.get(self.get_list_endpoint(site_slug=self.site.slug))
+        response_data = json.loads(response.content)
+        assert response_data["words"] == valid_words_list
+
+        # Updating visibility of one entry
+        dictionary_entry_2.visibility = Visibility.TEAM
+        dictionary_entry_2.save()
+
+        # Manually clearing the cache
+        caches[CACHE_KEY_WORDSY].clear()
+
+        # Checking response again, the updated entry should not show up
+        response_new = self.client.get(self.get_list_endpoint(site_slug=self.site.slug))
+        response_data_new = json.loads(response_new.content)
+        assert "bbbbb" not in response_data_new["words"]
+
+    @pytest.mark.django_db
+    def test_cache_expiry_word_deleted(self):
+        # Verifying that data is being picked up from cache and not from db.
+        DictionaryEntryFactory(
+            site=self.site, visibility=Visibility.PUBLIC, title="AAAAA"
+        )
+        dictionary_entry_2 = DictionaryEntryFactory(
+            site=self.site, visibility=Visibility.PUBLIC, title="BBBBB"
+        )
+        valid_words_list = ["aaaaa", "bbbbb"]
+
+        response = self.client.get(self.get_list_endpoint(site_slug=self.site.slug))
+        response_data = json.loads(response.content)
+        assert response_data["words"] == valid_words_list
+
+        # Updating visibility of one entry
+        dictionary_entry_2.delete()
+
+        # Manually clearing the cache
+        caches[CACHE_KEY_WORDSY].clear()
+
+        # Checking response again, the deleted entry should not show up
+        response_new = self.client.get(self.get_list_endpoint(site_slug=self.site.slug))
+        response_data_new = json.loads(response_new.content)
+        assert "bbbbb" not in response_data_new["words"]

--- a/firstvoices/backend/tests/test_apis/test_games_api.py
+++ b/firstvoices/backend/tests/test_apis/test_games_api.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+from django.core.cache import caches
 from rest_framework.test import APIClient
 
 from backend.models.constants import Role, Visibility
@@ -82,3 +83,55 @@ class TestWordsyEndpoint(BaseSiteContentApiTest):
         assert response_data["words"] == valid_words_list
         assert response_data["validGuesses"] == valid_words_list
         assert response_data["solution"] in valid_words_list
+
+    @pytest.mark.django_db
+    def test_cache_used(self):
+        # Veriyfing that data is being picked up from cache and not from db.
+        dictionary_entry_1 = DictionaryEntryFactory(
+            site=self.site, visibility=Visibility.PUBLIC, title="aaaaa"
+        )
+        dictionary_entry_2 = DictionaryEntryFactory(
+            site=self.site, visibility=Visibility.PUBLIC, title="bbbbb"
+        )
+        valid_words_list = [dictionary_entry_1.title, dictionary_entry_2.title]
+
+        response = self.client.get(self.get_list_endpoint(site_slug=self.site.slug))
+        response_data = json.loads(response.content)
+        assert response_data["words"] == valid_words_list
+
+        # Deleting one entry
+        dictionary_entry_2.delete()
+
+        # Checking response again, the entry should still be present
+        response_new = self.client.get(self.get_list_endpoint(site_slug=self.site.slug))
+        response_data_new = json.loads(response_new.content)
+        assert "bbbbb" in response_data_new["words"]
+
+    @pytest.mark.django_db
+    def test_cache_expiry_generates_new_config(self):
+        # Then, Manually clearing cache to emulate end-of-day and
+        # verifying that a new config is generated
+
+        valid_words_list = ["aaaaa", "bbbbb"]
+        for title in valid_words_list:
+            DictionaryEntryFactory(
+                site=self.site, visibility=Visibility.PUBLIC, title=title
+            )
+
+        response = self.client.get(self.get_list_endpoint(site_slug=self.site.slug))
+        response_data = json.loads(response.content)
+        assert response_data["words"] == valid_words_list
+        assert response_data["solution"] in valid_words_list
+
+        new_entry = DictionaryEntryFactory(
+            site=self.site, visibility=Visibility.PUBLIC, title="ccccc"
+        )
+
+        # Manually clearing the cache
+        caches["wordsy"].clear()
+
+        # Fetching response again, the new entry should be now present in the words list
+        # since cache is cleared, so the db should be accessed again
+        response_new = self.client.get(self.get_list_endpoint(site_slug=self.site.slug))
+        response_data_new = json.loads(response_new.content)
+        assert new_entry.title in response_data_new["words"]

--- a/firstvoices/backend/tests/utils.py
+++ b/firstvoices/backend/tests/utils.py
@@ -93,3 +93,8 @@ def update_widget_list_order(widgets, widget_list_two):
 
 def find_object_by_id(results_list, obj_id):
     return next((obj for obj in results_list if obj["id"] == str(obj_id)), None)
+
+
+def equate_list_content_without_order(actual, expected):
+    difference = set(actual) ^ set(expected)
+    return not difference

--- a/firstvoices/backend/urls.py
+++ b/firstvoices/backend/urls.py
@@ -77,7 +77,7 @@ sites_router.register(r"songs", SongViewSet, basename="song")
 sites_router.register(r"videos", VideoViewSet, basename="video")
 sites_router.register(r"widgets", SiteWidgetViewSet, basename="sitewidget")
 sites_router.register(r"stats", StatsViewSet, basename="stats")
-sites_router.register(r"games/wordsy", WordsyViewSet, basename="wordsy")
+sites_router.register(r"wordsy", WordsyViewSet, basename="wordsy")
 
 # stories and pages
 sites_router.register(r"stories", StoryViewSet, basename="story")

--- a/firstvoices/backend/urls.py
+++ b/firstvoices/backend/urls.py
@@ -12,6 +12,7 @@ from backend.views.custom_order_recalculate_views import (
 from backend.views.data_views import MTDSitesDataViewSet, SitesDataViewSet
 from backend.views.dictionary_views import DictionaryViewSet
 from backend.views.gallery_views import GalleryViewSet
+from backend.views.games_views import WordsyViewSet
 from backend.views.image_views import ImageViewSet
 from backend.views.immersion_label_views import ImmersionLabelViewSet
 from backend.views.join_request_views import JoinRequestViewSet
@@ -76,6 +77,7 @@ sites_router.register(r"songs", SongViewSet, basename="song")
 sites_router.register(r"videos", VideoViewSet, basename="video")
 sites_router.register(r"widgets", SiteWidgetViewSet, basename="sitewidget")
 sites_router.register(r"stats", StatsViewSet, basename="stats")
+sites_router.register(r"games/wordsy", WordsyViewSet, basename="wordsy")
 
 # stories and pages
 sites_router.register(r"stories", StoryViewSet, basename="story")

--- a/firstvoices/backend/views/games_views.py
+++ b/firstvoices/backend/views/games_views.py
@@ -1,5 +1,6 @@
 import math
 
+from django.core.cache import caches
 from django.db.models.expressions import RawSQL
 from django.utils.timezone import datetime
 from rest_framework.response import Response
@@ -15,7 +16,7 @@ def get_wordsy_solution_seed(num_words):
     # inspired from previous fv-wordsy game with slight modification
     epoch = datetime(2024, 1, 1, 0, 0, 0).timestamp()  # wordsy game epoch
     now = datetime.now().timestamp()
-    seconds_in_day = 86400
+    seconds_in_day = 86400000
     index = math.floor((now - epoch) / seconds_in_day)
     return index % num_words
 
@@ -28,38 +29,59 @@ class WordsyViewSet(SiteContentViewSetMixin, GenericViewSet):
     def list(self, request, **kwargs):
         site = self.get_validated_site()[0]
 
-        orthography = (
-            Character.objects.filter(site=site)
-            .order_by("sort_order")
-            .values_list("title", flat=True)
-        )
-        words = list(
-            DictionaryEntry.objects.annotate(
-                chars_length=RawSQL(
-                    "ARRAY_LENGTH(ARRAY_REMOVE(split_chars_base, ' '), 1)", ()
+        # setting cache_expiry to 23:59 for current date
+        today = datetime.today().date()
+        eod = datetime.today().time().max
+        cache_expiry = (
+            datetime.combine(today, eod)
+            - datetime.combine(today, datetime.now().time())
+        ).total_seconds()
+
+        # Checking if required query sets are present in cache
+        cache_key_orthography = f"{site.title}-orthography"
+        cache_key_words = f"{site.title}-words"
+
+        # orthography
+        orthography_qs = caches["wordsy"].get(cache_key_orthography)
+        if orthography_qs is None:
+            orthography_qs = list(
+                Character.objects.filter(site=site)
+                .order_by("sort_order")
+                .values_list("title", flat=True)
+            )
+            caches["wordsy"].set(cache_key_orthography, orthography_qs, cache_expiry)
+
+        # words
+        words_qs = caches["wordsy"].get(cache_key_words)
+        if words_qs is None:
+            # Filtering words based on their length excluding spaces
+            words_qs = list(
+                DictionaryEntry.objects.annotate(
+                    chars_length=RawSQL(
+                        "ARRAY_LENGTH(ARRAY_REMOVE(split_chars_base, ' '), 1)", ()
+                    )
                 )
+                .filter(
+                    site=site,
+                    visibility=site.visibility,
+                    exclude_from_games=False,
+                    exclude_from_kids=False,
+                    chars_length__exact=SOLUTION_LENGTH,
+                )
+                .order_by("custom_order")
+                .values_list("title", flat=True)
             )
-            .filter(
-                site=site,
-                visibility=site.visibility,
-                exclude_from_games=False,
-                exclude_from_kids=False,
-                chars_length__exact=SOLUTION_LENGTH,
-            )
-            .order_by("custom_order")
-            .values_list("title", flat=True)
-        )
-        valid_guesses = words
-        solution = ""
-        if len(words):
-            seed = get_wordsy_solution_seed(len(words))
-            solution = words[seed]
+            caches["wordsy"].set(cache_key_words, words_qs, cache_expiry)
+
+        if len(words_qs):
+            seed = get_wordsy_solution_seed(len(words_qs))
+            solution = words_qs[seed]
 
         return Response(
             data={
-                "orthography": orthography,
-                "words": words,
-                "valid_guesses": valid_guesses,
-                "solution": solution,
+                "orthography": orthography_qs,
+                "words": words_qs,
+                "valid_guesses": words_qs,  # to be expanded later with phrases that satisfy criteria
+                "solution": solution if solution else "",
             }
         )

--- a/firstvoices/backend/views/games_views.py
+++ b/firstvoices/backend/views/games_views.py
@@ -3,10 +3,18 @@ import math
 from django.core.cache import caches
 from django.db.models.expressions import RawSQL
 from django.utils.timezone import datetime
+from drf_spectacular.utils import (
+    OpenApiResponse,
+    extend_schema,
+    extend_schema_view,
+    inline_serializer,
+)
+from rest_framework import serializers
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from backend.models import Character, DictionaryEntry
+from backend.views.api_doc_variables import site_slug_parameter
 from backend.views.base_views import SiteContentViewSetMixin
 
 CACHE_KEY_WORDSY = "wordsy"
@@ -22,6 +30,25 @@ def get_wordsy_solution_seed(num_words):
     return index % num_words
 
 
+@extend_schema_view(
+    list=extend_schema(
+        description="Returns the wordsy config for the day.",
+        responses={
+            200: inline_serializer(
+                name="wordsy_response",
+                fields={
+                    "orthography": serializers.ListField(),
+                    "words": serializers.ListField(),
+                    "validGuesses": serializers.ListField(),
+                    "solution": serializers.CharField(),
+                },
+            ),
+            403: OpenApiResponse(description="Todo: Not authorized for this Site"),
+            404: OpenApiResponse(description="Todo: Site not found"),
+        },
+        parameters=[site_slug_parameter],
+    ),
+)
 class WordsyViewSet(SiteContentViewSetMixin, GenericViewSet):
     http_method_names = ["get"]
     pagination_class = None

--- a/firstvoices/backend/views/games_views.py
+++ b/firstvoices/backend/views/games_views.py
@@ -57,9 +57,7 @@ class WordsyViewSet(SiteContentViewSetMixin, GenericViewSet):
             # Filtering words based on their length excluding spaces
             words_qs = list(
                 DictionaryEntry.objects.annotate(
-                    chars_length=RawSQL(
-                        "ARRAY_LENGTH(ARRAY_REMOVE(split_chars_base, ' '), 1)", ()
-                    )
+                    chars_length=RawSQL("ARRAY_LENGTH(split_chars_base, 1)", ())
                 )
                 .filter(
                     site=site,
@@ -76,12 +74,14 @@ class WordsyViewSet(SiteContentViewSetMixin, GenericViewSet):
         if len(words_qs):
             seed = get_wordsy_solution_seed(len(words_qs))
             solution = words_qs[seed]
+        else:
+            solution = ""
 
         return Response(
             data={
                 "orthography": orthography_qs,
                 "words": words_qs,
                 "valid_guesses": words_qs,  # to be expanded later with phrases that satisfy criteria
-                "solution": solution if solution else "",
+                "solution": solution,
             }
         )

--- a/firstvoices/backend/views/games_views.py
+++ b/firstvoices/backend/views/games_views.py
@@ -66,6 +66,7 @@ class WordsyViewSet(SiteContentViewSetMixin, GenericViewSet):
                     exclude_from_kids=False,
                     chars_length__exact=SOLUTION_LENGTH,
                 )
+                .exclude(title__contains=" ")
                 .order_by("custom_order")
                 .values_list("title", flat=True)
             )

--- a/firstvoices/backend/views/games_views.py
+++ b/firstvoices/backend/views/games_views.py
@@ -1,0 +1,50 @@
+from django.db.models.expressions import RawSQL
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
+
+from backend.models import Character, DictionaryEntry
+from backend.views.base_views import SiteContentViewSetMixin
+
+SOLUTION_LENGTH = 5
+
+
+class WordsyViewSet(SiteContentViewSetMixin, GenericViewSet):
+    http_method_names = ["get"]
+    pagination_class = None
+    queryset = ""
+
+    def list(self, request, **kwargs):
+        site = self.get_validated_site()[0]
+
+        orthography = (
+            Character.objects.filter(site=site)
+            .order_by("sort_order")
+            .values_list("title", flat=True)
+        )
+        words = (
+            DictionaryEntry.objects.annotate(
+                chars_length=RawSQL(
+                    "ARRAY_LENGTH(ARRAY_REMOVE(split_chars_base, ' '), 1)", ()
+                )
+            )
+            .filter(
+                site=site,
+                visibility=site.visibility,
+                exclude_from_games=False,
+                exclude_from_kids=False,
+                chars_length__exact=SOLUTION_LENGTH,
+            )
+            .order_by("custom_order")
+            .values_list("title", flat=True)
+        )
+        valid_guesses = words
+        solution = ""
+
+        return Response(
+            data={
+                "orthography": orthography,
+                "words": words,
+                "valid_guesses": valid_guesses,
+                "solution": solution,
+            }
+        )

--- a/firstvoices/backend/views/games_views.py
+++ b/firstvoices/backend/views/games_views.py
@@ -103,7 +103,9 @@ class WordsyViewSet(SiteContentViewSetMixin, GenericViewSet):
             )
             words = []
             for split_chars in words_qs.iterator():
-                words.append("".join(split_chars))
+                title_from_base_chars = "".join(split_chars)
+                if title_from_base_chars not in words:
+                    words.append(title_from_base_chars)
             caches[CACHE_KEY_WORDSY].set(cache_key_words, words, cache_expiry)
 
         if len(words):

--- a/firstvoices/firstvoices/settings.py
+++ b/firstvoices/firstvoices/settings.py
@@ -200,6 +200,10 @@ CACHES = {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "LOCATION": "throttle",
     },
+    "wordsy": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "wordsy",
+    },
 }
 
 DATABASES = {"default": database.config()}

--- a/firstvoices/firstvoices/settings.py
+++ b/firstvoices/firstvoices/settings.py
@@ -188,20 +188,22 @@ STATIC_ROOT = "static"
 
 WSGI_APPLICATION = "firstvoices.wsgi.application"
 
+LOCMEM_CACHE_BACKEND = "django.core.cache.backends.locmem.LocMemCache"
+
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.dummy.DummyCache",
     },
     "auth": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "BACKEND": LOCMEM_CACHE_BACKEND,
         "LOCATION": "auth",
     },
     "throttle": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "BACKEND": LOCMEM_CACHE_BACKEND,
         "LOCATION": "throttle",
     },
     "wordsy": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "BACKEND": LOCMEM_CACHE_BACKEND,
         "LOCATION": "wordsy",
     },
 }


### PR DESCRIPTION
### Description of Changes
- Added endpoint to generate config for _wordsy_ game at `/{site_slug}/wordsy`.
- Uses cache for querysets to preserve the config for the given calendar date.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [x] Pull the branch and test locally

### Additional Notes
N/A
