### PR TITLE
FW-5365 Order Immersion Label List APIs

### DIFF
--- a/firstvoices/backend/views/immersion_label_views.py
+++ b/firstvoices/backend/views/immersion_label_views.py
@@ -107,8 +107,7 @@ from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSe
             200: inline_serializer(
                 name="ImmersionLabelMap",
                 fields={
-                    "key": serializers.CharField(),
-                    "dictionary_entry_title": serializers.CharField(),
+                    "key": serializers.CharField(default="Dictionary Entry Title"),
                 },
             ),
             403: OpenApiResponse(description=doc_strings.error_403),
@@ -133,12 +132,16 @@ class ImmersionLabelViewSet(
 
     def get_queryset(self):
         site = self.get_validated_site()
-        return ImmersionLabel.objects.filter(site__slug=site[0].slug).select_related(
-            "site",
-            "site__language",
-            "created_by",
-            "last_modified_by",
-            "dictionary_entry",
+        return (
+            ImmersionLabel.objects.filter(site__slug=site[0].slug)
+            .select_related(
+                "site",
+                "site__language",
+                "created_by",
+                "last_modified_by",
+                "dictionary_entry",
+            )
+            .order_by("key")
         )
 
     @action(detail=False, methods=["get"])
@@ -152,4 +155,6 @@ class ImmersionLabelViewSet(
             label.key: label.dictionary_entry.title for label in immersion_labels
         }
 
-        return Response(immersion_labels_map)
+        sorted_immersion_labels_map = dict(sorted(immersion_labels_map.items()))
+
+        return Response(sorted_immersion_labels_map)


### PR DESCRIPTION
### Description of Changes
- Orders both the list view and `all` view alphabetically by key
- Bonus change: fixes immersion label `all` API doc

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~~[ ] Admin Panel has been updated if models have been added or modified~~
- ~~[ ] Migrations have been updated and committed if applicable~~
- ~~[ ] Team Postman workspace has been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
