### PR TITLE
Fw 5349 rebuild mtd index when saving a public dictionary entry

### DIFF
--- a/firstvoices/backend/apps.py
+++ b/firstvoices/backend/apps.py
@@ -4,3 +4,8 @@ from django.apps import AppConfig
 class BackendConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "backend"
+
+    def ready(self):
+        import backend.models.signals  # noqa F401
+
+        # Search signals to be added later

--- a/firstvoices/backend/models/__init__.py
+++ b/firstvoices/backend/models/__init__.py
@@ -22,7 +22,6 @@ from .media import Image  # noqa F401
 from .mtd import MTDExportFormat  # noqa F401
 from .page import SitePage  # noqa F401
 from .part_of_speech import PartOfSpeech  # noqa F401
-from .signals.mtd_signals import *  # noqa F401 - MTD Index signals
 from .sites import Membership, Site  # noqa F401
 from .song import Lyric, Song  # noqa F401
 from .story import Story, StoryPage  # noqa F401

--- a/firstvoices/backend/models/__init__.py
+++ b/firstvoices/backend/models/__init__.py
@@ -22,6 +22,7 @@ from .media import Image  # noqa F401
 from .mtd import MTDExportFormat  # noqa F401
 from .page import SitePage  # noqa F401
 from .part_of_speech import PartOfSpeech  # noqa F401
+from .signals.mtd_signals import *  # noqa F401
 from .sites import Membership, Site  # noqa F401
 from .song import Lyric, Song  # noqa F401
 from .story import Story, StoryPage  # noqa F401

--- a/firstvoices/backend/models/__init__.py
+++ b/firstvoices/backend/models/__init__.py
@@ -22,7 +22,7 @@ from .media import Image  # noqa F401
 from .mtd import MTDExportFormat  # noqa F401
 from .page import SitePage  # noqa F401
 from .part_of_speech import PartOfSpeech  # noqa F401
-from .signals.mtd_signals import *  # noqa F401
+from .signals.mtd_signals import *  # noqa F401 - MTD Index signals
 from .sites import Membership, Site  # noqa F401
 from .song import Lyric, Song  # noqa F401
 from .story import Story, StoryPage  # noqa F401

--- a/firstvoices/backend/models/signals/__init__.py
+++ b/firstvoices/backend/models/signals/__init__.py
@@ -1,0 +1,1 @@
+from .mtd_signals import *  # noqa F401

--- a/firstvoices/backend/models/signals/mtd_signals.py
+++ b/firstvoices/backend/models/signals/mtd_signals.py
@@ -1,5 +1,4 @@
 from django.db import transaction
-from django.db.models import Count
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
@@ -30,13 +29,13 @@ def request_update_mtd_index(sender, instance, **kwargs):
 def request_update_mtd_index_category_ops(sender, instance, **kwargs):
     # Check if there are any relevant dictionary entries affected
     # relevant dictionary entries are public and have at-least one translation
-    relevant_dictionary_entries = DictionaryEntry.objects.filter(
-        categories=instance, visibility=Visibility.PUBLIC
-    )
     relevant_dictionary_entries_count = (
-        relevant_dictionary_entries.annotate(translation_count=Count("translation_set"))
-        .filter(translation_count__gt=0)
+        DictionaryEntry.objects.filter(
+            categories=instance, visibility=Visibility.PUBLIC
+        )
+        .exclude(translation_set=None)
         .count()
     )
+
     if relevant_dictionary_entries_count:
         rebuild_mtd_index(instance.site.slug)

