### PR TITLE
FW-5285 Add proper duplicate image validation to galleries

### DIFF
--- a/firstvoices/backend/serializers/gallery_serializers.py
+++ b/firstvoices/backend/serializers/gallery_serializers.py
@@ -42,6 +42,15 @@ class GalleryDetailSerializer(WritableSiteContentSerializer):
         many=True, required=False, source="galleryitem_set"
     )
 
+    def validate(self, attrs):
+        """
+        Validate that gallery items are unique.
+        """
+        gallery_items = attrs.get("galleryitem_set", [])
+        if len(gallery_items) != len({x["image"] for x in gallery_items}):
+            raise serializers.ValidationError("Gallery items must be unique.")
+        return attrs
+
     def create(self, validated_data):
         gallery_items = validated_data.pop("galleryitem_set", [])
 

--- a/firstvoices/backend/serializers/gallery_serializers.py
+++ b/firstvoices/backend/serializers/gallery_serializers.py
@@ -49,7 +49,7 @@ class GalleryDetailSerializer(WritableSiteContentSerializer):
         gallery_items = attrs.get("galleryitem_set", [])
         if len(gallery_items) != len({x["image"] for x in gallery_items}):
             raise serializers.ValidationError("Gallery items must be unique.")
-        return attrs
+        return super().validate(attrs)
 
     def create(self, validated_data):
         gallery_items = validated_data.pop("galleryitem_set", [])


### PR DESCRIPTION
### Description of Changes
- Adds proper validation in the gallery API for duplicate images
- Adds a test for the validation

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Team Postman workspace has been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
I could not use the built-in drf UniqueValidator as the UniqueValidator checks the queryset of the model itself rather than GalleryItem
