### PR TITLE
Add isImmersionLabel field to dictionary entries

### DIFF
--- a/firstvoices/backend/serializers/dictionary_serializers.py
+++ b/firstvoices/backend/serializers/dictionary_serializers.py
@@ -146,7 +146,7 @@ class DictionaryEntryDetailSerializer(
         many=True, required=False, source="pronunciation_set", default=[]
     )
 
-    is_immersion_label = serializers.SerializerMethodField()
+    is_immersion_label = serializers.SerializerMethodField(read_only=True)
 
     logger = logging.getLogger(__name__)
 

--- a/firstvoices/backend/serializers/dictionary_serializers.py
+++ b/firstvoices/backend/serializers/dictionary_serializers.py
@@ -4,7 +4,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
-from backend.models import category, dictionary, part_of_speech
+from backend.models import ImmersionLabel, category, dictionary, part_of_speech
 from backend.serializers.base_serializers import (
     LinkedSiteMinimalSerializer,
     ReadOnlyVisibilityFieldMixin,
@@ -145,6 +145,8 @@ class DictionaryEntryDetailSerializer(
     pronunciations = PronunciationSerializer(
         many=True, required=False, source="pronunciation_set", default=[]
     )
+
+    is_immersion_label = serializers.SerializerMethodField()
 
     logger = logging.getLogger(__name__)
 
@@ -322,6 +324,10 @@ class DictionaryEntryDetailSerializer(
         word_list = base_title.split(" ")
         return word_list
 
+    @extend_schema_field(OpenApiTypes.BOOL)
+    def get_is_immersion_label(self, entry):
+        return ImmersionLabel.objects.filter(dictionary_entry=entry).exists()
+
     class Meta:
         model = dictionary.DictionaryEntry
         fields = (
@@ -337,6 +343,7 @@ class DictionaryEntryDetailSerializer(
                 "translations",
                 "part_of_speech",
                 "pronunciations",
+                "is_immersion_label",
             )
             + RelatedMediaSerializerMixin.Meta.fields
             + RelatedDictionaryEntrySerializerMixin.Meta.fields


### PR DESCRIPTION
### Description of Changes
Adds the `isImmersionLabel` field to dictionary entries via a read-only serializer method.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
If the team would prefer to have this value in the db as a column I could additionally edit the model, but I'm not sure if that's necessary. 