--- a/firstvoices/backend/models/signals/mtd_signals.py
+++ b/firstvoices/backend/models/signals/mtd_signals.py
@@ -1,0 +1,47 @@
+from django.db import transaction
+from django.db.models import Count
+from django.db.models.signals import m2m_changed, post_delete, post_save
+from django.dispatch import receiver
+
+from backend.models import Category, DictionaryEntry
+from backend.models.constants import Visibility
+from backend.tasks.build_mtd_export_format import build_index_and_calculate_scores
+from firstvoices.celery import link_error_handler
+
+
+def rebuild_mtd_index(site_slug):
+    transaction.on_commit(
+        lambda: build_index_and_calculate_scores.apply_async(
+            (site_slug,),
+            link_error=link_error_handler.s(),
+        )
+    )
+
+
+@receiver(post_save, sender=DictionaryEntry)
+@receiver(post_delete, sender=DictionaryEntry)
+def request_update_mtd_index(sender, instance, **kwargs):
+    if instance.visibility == Visibility.PUBLIC:
+        rebuild_mtd_index(instance.site.slug)
+
+
+@receiver(post_save, sender=Category)
+@receiver(post_delete, sender=Category)
+def request_update_mtd_index_category_ops(sender, instance, **kwargs):
+    # Check if there are any relevant dictionary entries affected
+    # relevant dictionary entries are public and have at-least one translation
+    relevant_dictionary_entries = DictionaryEntry.objects.filter(
+        categories=instance, visibility=Visibility.PUBLIC
+    )
+    relevant_dictionary_entries = relevant_dictionary_entries.annotate(
+        translation_count=Count("translation_set")
+    ).filter(translation_count__gt=0)
+    if len(relevant_dictionary_entries) > 0:
+        rebuild_mtd_index(instance.site.slug)
+
+
+@receiver(m2m_changed, sender=DictionaryEntry.related_audio.through)
+@receiver(m2m_changed, sender=DictionaryEntry.related_images.through)
+def request_update_mtd_index_audio_ops(sender, instance, **kwargs):
+    if instance.visibility == Visibility.PUBLIC:
+        rebuild_mtd_index(instance.site.slug)

--- a/firstvoices/backend/models/signals/mtd_signals.py
+++ b/firstvoices/backend/models/signals/mtd_signals.py
@@ -1,6 +1,6 @@
 from django.db import transaction
 from django.db.models import Count
-from django.db.models.signals import m2m_changed, post_delete, post_save
+from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
 from backend.models import Category, DictionaryEntry
@@ -33,15 +33,10 @@ def request_update_mtd_index_category_ops(sender, instance, **kwargs):
     relevant_dictionary_entries = DictionaryEntry.objects.filter(
         categories=instance, visibility=Visibility.PUBLIC
     )
-    relevant_dictionary_entries = relevant_dictionary_entries.annotate(
-        translation_count=Count("translation_set")
-    ).filter(translation_count__gt=0)
-    if len(relevant_dictionary_entries) > 0:
-        rebuild_mtd_index(instance.site.slug)
-
-
-@receiver(m2m_changed, sender=DictionaryEntry.related_audio.through)
-@receiver(m2m_changed, sender=DictionaryEntry.related_images.through)
-def request_update_mtd_index_audio_ops(sender, instance, **kwargs):
-    if instance.visibility == Visibility.PUBLIC:
+    relevant_dictionary_entries_count = (
+        relevant_dictionary_entries.annotate(translation_count=Count("translation_set"))
+        .filter(translation_count__gt=0)
+        .count()
+    )
+    if relevant_dictionary_entries_count:
         rebuild_mtd_index(instance.site.slug)

--- a/firstvoices/backend/tests/test_tasks/test_mtd_index_rebuild.py
+++ b/firstvoices/backend/tests/test_tasks/test_mtd_index_rebuild.py
@@ -66,6 +66,32 @@ class TestMtdIndexRebuild:
         entry.delete()
         assert self.mocked_func.call_count == 0
 
