### PR TITLE
Fw 5381 import embedded video links

### DIFF
--- a/firstvoices/backend/management/commands/import_csv_data.py
+++ b/firstvoices/backend/management/commands/import_csv_data.py
@@ -160,7 +160,7 @@ def run_import():
 
             # raise errors to halt the import if an issue occurs
             try:
-                result = resource.import_data(dataset=table, raise_errors=True)
+                result = resource.import_data(dataset=table, raise_errors=False)
                 logger.info(
                     " ".join(
                         [f"{type}: {total}" for type, total in result.totals.items()]

--- a/firstvoices/backend/management/commands/import_csv_data.py
+++ b/firstvoices/backend/management/commands/import_csv_data.py
@@ -61,7 +61,6 @@ def run_import():
     Locally downloads import files from AWS, then matches them with the right
     backend model resource to import with. Deletes the database, then imports
     model-by-model in a specified order into the clean space.
-    Halts the process when encountering any data/validation error.
 
     Run with:
         python manage.py import_csv_data

--- a/firstvoices/backend/resources/base.py
+++ b/firstvoices/backend/resources/base.py
@@ -4,6 +4,7 @@ from backend.models.constants import Visibility
 from backend.models.media import Audio, Image, Video
 from backend.models.sites import Site
 from backend.resources.utils.import_export_widgets import (
+    ArrayOfStringsWidget,
     ChoicesWidget,
     UserForeignKeyWidget,
 )
@@ -65,6 +66,11 @@ class RelatedMediaResourceMixin(resources.ModelResource):
         attribute="related_videos",
         m2m_add=True,
         widget=widgets.ManyToManyWidget(Video, separator=",", field="id"),
+    )
+    related_video_links = fields.Field(
+        column_name="related_video_links",
+        attribute="related_video_links",
+        widget=ArrayOfStringsWidget(),
     )
 
     class Meta:

--- a/firstvoices/backend/tests/test_resources/test_character_resource.py
+++ b/firstvoices/backend/tests/test_resources/test_character_resource.py
@@ -213,6 +213,7 @@ class TestIgnoredCharacterImport:
         assert table["site"][0] == str(new_char.site.id)
 
 
+@pytest.mark.skip("Tests are for initial migration only")
 class TestAlphabetConfusablesImport:
     @staticmethod
     def build_table(data: list[str]):

--- a/firstvoices/backend/tests/test_resources/test_dictionary_resources.py
+++ b/firstvoices/backend/tests/test_resources/test_dictionary_resources.py
@@ -30,14 +30,15 @@ from backend.resources.dictionary import (
 from backend.tests import factories
 
 
-@pytest.mark.skip("Tests are for initial migration only")
+# @pytest.mark.skip("Tests are for initial migration only")
 class TestDictionaryEntryImport:
     @staticmethod
     def build_table(data: list[str]):
         headers = [
             # these headers should match what is produced by fv-nuxeo-export tool
             "id,created,created_by,last_modified,last_modified_by,site,"
-            "title,visibility,type,batch_id,exclude_from_kids,exclude_from_games,part_of_speech"
+            "title,visibility,type,batch_id,exclude_from_kids,exclude_from_games,part_of_speech,"
+            "related_video_links"
         ]
         table = tablib.import_set("\n".join(headers + data), format="csv")
         return table
@@ -48,9 +49,9 @@ class TestDictionaryEntryImport:
         site = factories.SiteFactory.create()
         data = [
             f"{uuid.uuid4()},2023-02-02 21:21:10.713,user_one@test.com,2023-02-02 21:21:39.864,user_one@test.com,"
-            f"{site.id},test_word,Public,Word,batch_id,False,False,Noun",
+            f"{site.id},test_word,Public,Word,batch_id,False,False,Noun,https://www.youtube.com/watch?v=A1bcde23f5g",
             f"{uuid.uuid4()},2023-02-02 21:21:10.713,user_two@test.com,2023-02-02 21:21:39.864,user_two@test.com,"
-            f"{site.id},test_phrase,Team,Phrase,batch_id,True,True,Verb",
+            f"{site.id},test_phrase,Team,Phrase,batch_id,True,True,Verb,",
         ]
 
         table = self.build_table(data)
@@ -70,6 +71,9 @@ class TestDictionaryEntryImport:
         assert not test_word.exclude_from_kids
         assert not test_word.exclude_from_games
         assert table["part_of_speech"][0] == test_word.part_of_speech.title
+        assert test_word.related_video_links == table["related_video_links"][0].split(
+            ","
+        )
 
         test_phrase = DictionaryEntry.objects.get(id=table["id"][1])
         assert table["title"][1] == test_phrase.title

--- a/firstvoices/backend/tests/test_resources/test_join_request_resource.py
+++ b/firstvoices/backend/tests/test_resources/test_join_request_resource.py
@@ -8,6 +8,7 @@ from backend.resources.join_requests import JoinRequestResource
 from backend.tests import factories
 
 
+@pytest.mark.skip("Tests are for initial migration only")
 class TestJoinRequestImport:
     @staticmethod
     def build_table(data: list[str]):

--- a/firstvoices/backend/tests/test_resources/test_membership_resource.py
+++ b/firstvoices/backend/tests/test_resources/test_membership_resource.py
@@ -14,6 +14,7 @@ from backend.tests.factories import (
 )
 
 
+@pytest.mark.skip("Tests are for initial migration only")
 class TestAppMembershipImport:
     @staticmethod
     def build_table(data: list[str]):
@@ -65,6 +66,7 @@ class TestAppMembershipImport:
         assert old_membership.role == AppRole.SUPERADMIN
 
 
+@pytest.mark.skip("Tests are for initial migration only")
 class TestSiteMembershipImport:
     @staticmethod
     def build_table(data: list[str]):

--- a/firstvoices/backend/tests/test_resources/test_song_resource.py
+++ b/firstvoices/backend/tests/test_resources/test_song_resource.py
@@ -8,14 +8,14 @@ from backend.resources.songs import LyricResource, SongResource
 from backend.tests import factories
 
 
-@pytest.mark.skip("Tests are for initial migration only")
+# @pytest.mark.skip("Tests are for initial migration only")
 class TestSongsImport:
     @staticmethod
     def build_table(data: list[str]):
         headers = [
             "id,created,created_by,last_modified,last_modified_by,visibility,title,introduction,exclude_from_games,"
             "site,title_translation,acknowledgements,notes,introduction_translation,exclude_from_kids,hide_overlay,"
-            "related_audio,related_images,related_videos"
+            "related_audio,related_images,related_videos,related_video_links"
         ]
         table = tablib.import_set("\n".join(headers + data), format="csv")
         return table
@@ -33,7 +33,8 @@ class TestSongsImport:
             f"{uuid.uuid4()},2023-02-02 21:21:10.713,user_one@test.com,2023-02-02 21:21:39.864,user_one@test.com,"
             f"Public,Sample Song,Sample introduction,False,{site.id},Sample title translation,"
             f'"Sample acknowledgement one, with comma|Sample acknowledgement two",,'
-            f'Sample intro translation,False,False,"{audio_one.id},{audio_two.id}",{image.id},{video.id}'
+            f'Sample intro translation,False,False,"{audio_one.id},{audio_two.id}",{image.id},{video.id},'
+            "https://www.youtube.com/watch?v=A1bcde23f5g"
         ]
         table = self.build_table(data)
 
@@ -64,6 +65,9 @@ class TestSongsImport:
         assert table["related_audio"][0].split(",")[1] in related_audio_string_list
         assert str(new_song.related_images.first().id) == table["related_images"][0]
         assert str(new_song.related_videos.first().id) == table["related_videos"][0]
+        assert new_song.related_video_links == table["related_video_links"][0].split(
+            ","
+        )
         assert new_song.get_visibility_display() == table["visibility"][0]
         assert str(new_song.site.id) == table["site"][0]
 

--- a/firstvoices/backend/tests/test_resources/test_stories_resource.py
+++ b/firstvoices/backend/tests/test_resources/test_stories_resource.py
@@ -19,7 +19,7 @@ sample_draftjs_text = "\"{'entityMap': {}, 'blocks': [{'key': '', 'text': 'Histo
 sample_draftjs_transl = "\"{'entityMap': {}, 'blocks': [{'key': '', 'text': 'History of the Three Bears', 'type': 'unstyled', 'depth': 0, 'inlineStyleRanges': [], 'entityRanges': [], 'data': {}}]}\""  # noqa E501
 
 
-@pytest.mark.skip("Tests are for initial migration only")
+# @pytest.mark.skip("Tests are for initial migration only")
 class TestStoryImport:
     @staticmethod
     def build_table(data: list[str]):
@@ -28,7 +28,7 @@ class TestStoryImport:
             "id,created,created_by,last_modified,last_modified_by,visibility"
             ",title,title_translation,introduction,introduction_translation"
             ",for_games,for_kids_1,for_kids_2,hide_overlay,site,exclude_from_kids,exclude_from_games"
-            ",author,notes,acknowledgements,related_audio,related_images,related_videos"
+            ",author,notes,acknowledgements,related_audio,related_images,related_videos,related_video_links"
         ]
         table = tablib.import_set("\n".join(headers + data), format="csv")
         return table
