### PR TITLE
FW-5487 Add check for superadmin before any recalculation endpoint hits

### DIFF
--- a/firstvoices/backend/tests/test_apis/test_dictionary_cleanup_api.py
+++ b/firstvoices/backend/tests/test_apis/test_dictionary_cleanup_api.py
@@ -20,6 +20,7 @@ from backend.tests.test_apis.base_api_test import BaseApiTest
 class TestDictionaryCleanupPreviewAPI(BaseApiTest):
     API_DETAIL_VIEW = "api:dictionary-cleanup-preview-list"
     SUCCESS_MESSAGE = {"message": "Recalculation preview has been queued."}
+    CLEAR = "/clear"
 
     @pytest.fixture
     def mock_celery_task_status(self, mocker):
@@ -182,7 +183,7 @@ class TestDictionaryCleanupPreviewAPI(BaseApiTest):
 
         assert response.status_code == 403
 
-        response = self.client.delete(self.get_detail_endpoint(site.slug) + "/clear")
+        response = self.client.delete(self.get_detail_endpoint(site.slug) + self.CLEAR)
 
         assert response.status_code == 403
 
@@ -204,7 +205,7 @@ class TestDictionaryCleanupPreviewAPI(BaseApiTest):
 
         assert response.status_code == 403
 
-        response = self.client.delete(self.get_detail_endpoint(site.slug) + "/clear")
+        response = self.client.delete(self.get_detail_endpoint(site.slug) + self.CLEAR)
 
         assert response.status_code == 403
 
@@ -228,7 +229,7 @@ class TestDictionaryCleanupPreviewAPI(BaseApiTest):
 
         assert response.status_code == 202
 
-        response = self.client.delete(self.get_detail_endpoint(site.slug) + "/clear")
+        response = self.client.delete(self.get_detail_endpoint(site.slug) + self.CLEAR)
 
         assert response.status_code == 204
 
@@ -245,7 +246,7 @@ class TestDictionaryCleanupPreviewAPI(BaseApiTest):
         )
 
         response_delete = self.client.delete(
-            self.get_detail_endpoint(site.slug) + "/clear"
+            self.get_detail_endpoint(site.slug) + self.CLEAR
         )
         assert response_delete.status_code == 204
 
@@ -267,7 +268,7 @@ class TestDictionaryCleanupPreviewAPI(BaseApiTest):
         )
 
         response_delete = self.client.delete(
-            self.get_detail_endpoint(site.slug) + "/clear"
+            self.get_detail_endpoint(site.slug) + self.CLEAR
         )
         assert response_delete.status_code == 403
 

--- a/firstvoices/backend/tests/test_apis/test_dictionary_cleanup_api.py
+++ b/firstvoices/backend/tests/test_apis/test_dictionary_cleanup_api.py
@@ -5,7 +5,7 @@ import pytest
 from django.urls import reverse
 
 from backend.models import DictionaryEntry
-from backend.models.constants import AppRole, Visibility
+from backend.models.constants import AppRole, Role, Visibility
 from backend.serializers.async_results_serializers import (
     CustomOrderRecalculationResultSerializer,
 )
@@ -155,31 +155,82 @@ class TestDictionaryCleanupPreviewAPI(BaseApiTest):
         assert response_data["results"] == self.get_expected_response(site=site)
 
     @pytest.mark.django_db
-    def test_recalculate_permissions(self, mock_celery_task_response_preview):
-        site = factories.SiteFactory.create(slug="test", visibility=Visibility.PUBLIC)
+    @pytest.mark.parametrize(
+        "role",
+        (
+            Role.MEMBER,
+            Role.ASSISTANT,
+            Role.EDITOR,
+            Role.LANGUAGE_ADMIN,
+        ),
+    )
+    def test_recalculate_permissions_403_user_roles(
+        self, mock_celery_task_response_preview, role
+    ):
+        site, user = factories.get_site_with_member(
+            site_visibility=Visibility.PUBLIC, user_role=role
+        )
+        self.client.force_authenticate(user=user)
+
+        mock_celery_task_response_preview.return_value = None
+
+        response = self.client.get(self.get_detail_endpoint(site.slug))
+
+        assert response.status_code == 403
+
+        response = self.client.post(self.get_detail_endpoint(site.slug))
+
+        assert response.status_code == 403
+
+        response = self.client.delete(self.get_detail_endpoint(site.slug) + "/clear")
+
+        assert response.status_code == 403
+
+    @pytest.mark.django_db
+    def test_recalculate_permissions_403_staff(self, mock_celery_task_response_preview):
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+        factories.AlphabetFactory.create(site=site)
+
+        user = factories.get_app_admin(role=AppRole.STAFF)
+        self.client.force_authenticate(user=user)
+
+        mock_celery_task_response_preview.return_value = None
+
+        response = self.client.get(self.get_detail_endpoint(site.slug))
+
+        assert response.status_code == 403
+
+        response = self.client.post(self.get_detail_endpoint(site.slug))
+
+        assert response.status_code == 403
+
+        response = self.client.delete(self.get_detail_endpoint(site.slug) + "/clear")
+
+        assert response.status_code == 403
+
+    @pytest.mark.django_db
+    def test_recaltulate_permissions_superadmin(
+        self, mock_celery_task_response_preview
+    ):
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
         factories.AlphabetFactory.create(site=site)
 
         user = factories.get_app_admin(role=AppRole.SUPERADMIN)
         self.client.force_authenticate(user=user)
 
