### PR TITLE
FW-5444 add site visibility validator to immersion labels

### DIFF
--- a/firstvoices/backend/serializers/immersion_label_serializers.py
+++ b/firstvoices/backend/serializers/immersion_label_serializers.py
@@ -10,7 +10,7 @@ from backend.serializers.dictionary_serializers import (
     WritableRelatedDictionaryEntrySerializer,
 )
 from backend.serializers.fields import SiteHyperlinkedIdentityField
-from backend.serializers.validators import SameSite, SameVisibilityAsSite
+from backend.serializers.validators import MeetsSiteVisibility, SameSite
 
 
 class ImmersionLabelDetailSerializer(WritableSiteContentSerializer):
@@ -20,7 +20,7 @@ class ImmersionLabelDetailSerializer(WritableSiteContentSerializer):
     dictionary_entry = WritableRelatedDictionaryEntrySerializer(
         required=True,
         queryset=DictionaryEntry.objects.all(),
-        validators=[SameSite(), SameVisibilityAsSite()],
+        validators=[SameSite(), MeetsSiteVisibility()],
     )
     key = serializers.CharField(allow_blank=False, allow_null=False)
 

--- a/firstvoices/backend/serializers/immersion_label_serializers.py
+++ b/firstvoices/backend/serializers/immersion_label_serializers.py
@@ -10,7 +10,7 @@ from backend.serializers.dictionary_serializers import (
     WritableRelatedDictionaryEntrySerializer,
 )
 from backend.serializers.fields import SiteHyperlinkedIdentityField
-from backend.serializers.validators import SameSite
+from backend.serializers.validators import SameSite, SameVisibilityAsSite
 
 
 class ImmersionLabelDetailSerializer(WritableSiteContentSerializer):
@@ -20,7 +20,7 @@ class ImmersionLabelDetailSerializer(WritableSiteContentSerializer):
     dictionary_entry = WritableRelatedDictionaryEntrySerializer(
         required=True,
         queryset=DictionaryEntry.objects.all(),
-        validators=[SameSite()],
+        validators=[SameSite(), SameVisibilityAsSite()],
     )
     key = serializers.CharField(allow_blank=False, allow_null=False)
 

--- a/firstvoices/backend/serializers/validators.py
+++ b/firstvoices/backend/serializers/validators.py
@@ -23,6 +23,23 @@ class SameSite:
             raise serializers.ValidationError(self.message)
 
 
+class SameVisibilityAsSite:
+    """
+    Validates that the value has the same visibility or greater than that value's site.
+    """
+
+    message = _("Object must have the same or greater visibility than the site.")
+    requires_context = True
+
+    def __init__(self, message=None):
+        self.message = message or self.message
+
+    def __call__(self, value, serializer):
+        expected_site = get_site_from_context(serializer)
+        if value.visibility <= expected_site.visibility:
+            raise serializers.ValidationError(self.message)
+
+
 class HasNoParent:
     """
     Validates that the value does not have a parent.

--- a/firstvoices/backend/serializers/validators.py
+++ b/firstvoices/backend/serializers/validators.py
@@ -23,7 +23,7 @@ class SameSite:
             raise serializers.ValidationError(self.message)
 
 
-class SameVisibilityAsSite:
+class MeetsSiteVisibility:
     """
     Validates that the value has the same visibility or greater than that value's site.
     """

--- a/firstvoices/backend/serializers/validators.py
+++ b/firstvoices/backend/serializers/validators.py
@@ -36,7 +36,7 @@ class SameVisibilityAsSite:
 
     def __call__(self, value, serializer):
         expected_site = get_site_from_context(serializer)
-        if value.visibility <= expected_site.visibility:
+        if value.visibility < expected_site.visibility:
             raise serializers.ValidationError(self.message)
 
 

--- a/firstvoices/backend/tests/test_apis/test_immersion_label_api.py
+++ b/firstvoices/backend/tests/test_apis/test_immersion_label_api.py
@@ -21,7 +21,7 @@ class TestImmersionEndpoints(BaseUncontrolledSiteContentApiTest):
     def get_lookup_key(self, instance):
         return instance.key
 
-    def create_minimal_instance(self, site, visibility):
+    def create_minimal_instance(self, site, visibility=Visibility.PUBLIC):
         return factories.ImmersionLabelFactory(
             site=site,
             dictionary_entry=factories.DictionaryEntryFactory(
@@ -72,7 +72,9 @@ class TestImmersionEndpoints(BaseUncontrolledSiteContentApiTest):
         }
 
     def get_valid_patch_data(self, site=None):
-        entry = factories.DictionaryEntryFactory(site=site)
+        entry = factories.DictionaryEntryFactory(
+            site=site, visibility=Visibility.PUBLIC
+        )
         return {
             "dictionary_entry": str(entry.id),
         }
@@ -344,7 +346,9 @@ class TestImmersionEndpoints(BaseUncontrolledSiteContentApiTest):
         self.client.force_authenticate(user=user)
 
         site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
-        entry = factories.DictionaryEntryFactory.create(site=site)
+        entry = factories.DictionaryEntryFactory.create(
+            site=site, visibility=Visibility.PUBLIC
+        )
         label = factories.ImmersionLabelFactory.create(site=site)
 
         data = {

--- a/firstvoices/backend/tests/test_apis/test_immersion_label_api.py
+++ b/firstvoices/backend/tests/test_apis/test_immersion_label_api.py
@@ -159,6 +159,28 @@ class TestImmersionEndpoints(BaseUncontrolledSiteContentApiTest):
         assert response.status_code == 400
 
     @pytest.mark.django_db
+    def test_dictionary_entry_visibility_validation(self):
+        """
+        Tests that a validation error is raised if the dictionary entry's visibility is less than the site's.
+        """
+        user = factories.get_app_admin(AppRole.SUPERADMIN)
+        self.client.force_authenticate(user=user)
+        site = factories.SiteFactory.create(visibility=Visibility.MEMBERS)
+        entry = factories.DictionaryEntryFactory.create(
+            site=site, visibility=Visibility.TEAM
+        )
+
+        data = {
+            "dictionary_entry": str(entry.id),
+            "key": self.TEST_KEY,
+        }
+
+        response = self.client.post(
+            self.get_list_endpoint(site_slug=site.slug), format="json", data=data
+        )
+        assert response.status_code == 400
+
+    @pytest.mark.django_db
     def test_labels_ordered_by_key(self):
         """
         Tests that the labels are ordered alphabetically by key.


### PR DESCRIPTION
### Description of Changes
- Adds a validator that ensures an object's visbility is greater than or equal to the site's visibility.
- Adds the validator to immersion labels
- Update + add test for the validator

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Team Postman workspace has been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [x] ~~Pull the branch and test locally~~

### Additional Notes
N/A