@@ -41,11 +41,11 @@ class TestStoryImport:
             f"{uuid.uuid4()},2022-04-06 14:08:27.693,one@test.com,2022-04-06 14:45:52.750,one@test.com,Members"
             f",Testytest,Test story,{sample_draftjs_text},{sample_draftjs_transl}"
             f",,,True,,{site.id},False,False"
-            ",By: The Author,,,,,",
+            ",By: The Author,,,,,,",
             f"{uuid.uuid4()},2022-04-06 14:08:27.693,one@test.com,2022-04-06 14:45:52.750,one@test.com,Members"
             f",Testytest2,Test story two,{sample_draftjs_text},{sample_draftjs_transl}"
             f",,,True,true,{site.id},False,False"
-            ",,,,,,",
+            ",,,,,,,",
         ]
         table = self.build_table(data)
 
@@ -125,7 +125,8 @@ class TestStoryImport:
             f"{uuid.uuid4()},2022-04-06 14:08:27.693,one@test.com,2022-04-06 14:45:52.750,one@test.com,Members"
             f",Testytest,Test story,,"
             f",,,True,,{site.id},False,False"
-            f',Authorname,,,{audio.id},"{img_1.id},{img_2.id}",{video.id}'
+            f',Authorname,,,{audio.id},"{img_1.id},{img_2.id}",{video.id},'
+            "https://www.youtube.com/watch?v=A1bcde23f5g"
         ]
         table = self.build_table(data)
 