+    @pytest.mark.parametrize("visibility", [Visibility.TEAM, Visibility.MEMBERS])
+    def test_non_public_to_public_visibility_change(self, visibility):
+        entry = DictionaryEntry(site=self.site, visibility=visibility)
+        entry.save()
+
+        assert self.mocked_func.call_count == 0
+
+        entry.visibility = Visibility.PUBLIC
+        entry.save()
+
+        assert self.mocked_func.call_count == 1
+        self.mocked_func.assert_called_with(self.site.slug)
+
+    @pytest.mark.parametrize("visibility", [Visibility.TEAM, Visibility.MEMBERS])
+    def test_public_to_non_public_visibility_change(self, visibility):
+        entry = DictionaryEntry(site=self.site, visibility=Visibility.PUBLIC)
+        entry.save()
+
+        assert self.mocked_func.call_count == 1
+
+        entry.visibility = visibility
+        entry.save()
+
+        assert self.mocked_func.call_count == 2
+        self.mocked_func.assert_called_with(self.site.slug)
+
     def test_category_updated_public_entry(self):
         category = Category(
             title="test_category",

--- a/firstvoices/backend/tests/test_tasks/test_mtd_index_rebuild.py
+++ b/firstvoices/backend/tests/test_tasks/test_mtd_index_rebuild.py
@@ -1,0 +1,187 @@
+import pytest
+
+from backend.models import Category, DictionaryEntry, Site, Translation
+from backend.models.constants import AppRole, Visibility
+from backend.models.media import Audio, Image
+from backend.tests.factories import get_app_admin
+
+
+@pytest.mark.django_db
+class TestMtdIndexRebuild:
+    # Test if the mtd index rebuild is triggered only when required
+    # Mocking rebuild_mtd_index method from mtd_signals.py
+    # To also test the signals functionality, using models instead of test factories
+
+    def setup_method(self):
+        self.admin_user = get_app_admin(AppRole.STAFF)
+        self.site = Site(
+            title="test_site",
+            slug="test_site",
+            visibility=Visibility.PUBLIC,
+            created_by=self.admin_user,
+            last_modified_by=self.admin_user,
+        )
+        self.site.save()
+
+    def test_public_entry_updated(self, mocker):
+        mocked_func = mocker.patch(
+            "backend.models.signals.mtd_signals.rebuild_mtd_index"
+        )
+        entry = DictionaryEntry(
+            title="test_entry", site=self.site, visibility=Visibility.PUBLIC
+        )
+        entry.save()
+
+        assert mocked_func.call_count == 1
+        mocked_func.assert_called_once_with(self.site.slug)
+
+        entry.title = "Entry updated"
+        entry.save()
+
+        assert mocked_func.call_count == 2
+        mocked_func.assert_called_with(self.site.slug)
+
+        # Deleting entry
+        entry.delete()
+        assert mocked_func.call_count == 3
+        mocked_func.assert_called_with(self.site.slug)
+
+    @pytest.mark.parametrize("visibility", [Visibility.TEAM, Visibility.MEMBERS])
+    def test_non_public_entry_updated(self, mocker, visibility):
+        mocked_func = mocker.patch(
+            "backend.models.signals.mtd_signals.rebuild_mtd_index"
+        )
+        entry = DictionaryEntry(site=self.site, visibility=visibility)
+        entry.save()
+
+        # mtd index rebuild should not be triggered
+        assert mocked_func.call_count == 0
+
+        entry.title = "Entry updated"
+        entry.save()
+
+        assert mocked_func.call_count == 0
+
+        # Deleting entry
+        entry.delete()
+        assert mocked_func.call_count == 0
+
+    def test_category_updated_public_entry(self, mocker):
+        mocked_func = mocker.patch(
+            "backend.models.signals.mtd_signals.rebuild_mtd_index"
+        )
+        category = Category(
+            title="test_category",
+            site=self.site,
+            created_by=self.admin_user,
+            last_modified_by=self.admin_user,
+        )
+        category.save()
+        entry = DictionaryEntry(site=self.site, visibility=Visibility.PUBLIC)
+        entry.categories.add(category)
+        translation = Translation(text="Test Translation", dictionary_entry=entry)
+        translation.save()
+
+        entry.save()
+        assert mocked_func.call_count == 1
+
+        category.title = "Category title updated"
+        category.save()
+        assert mocked_func.call_count == 2
+        mocked_func.assert_called_with(self.site.slug)
+
+    def test_category_updated_public_entry_no_translation(self, mocker):
+        mocked_func = mocker.patch(
+            "backend.models.signals.mtd_signals.rebuild_mtd_index"
+        )
+        category = Category(
+            title="test_category",
+            site=self.site,
+            created_by=self.admin_user,
+            last_modified_by=self.admin_user,
+        )
+        category.save()
+        entry = DictionaryEntry(site=self.site, visibility=Visibility.PUBLIC)
+        entry.categories.add(category)
+
+        entry.save()
+        assert mocked_func.call_count == 1
+
+        category.title = "Category title updated"
+        category.save()
+
+        # Should not trigger rebuild of index
+        assert mocked_func.call_count == 1
+        mocked_func.assert_called_with(self.site.slug)
+
+    @pytest.mark.parametrize("visibility", [Visibility.TEAM, Visibility.MEMBERS])
+    def test_category_updated_non_public_entry(self, mocker, visibility):
+        mocked_func = mocker.patch(
+            "backend.models.signals.mtd_signals.rebuild_mtd_index"
+        )
+        category = Category(
+            title="test_category",
+            site=self.site,
+            created_by=self.admin_user,
+            last_modified_by=self.admin_user,
+        )
+        category.save()
+        entry = DictionaryEntry(site=self.site, visibility=visibility)
+        entry.categories.add(category)
+        translation = Translation(text="Test Translation", dictionary_entry=entry)
+        translation.save()
+
+        entry.save()
+        assert mocked_func.call_count == 0
+
+        category.title = "Category title updated"
+        category.save()
+
+        # Should not trigger the rebuild of index
+        assert mocked_func.call_count == 0
+
+    def test_related_image_updated(self, mocker):
+        mocked_func = mocker.patch(
+            "backend.models.signals.mtd_signals.rebuild_mtd_index"
+        )
+        image = Image(title="test image", site=self.site)
+        image.save()
+
+        entry = DictionaryEntry(site=self.site, visibility=Visibility.PUBLIC)
+        entry.save()
+
+        assert mocked_func.call_count == 1
+
+        entry.related_images.add(image)
+        entry.save()
+
+        assert mocked_func.call_count == 2
+
+        entry.related_images.remove(image)
+        entry.save()
+
+        assert mocked_func.call_count == 3
+        mocked_func.assert_called_with(self.site.slug)
+
+    def test_related_audio_updated(self, mocker):
+        mocked_func = mocker.patch(
+            "backend.models.signals.mtd_signals.rebuild_mtd_index"
+        )
+        audio = Audio(title="test audio", site=self.site)
+        audio.save()
+
+        entry = DictionaryEntry(site=self.site, visibility=Visibility.PUBLIC)
+        entry.save()
+
+        assert mocked_func.call_count == 1
+
+        entry.related_audio.add(audio)
+        entry.save()
+
+        assert mocked_func.call_count == 2
+
+        entry.related_audio.remove(audio)
+        entry.save()
+
+        assert mocked_func.call_count == 3
+        mocked_func.assert_called_with(self.site.slug)

--- a/firstvoices/backend/tests/test_tasks/test_mtd_index_rebuild.py
+++ b/firstvoices/backend/tests/test_tasks/test_mtd_index_rebuild.py
@@ -10,7 +10,13 @@ from backend.tests.factories import get_app_admin
 class TestMtdIndexRebuild:
     # Test if the mtd index rebuild is triggered only when required
     # Mocking rebuild_mtd_index method from mtd_signals.py
-    # To also test the signals functionality, using models instead of test factories
+    # To also test functionality of the associated signals, using models instead of test factories
+
+    @pytest.fixture(scope="function", autouse=True)
+    def mocked_mtd_index_func(self, mocker):
+        self.mocked_func = mocker.patch(
+            "backend.models.signals.mtd_signals.rebuild_mtd_index"
+        )
 
     def setup_method(self):
         self.admin_user = get_app_admin(AppRole.STAFF)
@@ -23,53 +29,44 @@ class TestMtdIndexRebuild:
         )
         self.site.save()
 