-        factories.DictionaryEntryFactory.create(site=site, title="test")
-
         mock_celery_task_response_preview.return_value = None
 
-        response_post = self.client.post(self.get_detail_endpoint(site.slug))
-        response_post_data = json.loads(response_post.content)
+        response = self.client.get(self.get_detail_endpoint(site.slug))
 
-        assert response_post.status_code == 202
-        assert response_post_data == self.SUCCESS_MESSAGE
+        assert response.status_code == 200
 
-        user = factories.get_non_member_user()
-        self.client.force_authenticate(user=user)
+        response = self.client.post(self.get_detail_endpoint(site.slug))
 
-        response_get = self.client.get(self.get_detail_endpoint(site.slug))
-        response_get_data = json.loads(response_get.content)
+        assert response.status_code == 202
 
-        assert response_get.status_code == 200
-        assert response_get_data["results"] == []
+        response = self.client.delete(self.get_detail_endpoint(site.slug) + "/clear")
+
+        assert response.status_code == 204
 
     @pytest.mark.django_db
     def test_clear(self, is_preview=True):
@@ -283,8 +334,30 @@ class TestDictionaryCleanupAPI(TestDictionaryCleanupPreviewAPI):
         super().test_recalculate_post_success(mock_celery_task_response)
 
     @pytest.mark.django_db
-    def test_recalculate_permissions(self, mock_celery_task_response):
-        super().test_recalculate_permissions(mock_celery_task_response)
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        "role",
+        (
+            Role.MEMBER,
+            Role.ASSISTANT,
+            Role.EDITOR,
+            Role.LANGUAGE_ADMIN,
+        ),
+    )
+    def test_recalculate_permissions_403_user_roles(
+        self, mock_celery_task_response, role
+    ):
+        super().test_recalculate_permissions_403_user_roles(
+            mock_celery_task_response, role
+        )
+
+    @pytest.mark.django_db
+    def test_recalculate_permissions_403_staff(self, mock_celery_task_response):
+        super().test_recalculate_permissions_403_staff(mock_celery_task_response)
+
+    @pytest.mark.django_db
+    def test_recaltulate_permissions_superadmin(self, mock_celery_task_response):
+        super().test_recaltulate_permissions_superadmin(mock_celery_task_response)
 
     @pytest.mark.django_db
     def test_clear(self, is_preview=False):

--- a/firstvoices/backend/views/custom_order_recalculate_views.py
+++ b/firstvoices/backend/views/custom_order_recalculate_views.py
@@ -1,4 +1,5 @@
 from celery.result import AsyncResult
+from django.core.exceptions import PermissionDenied
 from django.urls import reverse
 from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import status
@@ -6,6 +7,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from backend.models import CustomOrderRecalculationResult
+from backend.permissions.predicates import is_superadmin
 from backend.serializers.async_results_serializers import (
     CustomOrderRecalculationPreviewResultSerializer,
     CustomOrderRecalculationResultSerializer,
@@ -58,8 +60,8 @@ from backend.views.exceptions import CeleryError
     ),
 )
 class CustomOrderRecalculateView(
-    FVPermissionViewSetMixin,
     SiteContentViewSetMixin,
+    FVPermissionViewSetMixin,
     ListViewOnlyModelViewSet,
 ):
     http_method_names = ["get", "post", "delete"]
@@ -68,6 +70,11 @@ class CustomOrderRecalculateView(
         **FVPermissionViewSetMixin.permission_type_map,
         "clear": "delete",
     }
+
+    def initial(self, *args, **kwargs):
+        if not is_superadmin(self.request.user, None):
+            raise PermissionDenied
+        super().initial(*args, **kwargs)
 
     def get_view_name(self):
         return "Custom Order Recalculation Results"
@@ -162,8 +169,8 @@ class CustomOrderRecalculateView(
     ),
 )
 class CustomOrderRecalculatePreviewView(
-    FVPermissionViewSetMixin,
     SiteContentViewSetMixin,
+    FVPermissionViewSetMixin,
     ListViewOnlyModelViewSet,
 ):
     http_method_names = ["get", "post", "delete"]
@@ -172,6 +179,11 @@ class CustomOrderRecalculatePreviewView(
         **FVPermissionViewSetMixin.permission_type_map,
         "clear": "delete",
     }
+
+    def initial(self, *args, **kwargs):
+        if not is_superadmin(self.request.user, None):
+            raise PermissionDenied
+        super().initial(*args, **kwargs)
 
     def get_view_name(self):
         return "Custom Order Recalculation Preview Results"


### PR DESCRIPTION
### Description of Changes
- Adds a check to the `initial` method of the custom order recalculate views to ensure the user is a super user before hitting any of the endpoints in that view.
- Adds better tests to ensure only superadmins are able to use the recalculation endpoints

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Team Postman workspace has been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