@@ -146,6 +147,9 @@ class TestStoryImport:
         assert img_1 in new_story.related_images.all()
         assert img_2 in new_story.related_images.all()
         assert new_story.related_images.all().count() == 2
+        assert new_story.related_video_links == table["related_video_links"][0].split(
+            ","
+        )
 
     @pytest.mark.django_db
     def test_import_related_media_skip_nonexistent(self):
@@ -159,7 +163,7 @@ class TestStoryImport:
             f"{uuid.uuid4()},2022-04-06 14:08:27.693,one@test.com,2022-04-06 14:45:52.750,one@test.com,Members"
             f",Testytest,Test story,,"
             f",,,True,,{site.id},False,False"
-            f',Authorname,,,{no_audio_here},"{img_1.id},{no_img_here}",{no_video_here}'
+            f',Authorname,,,{no_audio_here},"{img_1.id},{no_img_here}",{no_video_here},'
         ]
         table = self.build_table(data)
 

--- a/firstvoices/backend/tests/test_resources/test_user_resource.py
+++ b/firstvoices/backend/tests/test_resources/test_user_resource.py
@@ -15,6 +15,7 @@ def build_table(data: list[str]):
     return table
 
 
+@pytest.mark.skip("Tests are for initial migration only")
 class TestUserImport:
     @pytest.mark.django_db
     def test_import_base_data(self):


### PR DESCRIPTION
### Description of Changes
Added a field for related video links to the Dictionary, Song, and Story imports. Added testing for video links and reorganized which migration resource tests are skipped.

Note: error-raising is removed from the import script so that we gracefully handle imports onto site data that may have since been deleted (it will skip without failing). And because we are slowly removing support for the import process.

### Checklist
- README / documentation has been updated if needed
- [X] PR title / commit messages contain Jira ticket number if applicable
- [X] Tests have been updated / created if applicable
- Admin Panel has been updated if models have been added or modified
- Migrations have been updated and committed if applicable
- Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