-    def test_public_entry_updated(self, mocker):
-        mocked_func = mocker.patch(
-            "backend.models.signals.mtd_signals.rebuild_mtd_index"
-        )
+    def test_public_entry_updated(self):
         entry = DictionaryEntry(
             title="test_entry", site=self.site, visibility=Visibility.PUBLIC
         )
         entry.save()
 
-        assert mocked_func.call_count == 1
-        mocked_func.assert_called_once_with(self.site.slug)
+        assert self.mocked_func.call_count == 1
+        self.mocked_func.assert_called_once_with(self.site.slug)
 
         entry.title = "Entry updated"
         entry.save()
 
-        assert mocked_func.call_count == 2
-        mocked_func.assert_called_with(self.site.slug)
+        assert self.mocked_func.call_count == 2
+        self.mocked_func.assert_called_with(self.site.slug)
 
         # Deleting entry
         entry.delete()
-        assert mocked_func.call_count == 3
-        mocked_func.assert_called_with(self.site.slug)
+        assert self.mocked_func.call_count == 3
+        self.mocked_func.assert_called_with(self.site.slug)
 
     @pytest.mark.parametrize("visibility", [Visibility.TEAM, Visibility.MEMBERS])
-    def test_non_public_entry_updated(self, mocker, visibility):
-        mocked_func = mocker.patch(
-            "backend.models.signals.mtd_signals.rebuild_mtd_index"
-        )
+    def test_non_public_entry_updated(self, visibility):
         entry = DictionaryEntry(site=self.site, visibility=visibility)
         entry.save()
 
         # mtd index rebuild should not be triggered
-        assert mocked_func.call_count == 0
+        assert self.mocked_func.call_count == 0
 
         entry.title = "Entry updated"
         entry.save()
 
-        assert mocked_func.call_count == 0
+        assert self.mocked_func.call_count == 0
 
         # Deleting entry
         entry.delete()
-        assert mocked_func.call_count == 0
+        assert self.mocked_func.call_count == 0
 
