### PR TITLE
FW-5411 normalize after cleaning confusables

### DIFF
--- a/firstvoices/backend/models/characters.py
+++ b/firstvoices/backend/models/characters.py
@@ -9,7 +9,7 @@ from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
 
 from backend.permissions import predicates
-from backend.utils.character_utils import CustomSorter
+from backend.utils.character_utils import CustomSorter, nfc
 
 from .app import AppJson
 from .base import BaseSiteContentModel
@@ -388,7 +388,8 @@ class Alphabet(BaseSiteContentModel):
         variant characters.
         """
         if self.preprocess_transducer:
-            return self.preprocess_transducer(text).output_string
+            new_text = self.preprocess_transducer(text).output_string
+            return nfc(new_text)
         else:
             return text
 


### PR DESCRIPTION
### Description of Changes
Added additional normalization step after cleaning confusables, to keep data normalized and to prevent bugs in later operations.

### Checklist
- README / documentation has been updated if needed
- [X] PR title / commit messages contain Jira ticket number if applicable
- [X] Tests have been updated / created if applicable
- Admin Panel has been updated if models have been added or modified
- Migrations have been updated and committed if applicable
- Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
