### PR TITLE
FW-4627 Media update APIs original field read-only fix

### DIFF
--- a/firstvoices/backend/serializers/media_serializers.py
+++ b/firstvoices/backend/serializers/media_serializers.py
@@ -104,6 +104,13 @@ class MediaSerializer(ExternalSiteContentUrlMixin, serializers.ModelSerializer):
         file.save()
         return file
 
+    def get_fields(self, *args, **kwargs):
+        fields = super().get_fields(*args, **kwargs)
+        request = self.context.get("request", None)
+        if request and getattr(request, "method", None) in ["PUT", "PATCH"]:
+            fields["original"].read_only = True
+        return fields
+
     class Meta:
         fields = base_id_fields + (
             "description",

--- a/firstvoices/backend/tests/test_apis/base_api_test.py
+++ b/firstvoices/backend/tests/test_apis/base_api_test.py
@@ -7,6 +7,7 @@ from rest_framework.reverse import reverse
 from rest_framework.test import APIClient
 
 from backend.models.constants import AppRole, Role, Visibility
+from backend.models.media import Audio, Image, Video
 from backend.tests import factories
 
 
@@ -696,7 +697,13 @@ class SiteContentUpdateApiTestMixin:
 
         expected_data = self.add_expected_defaults(data)
         self.assert_updated_instance(expected_data, self.get_updated_instance(instance))
-        self.assert_update_response(expected_data, response_data)
+
+        # We need to pass instance to verify that the original is not modified
+        # in case of media files
+        if self.model in [Audio, Image, Video]:
+            self.assert_update_response(instance, expected_data, response_data)
+        else:
+            self.assert_update_response(expected_data, response_data)
 
 
 class ControlledSiteContentUpdateApiTestMixin:

--- a/firstvoices/backend/tests/test_apis/base_api_test.py
+++ b/firstvoices/backend/tests/test_apis/base_api_test.py
@@ -674,7 +674,11 @@ class SiteContentUpdateApiTestMixin:
         assert response_data["id"] == str(instance.id)
 
         self.assert_updated_instance(data, self.get_updated_instance(instance))
-        self.assert_update_response(data, response_data)
+
+        if self.model in [Audio, Image, Video]:
+            self.assert_update_response(instance, data, response_data)
+        else:
+            self.assert_update_response(data, response_data)
 
     @pytest.mark.django_db
     def test_update_with_nulls_success_200(self):

--- a/firstvoices/backend/tests/test_apis/base_api_test.py
+++ b/firstvoices/backend/tests/test_apis/base_api_test.py
@@ -653,17 +653,7 @@ class SiteContentUpdateApiTestMixin:
 
         assert response.status_code == 404
 
-    @pytest.mark.django_db
-    def perform_success_request(self, data_with_nulls=False):
-        site = self.create_site_with_app_admin(Visibility.PUBLIC)
-
-        instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
-
-        if data_with_nulls:
-            data = self.get_valid_data_with_nulls(site)
-        else:
-            data = self.get_valid_data(site)
-
+    def perform_detail_request(self, instance, site, data):
         response = self.client.put(
             self.get_detail_endpoint(
                 key=self.get_lookup_key(instance), site_slug=site.slug
@@ -673,20 +663,26 @@ class SiteContentUpdateApiTestMixin:
         )
         response_data = json.loads(response.content)
 
-        return instance, data, response_data
+        return response_data
 
     @pytest.mark.django_db
     def test_update_success_200(self):
-        instance, expected_data, response_data = self.perform_success_request()
-        self.assert_updated_instance(expected_data, self.get_updated_instance(instance))
-        self.assert_update_response(expected_data, response_data)
+        site = self.create_site_with_app_admin(Visibility.PUBLIC)
+        instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
+        data = self.get_valid_data(site)
+
+        response_data = self.perform_detail_request(instance, site, data)
+        self.assert_updated_instance(data, self.get_updated_instance(instance))
+        self.assert_update_response(data, response_data)
 
     @pytest.mark.django_db
     def test_update_with_nulls_success_200(self):
-        instance, expected_data, response_data = self.perform_success_request(
-            data_with_nulls=True
-        )
-        expected_data = self.add_expected_defaults(expected_data)
+        site = self.create_site_with_app_admin(Visibility.PUBLIC)
+        instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
+        data = self.get_valid_data_with_nulls(site)
+        expected_data = self.add_expected_defaults(data)
+
+        response_data = self.perform_detail_request(instance, site, data)
         self.assert_updated_instance(expected_data, self.get_updated_instance(instance))
         self.assert_update_response(expected_data, response_data)
 

--- a/firstvoices/backend/tests/test_apis/base_api_test.py
+++ b/firstvoices/backend/tests/test_apis/base_api_test.py
@@ -7,7 +7,6 @@ from rest_framework.reverse import reverse
 from rest_framework.test import APIClient
 
 from backend.models.constants import AppRole, Role, Visibility
-from backend.models.media import Audio, Image, Video
 from backend.tests import factories
 
 
@@ -674,11 +673,7 @@ class SiteContentUpdateApiTestMixin:
         assert response_data["id"] == str(instance.id)
 
         self.assert_updated_instance(data, self.get_updated_instance(instance))
-
-        if self.model in [Audio, Image, Video]:
-            self.assert_update_response_media(instance, data, response_data)
-        else:
-            self.assert_update_response(data, response_data)
+        self.assert_update_response(data, response_data)
 
     @pytest.mark.django_db
     def test_update_with_nulls_success_200(self):
@@ -701,13 +696,7 @@ class SiteContentUpdateApiTestMixin:
 
         expected_data = self.add_expected_defaults(data)
         self.assert_updated_instance(expected_data, self.get_updated_instance(instance))
-
-        # We need to pass instance to verify that the original is not modified
-        # in case of media files
-        if self.model in [Audio, Image, Video]:
-            self.assert_update_response_media(instance, expected_data, response_data)
-        else:
-            self.assert_update_response(expected_data, response_data)
+        self.assert_update_response(expected_data, response_data)
 
 
 class ControlledSiteContentUpdateApiTestMixin:

--- a/firstvoices/backend/tests/test_apis/base_api_test.py
+++ b/firstvoices/backend/tests/test_apis/base_api_test.py
@@ -654,11 +654,15 @@ class SiteContentUpdateApiTestMixin:
         assert response.status_code == 404
 
     @pytest.mark.django_db
-    def test_update_success_200(self):
+    def perform_success_request(self, data_with_nulls=False):
         site = self.create_site_with_app_admin(Visibility.PUBLIC)
 
         instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
-        data = self.get_valid_data(site)
+
+        if data_with_nulls:
+            data = self.get_valid_data_with_nulls(site)
+        else:
+            data = self.get_valid_data(site)
 
         response = self.client.put(
             self.get_detail_endpoint(
@@ -667,34 +671,22 @@ class SiteContentUpdateApiTestMixin:
             data=self.format_upload_data(data),
             content_type=self.content_type,
         )
-
-        assert response.status_code == 200
         response_data = json.loads(response.content)
-        assert response_data["id"] == str(instance.id)
 
-        self.assert_updated_instance(data, self.get_updated_instance(instance))
-        self.assert_update_response(data, response_data)
+        return instance, data, response_data
+
+    @pytest.mark.django_db
+    def test_update_success_200(self):
+        instance, expected_data, response_data = self.perform_success_request()
+        self.assert_updated_instance(expected_data, self.get_updated_instance(instance))
+        self.assert_update_response(expected_data, response_data)
 
     @pytest.mark.django_db
     def test_update_with_nulls_success_200(self):
-        site = self.create_site_with_app_admin(Visibility.PUBLIC)
-
-        instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
-        data = self.get_valid_data_with_nulls(site)
-
-        response = self.client.put(
-            self.get_detail_endpoint(
-                key=self.get_lookup_key(instance), site_slug=site.slug
-            ),
-            data=self.format_upload_data(data),
-            content_type=self.content_type,
+        instance, expected_data, response_data = self.perform_success_request(
+            data_with_nulls=True
         )
-
-        assert response.status_code == 200
-        response_data = json.loads(response.content)
-        assert response_data["id"] == str(instance.id)
-
-        expected_data = self.add_expected_defaults(data)
+        expected_data = self.add_expected_defaults(expected_data)
         self.assert_updated_instance(expected_data, self.get_updated_instance(instance))
         self.assert_update_response(expected_data, response_data)
 

--- a/firstvoices/backend/tests/test_apis/base_api_test.py
+++ b/firstvoices/backend/tests/test_apis/base_api_test.py
@@ -676,7 +676,7 @@ class SiteContentUpdateApiTestMixin:
         self.assert_updated_instance(data, self.get_updated_instance(instance))
 
         if self.model in [Audio, Image, Video]:
-            self.assert_update_response(instance, data, response_data)
+            self.assert_update_response_media(instance, data, response_data)
         else:
             self.assert_update_response(data, response_data)
 
@@ -705,7 +705,7 @@ class SiteContentUpdateApiTestMixin:
         # We need to pass instance to verify that the original is not modified
         # in case of media files
         if self.model in [Audio, Image, Video]:
-            self.assert_update_response(instance, expected_data, response_data)
+            self.assert_update_response_media(instance, expected_data, response_data)
         else:
             self.assert_update_response(expected_data, response_data)
 

--- a/firstvoices/backend/tests/test_apis/base_media_test.py
+++ b/firstvoices/backend/tests/test_apis/base_media_test.py
@@ -506,6 +506,7 @@ class BaseMediaApiTest(
         }
 
         self.assert_response(
+            original_instance=original_instance,
             actual_response=actual_response,
             expected_data=expected_data,
         )

--- a/firstvoices/backend/tests/test_apis/base_media_test.py
+++ b/firstvoices/backend/tests/test_apis/base_media_test.py
@@ -501,15 +501,23 @@ class BaseMediaApiTest(
 
     @pytest.mark.django_db
     def test_update_success_200(self):
-        instance, expected_data, response_data = self.perform_success_request()
-        self.assert_update_response(expected_data, response_data, instance)
+        site = self.create_site_with_app_admin(Visibility.PUBLIC)
+        instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
+        data = self.get_valid_data(site)
+
+        response_data = self.perform_detail_request(instance, site, data)
+
+        self.assert_update_response(data, response_data, instance)
 
     @pytest.mark.django_db
     def test_update_with_nulls_success_200(self):
-        instance, expected_data, response_data = self.perform_success_request(
-            data_with_nulls=True
-        )
-        expected_data = self.add_expected_defaults(expected_data)
+        site = self.create_site_with_app_admin(Visibility.PUBLIC)
+        instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
+        data = self.get_valid_data_with_nulls(site)
+        expected_data = self.add_expected_defaults(data)
+
+        response_data = self.perform_detail_request(instance, site, data)
+
         self.assert_updated_instance(expected_data, self.get_updated_instance(instance))
         self.assert_update_response(expected_data, response_data, instance)
 

--- a/firstvoices/backend/tests/test_apis/base_media_test.py
+++ b/firstvoices/backend/tests/test_apis/base_media_test.py
@@ -511,29 +511,6 @@ class BaseMediaApiTest(
         )
 
     @pytest.mark.django_db
-    def test_update_with_nulls_success_200(self):
-        site = self.create_site_with_app_admin(Visibility.PUBLIC)
-
-        instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
-        data = self.get_valid_data_with_nulls(site)
-
-        response = self.client.put(
-            self.get_detail_endpoint(
-                key=self.get_lookup_key(instance), site_slug=site.slug
-            ),
-            data=self.format_upload_data(data),
-            content_type=self.content_type,
-        )
-
-        assert response.status_code == 200
-        response_data = json.loads(response.content)
-        assert response_data["id"] == str(instance.id)
-
-        expected_data = self.add_expected_defaults(data)
-        self.assert_updated_instance(expected_data, self.get_updated_instance(instance))
-        self.assert_update_response(instance, expected_data, response_data)
-
-    @pytest.mark.django_db
     def test_update_success_200(self):
         site = self.create_site_with_app_admin(Visibility.PUBLIC)
 

--- a/firstvoices/backend/tests/test_apis/base_media_test.py
+++ b/firstvoices/backend/tests/test_apis/base_media_test.py
@@ -615,21 +615,6 @@ class BaseMediaApiTest(
         assert len(response_data["usage"]["dictionaryEntries"]) == 0
         assert len(response_data["usage"]["songs"]) == 0
         assert len(response_data["usage"]["stories"]) == 0
-        assert response_data["id"] == str(instance.id)
-
-    def test_update_success_200(self):
-        instance, expected_data, response_data = self.perform_success_request()
-        self.assert_update_response(expected_data, response_data, instance)
-
-    @pytest.mark.django_db
-    def test_update_with_nulls_success_200(self):
-        instance, expected_data, response_data = self.perform_success_request(
-            data_with_nulls=True
-        )
-        expected_data = self.add_expected_defaults(expected_data)
-
-        self.assert_updated_instance(expected_data, self.get_updated_instance(instance))
-        self.assert_update_response(expected_data, response_data, instance)
 
 
 class BaseVisualMediaAPITest(BaseMediaApiTest):

--- a/firstvoices/backend/tests/test_apis/base_media_test.py
+++ b/firstvoices/backend/tests/test_apis/base_media_test.py
@@ -511,28 +511,6 @@ class BaseMediaApiTest(
         )
 
     @pytest.mark.django_db
-    def test_update_success_200(self):
-        site = self.create_site_with_app_admin(Visibility.PUBLIC)
-
-        instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
-        data = self.get_valid_data(site)
-
-        response = self.client.put(
-            self.get_detail_endpoint(
-                key=self.get_lookup_key(instance), site_slug=site.slug
-            ),
-            data=self.format_upload_data(data),
-            content_type=self.content_type,
-        )
-
-        assert response.status_code == 200
-        response_data = json.loads(response.content)
-        assert response_data["id"] == str(instance.id)
-
-        self.assert_updated_instance(data, self.get_updated_instance(instance))
-        self.assert_update_response(instance, data, response_data)
-
-    @pytest.mark.django_db
     def test_create_400_invalid_filetype(self):
         site = self.create_site_with_app_admin(Visibility.PUBLIC)
         data = self.get_valid_data(site)

--- a/firstvoices/backend/tests/test_apis/base_media_test.py
+++ b/firstvoices/backend/tests/test_apis/base_media_test.py
@@ -510,6 +510,15 @@ class BaseMediaApiTest(
             expected_data=expected_data,
         )
 
+    def assert_update_response_media(
+        self, original_instance, expected_data, actual_response
+    ):
+        self.assert_response(
+            original_instance=original_instance,
+            actual_response=actual_response,
+            expected_data={**expected_data},
+        )
+
     @pytest.mark.django_db
     def test_create_400_invalid_filetype(self):
         site = self.create_site_with_app_admin(Visibility.PUBLIC)
@@ -638,9 +647,8 @@ class BaseVisualMediaAPITest(BaseMediaApiTest):
         self.assert_secondary_fields(expected_data, actual_instance)
         assert actual_instance.title == expected_data["title"]
 
-    def assert_update_response(self, original_instance, expected_data, actual_response):
+    def assert_update_response(self, expected_data, actual_response):
         self.assert_response(
-            original_instance=original_instance,
             actual_response=actual_response,
             expected_data={**expected_data},
         )

--- a/firstvoices/backend/tests/test_apis/base_media_test.py
+++ b/firstvoices/backend/tests/test_apis/base_media_test.py
@@ -617,7 +617,17 @@ class BaseMediaApiTest(
         assert len(response_data["usage"]["stories"]) == 0
         assert response_data["id"] == str(instance.id)
 
-        expected_data = self.add_expected_defaults(data)
+    def test_update_success_200(self):
+        instance, expected_data, response_data = self.perform_success_request()
+        self.assert_update_response(expected_data, response_data, instance)
+
+    @pytest.mark.django_db
+    def test_update_with_nulls_success_200(self):
+        instance, expected_data, response_data = self.perform_success_request(
+            data_with_nulls=True
+        )
+        expected_data = self.add_expected_defaults(expected_data)
+
         self.assert_updated_instance(expected_data, self.get_updated_instance(instance))
         self.assert_update_response(expected_data, response_data, instance)
 

--- a/firstvoices/backend/tests/test_apis/test_audio_api.py
+++ b/firstvoices/backend/tests/test_apis/test_audio_api.py
@@ -277,6 +277,28 @@ class TestAudioEndpoint(BaseMediaApiTest):
         )
         self.assert_update_patch_speaker_response(instance, data, response_data)
 
+    # Setting speakers list to an empty array
+    @pytest.mark.django_db
+    def test_update_speakers_success_200_empty(self):
+        site = self.create_site_with_app_admin(Visibility.PUBLIC)
+        instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
+        data = self.get_valid_data(site)
+
+        # Setting speakers to an empty list
+        # removing file, since that is not json serializable
+        del data["original"]
+        data["speakers"] = []
+
+        response = self.client.put(
+            self.get_detail_endpoint(
+                key=self.get_lookup_key(instance), site_slug=site.slug
+            ),
+            data=self.format_upload_data(data, self.content_type_json),
+            content_type=self.content_type_json,
+        )
+        response_data = json.loads(response.content)
+        assert response_data["speakers"] == []
+
     def add_related_media_to_objects(self, visibility=Visibility.PUBLIC):
         if visibility == Visibility.TEAM:
             site = self.create_site_with_non_member(Visibility.PUBLIC)

--- a/firstvoices/backend/tests/test_apis/test_audio_api.py
+++ b/firstvoices/backend/tests/test_apis/test_audio_api.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-from django.test.client import encode_multipart
 
 from backend.models.constants import Visibility
 from backend.models.media import Audio
@@ -43,14 +42,6 @@ class TestAudioEndpoint(BaseMediaApiTest):
         return self.get_expected_audio_data(
             instance, speaker=None, detail_view=detail_view
         )
-
-    def format_upload_data(
-        self, data, content_type="multipart/form-data; boundary=TestBoundaryString"
-    ):
-        if content_type == self.content_type_json:
-            return json.dumps(data)
-        else:
-            return encode_multipart(self.boundary_string, data)
 
     @pytest.mark.django_db
     def test_detail_with_speakers(self):
@@ -234,7 +225,7 @@ class TestAudioEndpoint(BaseMediaApiTest):
             self.get_detail_endpoint(
                 key=self.get_lookup_key(instance), site_slug=site.slug
             ),
-            data=self.format_upload_data(data, self.content_type),
+            data=self.format_upload_data(data),
             content_type=self.content_type,
         )
 
@@ -261,7 +252,7 @@ class TestAudioEndpoint(BaseMediaApiTest):
             self.get_detail_endpoint(
                 key=self.get_lookup_key(instance), site_slug=site.slug
             ),
-            data=self.format_upload_data(data, self.content_type_json),
+            data=json.dumps(data),
             content_type=self.content_type_json,
         )
 
@@ -293,7 +284,7 @@ class TestAudioEndpoint(BaseMediaApiTest):
             self.get_detail_endpoint(
                 key=self.get_lookup_key(instance), site_slug=site.slug
             ),
-            data=self.format_upload_data(data, self.content_type_json),
+            data=json.dumps(data),
             content_type=self.content_type_json,
         )
         response_data = json.loads(response.content)

--- a/firstvoices/backend/tests/test_apis/test_audio_api.py
+++ b/firstvoices/backend/tests/test_apis/test_audio_api.py
@@ -243,28 +243,6 @@ class TestAudioEndpoint(BaseMediaApiTest):
         )
         self.assert_update_patch_speaker_response(instance, data, response_data)
 
-    def assert_patch_speaker_original_fields(self, original_instance, updated_instance):
-        self.assert_original_secondary_fields(original_instance, updated_instance)
-        assert updated_instance.title == original_instance.title
-        assert updated_instance.original.id == original_instance.original.id
-
-    def assert_update_patch_speaker_response(
-        self, original_instance, data, actual_response
-    ):
-        self.assert_response(
-            actual_response=actual_response,
-            expected_data={
-                "id": str(original_instance.id),
-                "title": original_instance.title,
-                "description": original_instance.description,
-                "acknowledgement": original_instance.acknowledgement,
-                "excludeFromKids": original_instance.exclude_from_kids,
-                "excludeFromGames": original_instance.exclude_from_games,
-                "original": original_instance.original,
-                "speakers": data["speakers"],
-            },
-        )
-
     def add_related_media_to_objects(self, visibility=Visibility.PUBLIC):
         if visibility == Visibility.TEAM:
             site = self.create_site_with_non_member(Visibility.PUBLIC)

--- a/firstvoices/backend/tests/test_apis/test_audio_api.py
+++ b/firstvoices/backend/tests/test_apis/test_audio_api.py
@@ -163,6 +163,7 @@ class TestAudioEndpoint(BaseMediaApiTest):
             "speakers": original_instance.speakers,
         }
         self.assert_response(
+            original_instance=original_instance,
             actual_response=actual_response,
             expected_data=expected_data,
         )

--- a/firstvoices/backend/tests/test_apis/test_audio_api.py
+++ b/firstvoices/backend/tests/test_apis/test_audio_api.py
@@ -140,7 +140,9 @@ class TestAudioEndpoint(BaseMediaApiTest):
         assert actual_instance.title == expected_data["title"]
         assert actual_instance.speakers.count() == 0
 
-    def assert_update_response(self, original_instance, expected_data, actual_response):
+    def assert_update_response_audio(
+        self, original_instance, expected_data, actual_response
+    ):
         self.assert_response(
             original_instance=original_instance,
             actual_response=actual_response,

--- a/firstvoices/backend/tests/test_apis/test_images_api.py
+++ b/firstvoices/backend/tests/test_apis/test_images_api.py
@@ -1,3 +1,8 @@
+import json
+
+import pytest
+
+from backend.models.constants import Visibility
 from backend.models.media import Image
 from backend.tests import factories
 

--- a/firstvoices/backend/tests/test_apis/test_videos_api.py
+++ b/firstvoices/backend/tests/test_apis/test_videos_api.py
@@ -1,3 +1,8 @@
+import json
+
+import pytest
+
+from backend.models.constants import Visibility
 from backend.models.media import Video
 from backend.tests import factories
 

--- a/firstvoices/backend/tests/test_apis/test_videos_api.py
+++ b/firstvoices/backend/tests/test_apis/test_videos_api.py
@@ -1,11 +1,6 @@
-import json
-
-import pytest
-
-from backend.models.media import Video, VideoFile
+from backend.models.media import Video
 from backend.tests import factories
 
-from ...models.constants import Visibility
 from .base_media_test import BaseVisualMediaAPITest
 
 
@@ -51,35 +46,6 @@ class TestVideosEndpoint(BaseVisualMediaAPITest):
                 expected.pop(ignored_field)
 
         assert actual_response == expected
-
-    @pytest.mark.disable_thumbnail_mocks
-    @pytest.mark.django_db
-    def test_patch_old_file_deleted(self, disable_celery):
-        site = self.create_site_with_app_admin(Visibility.PUBLIC)
-        instance = factories.VideoFactory.create(site=site)
-        instance = Video.objects.get(pk=instance.id)
-        data = self.get_valid_patch_file_data(site)
-
-        assert VideoFile.objects.count() == 1
-        old_original_file_id = instance.original.id
-
-        assert VideoFile.objects.filter(id=old_original_file_id).exists()
-
-        response = self.client.patch(
-            self.get_detail_endpoint(
-                key=self.get_lookup_key(instance), site_slug=site.slug
-            ),
-            data=self.format_upload_data(data),
-            content_type=self.content_type,
-        )
-
-        assert response.status_code == 200
-        response_data = json.loads(response.content)
-        assert response_data["id"] == str(instance.id)
-
-        # Check that old files have been deleted
-        assert VideoFile.objects.count() == 1
-        assert not VideoFile.objects.filter(id=old_original_file_id).exists()
 
     def add_related_media_to_objects(self, visibility=Visibility.PUBLIC):
         if visibility == Visibility.TEAM:

--- a/firstvoices/backend/views/audio_views.py
+++ b/firstvoices/backend/views/audio_views.py
@@ -93,3 +93,14 @@ class AudioViewSet(
         if self.action == "retrieve":
             return AudioDetailSerializer
         return AudioSerializer
+
+    def update(self, request, *args, **kwargs):
+        # To handle empty list in multipart form-data
+        request.data._mutable = True
+        speakers = request.data.getlist("speakers", None)
+        if len(speakers) == 1 and speakers[0] == "[]":
+            speakers = []
+        request.data.setlist("speakers", speakers)
+        request.data._mutable = False
+
+        return super().update(request, *args, **kwargs)

--- a/firstvoices/backend/views/audio_views.py
+++ b/firstvoices/backend/views/audio_views.py
@@ -34,7 +34,9 @@ from .api_doc_variables import id_parameter, site_slug_parameter
         ],
     ),
     create=extend_schema(
-        description=_("Add an audio item."),
+        description=_(
+            "Add an audio item. The 'original' field would not work with the 'application/json' content-type."
+        ),
         responses={
             201: OpenApiResponse(
                 description=doc_strings.success_201, response=AudioSerializer
@@ -74,6 +76,7 @@ class AudioViewSet(
     parser_classes = [
         parsers.FormParser,
         parsers.MultiPartParser,
+        parsers.JSONParser,
     ]  # to support file uploads
 
     def get_queryset(self):
@@ -93,14 +96,3 @@ class AudioViewSet(
         if self.action == "retrieve":
             return AudioDetailSerializer
         return AudioSerializer
-
-    def update(self, request, *args, **kwargs):
-        # To handle empty list in multipart form-data
-        request.data._mutable = True
-        speakers = request.data.getlist("speakers", None)
-        if len(speakers) == 1 and speakers[0] == "[]":
-            speakers = []
-        request.data.setlist("speakers", speakers)
-        request.data._mutable = False
-
-        return super().update(request, *args, **kwargs)

--- a/firstvoices/backend/views/audio_views.py
+++ b/firstvoices/backend/views/audio_views.py
@@ -76,7 +76,7 @@ class AudioViewSet(
     parser_classes = [
         parsers.FormParser,
         parsers.MultiPartParser,
-        parsers.JSONParser,
+        parsers.JSONParser,  # To support setting the speaker's list to empty
     ]  # to support file uploads
 
     def get_queryset(self):

--- a/firstvoices/backend/views/image_views.py
+++ b/firstvoices/backend/views/image_views.py
@@ -75,6 +75,7 @@ class ImageViewSet(
     parser_classes = [
         parsers.FormParser,
         parsers.MultiPartParser,
+        parsers.JSONParser,  # used in audio views, but added here for consistency across media views
     ]  # to support file uploads
 
     def get_queryset(self):

--- a/firstvoices/backend/views/video_views.py
+++ b/firstvoices/backend/views/video_views.py
@@ -75,6 +75,7 @@ class VideoViewSet(
     parser_classes = [
         parsers.FormParser,
         parsers.MultiPartParser,
+        parsers.JSONParser,  # used in audio views, but added here for consistency across media views
     ]  # to support file uploads
 
     def get_queryset(self):


### PR DESCRIPTION
### Description of Changes
- updated media APIs to mark the original field as read-only for PUT/PATCH requests
- Added json parser support to all media views. Primarily the use case is for setting the `speakers` to an empty list for audio files.
- Refactored tests to also test for the above cases

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- [x] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