-    def test_category_updated_public_entry(self, mocker):
-        mocked_func = mocker.patch(
-            "backend.models.signals.mtd_signals.rebuild_mtd_index"
-        )
+    def test_category_updated_public_entry(self):
         category = Category(
             title="test_category",
             site=self.site,
@@ -83,17 +80,14 @@ class TestMtdIndexRebuild:
         translation.save()
 
         entry.save()
-        assert mocked_func.call_count == 1
+        assert self.mocked_func.call_count == 1
 
-        category.title = "Category title updated"
+        category.title = "Updated category title"
         category.save()
-        assert mocked_func.call_count == 2
-        mocked_func.assert_called_with(self.site.slug)
+        assert self.mocked_func.call_count == 2
+        self.mocked_func.assert_called_with(self.site.slug)
 
-    def test_category_updated_public_entry_no_translation(self, mocker):
-        mocked_func = mocker.patch(
-            "backend.models.signals.mtd_signals.rebuild_mtd_index"
-        )
+    def test_category_updated_public_entry_no_translation(self):
         category = Category(
             title="test_category",
             site=self.site,
@@ -105,20 +99,17 @@ class TestMtdIndexRebuild:
         entry.categories.add(category)
 
         entry.save()
-        assert mocked_func.call_count == 1
+        assert self.mocked_func.call_count == 1
 
-        category.title = "Category title updated"
+        category.title = "Updated category"
         category.save()
 
         # Should not trigger rebuild of index
-        assert mocked_func.call_count == 1
-        mocked_func.assert_called_with(self.site.slug)
+        assert self.mocked_func.call_count == 1
+        self.mocked_func.assert_called_with(self.site.slug)
 
     @pytest.mark.parametrize("visibility", [Visibility.TEAM, Visibility.MEMBERS])
-    def test_category_updated_non_public_entry(self, mocker, visibility):
-        mocked_func = mocker.patch(
-            "backend.models.signals.mtd_signals.rebuild_mtd_index"
-        )
+    def test_category_updated_non_public_entry(self, visibility):
         category = Category(
             title="test_category",
             site=self.site,
@@ -132,56 +123,50 @@ class TestMtdIndexRebuild:
         translation.save()
 
         entry.save()
-        assert mocked_func.call_count == 0
+        assert self.mocked_func.call_count == 0
 
         category.title = "Category title updated"
         category.save()
 
         # Should not trigger the rebuild of index
-        assert mocked_func.call_count == 0
+        assert self.mocked_func.call_count == 0
 
-    def test_related_image_updated(self, mocker):
-        mocked_func = mocker.patch(
-            "backend.models.signals.mtd_signals.rebuild_mtd_index"
-        )
+    def test_related_image_updated(self):
         image = Image(title="test image", site=self.site)
         image.save()
 
         entry = DictionaryEntry(site=self.site, visibility=Visibility.PUBLIC)
         entry.save()
 
-        assert mocked_func.call_count == 1
+        assert self.mocked_func.call_count == 1
 
         entry.related_images.add(image)
         entry.save()
 
-        assert mocked_func.call_count == 2
+        assert self.mocked_func.call_count == 2
 
         entry.related_images.remove(image)
         entry.save()
 
-        assert mocked_func.call_count == 3
-        mocked_func.assert_called_with(self.site.slug)
+        assert self.mocked_func.call_count == 3
+        self.mocked_func.assert_called_with(self.site.slug)
 
-    def test_related_audio_updated(self, mocker):
-        mocked_func = mocker.patch(
-            "backend.models.signals.mtd_signals.rebuild_mtd_index"
-        )
+    def test_related_audio_updated(self):
         audio = Audio(title="test audio", site=self.site)
         audio.save()
 
         entry = DictionaryEntry(site=self.site, visibility=Visibility.PUBLIC)
         entry.save()
 
-        assert mocked_func.call_count == 1
+        assert self.mocked_func.call_count == 1
 
         entry.related_audio.add(audio)
         entry.save()
 
-        assert mocked_func.call_count == 2
+        assert self.mocked_func.call_count == 2
 
         entry.related_audio.remove(audio)
         entry.save()
 
-        assert mocked_func.call_count == 3
-        mocked_func.assert_called_with(self.site.slug)
+        assert self.mocked_func.call_count == 3
+        self.mocked_func.assert_called_with(self.site.slug)


### PR DESCRIPTION
### Description of Changes
- Added signals to rebuild the mtd language index when relevant models are updated. The signals are placed at `/models/signals/mtd_signals.py`
- There was no need to add additional signals for notes, translations and acknowledgements since if they are to be changed, the dictionary entry is saved, thus the index is rebuilt anyway.
- Added through signals for images and videos.
- Added separate signals for category models with relevant checks to prevent unnecessary rebuilding.

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable~
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [x] Pull the branch and test locally