### PR TITLE
FW-5432 Hide hidden sites in site APIs

### DIFF
--- a/firstvoices/backend/permissions/predicates/base.py
+++ b/firstvoices/backend/permissions/predicates/base.py
@@ -1,4 +1,4 @@
-from rules import predicate, Predicate
+from rules import Predicate, predicate
 
 from backend.models.constants import AppRole, Role, Visibility
 from backend.permissions.utils import get_app_role, get_site_role
@@ -98,10 +98,16 @@ def is_superadmin(user, obj):
     return get_app_role(user) == AppRole.SUPERADMIN
 
 
+@predicate
+def is_hidden_obj(user, obj):
+    return obj.is_hidden
+
+
 #
 # site and app role combos
 is_at_least_language_admin = Predicate(
-    has_language_admin_membership | is_at_least_staff_admin, name="is_at_least_language_admin"
+    has_language_admin_membership | is_at_least_staff_admin,
+    name="is_at_least_language_admin",
 )
 
 #

--- a/firstvoices/backend/permissions/predicates/base.py
+++ b/firstvoices/backend/permissions/predicates/base.py
@@ -99,7 +99,7 @@ def is_superadmin(user, obj):
 
 
 @predicate
-def is_hidden_obj(user, obj):
+def is_hidden_site(user, obj):
     return obj.is_hidden
 
 

--- a/firstvoices/backend/permissions/predicates/view.py
+++ b/firstvoices/backend/permissions/predicates/view.py
@@ -26,6 +26,6 @@ has_visible_site = Predicate(
     name="has_visible_site",
 )
 
-can_view_hidden_site = Predicate(
-    base.is_at_least_staff_admin | base.has_team_access, name="can_view_hidden_site"
+has_hidden_site = Predicate(
+    base.is_at_least_staff_admin | base.has_team_access, name="has_hidden_site"
 )

--- a/firstvoices/backend/permissions/predicates/view.py
+++ b/firstvoices/backend/permissions/predicates/view.py
@@ -25,3 +25,7 @@ has_visible_site = Predicate(
     ),
     name="has_visible_site",
 )
+
+can_view_hidden_site = Predicate(
+    base.is_at_least_staff_admin | base.has_team_access, name="can_view_hidden_site"
+)

--- a/firstvoices/backend/permissions/predicates/view.py
+++ b/firstvoices/backend/permissions/predicates/view.py
@@ -25,7 +25,3 @@ has_visible_site = Predicate(
     ),
     name="has_visible_site",
 )
-
-has_hidden_site = Predicate(
-    base.is_at_least_staff_admin | base.has_team_access, name="has_hidden_site"
-)

--- a/firstvoices/backend/permissions/predicates/view_models.py
+++ b/firstvoices/backend/permissions/predicates/view_models.py
@@ -9,7 +9,9 @@ from . import base, view
 # Rule for who can see detailed site info including homepage, content APIs, etc
 can_view_site = Predicate(
     (base.is_at_least_staff_admin | base.has_team_access)
-    | ((base.has_member_access_to_site_obj | base.is_public_obj) & ~base.is_hidden_obj),
+    | (
+        (base.has_member_access_to_site_obj | base.is_public_obj) & ~base.is_hidden_site
+    ),
     name="can_view_site",
 )
 

--- a/firstvoices/backend/permissions/predicates/view_models.py
+++ b/firstvoices/backend/permissions/predicates/view_models.py
@@ -8,12 +8,8 @@ from . import base, view
 
 # Rule for who can see detailed site info including homepage, content APIs, etc
 can_view_site = Predicate(
-    (
-        base.is_public_obj
-        | base.is_at_least_staff_admin
-        | base.has_member_access_to_site_obj
-        | base.has_team_access
-    ),
+    (base.is_at_least_staff_admin | base.has_team_access)
+    | ((base.has_member_access_to_site_obj | base.is_public_obj) & ~base.is_hidden_obj),
     name="can_view_site",
 )
 
@@ -22,7 +18,7 @@ can_view_user_info = Predicate(
     (
         base.is_at_least_staff_admin
         | base.has_language_admin_membership
-        | (base.is_own_obj & view.has_visible_site)
+        | (base.is_own_obj & view.has_visible_site & ~view.has_hidden_site)
     ),
     name="can_view_membership_model",
 )

--- a/firstvoices/backend/permissions/predicates/view_models.py
+++ b/firstvoices/backend/permissions/predicates/view_models.py
@@ -18,7 +18,7 @@ can_view_user_info = Predicate(
     (
         base.is_at_least_staff_admin
         | base.has_language_admin_membership
-        | (base.is_own_obj & view.has_visible_site & ~view.has_hidden_site)
+        | (base.is_own_obj & view.has_visible_site)
     ),
     name="can_view_membership_model",
 )

--- a/firstvoices/backend/tests/test_apis/test_my_sites_api.py
+++ b/firstvoices/backend/tests/test_apis/test_my_sites_api.py
@@ -144,6 +144,21 @@ class TestMySitesEndpoint(ReadOnlyApiTests):
         assert response_data["results"][0]["id"] == str(hidden_site.id)
 
     @pytest.mark.django_db
+    @pytest.mark.parametrize("role", [Role.ASSISTANT, Role.EDITOR, Role.LANGUAGE_ADMIN])
+    def test_hidden_sites_visible_team_members_detail(self, role):
+        user = factories.get_non_member_user()
+        instance = factories.SiteFactory.create(
+            visibility=Visibility.PUBLIC, is_hidden=True
+        )
+        factories.MembershipFactory.create(user=user, site=instance, role=role)
+        self.client.force_authenticate(user=user)
+
+        response = self.client.get(f"{self.get_detail_endpoint(instance.slug)}")
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+        assert response_data["id"] == str(instance.id)
+
+    @pytest.mark.django_db
     def test_hidden_sites_not_visible_to_members(self):
         user = factories.UserFactory.create()
         hidden_site = factories.SiteFactory.create(
@@ -161,7 +176,9 @@ class TestMySitesEndpoint(ReadOnlyApiTests):
         assert response_data["count"] == 0
 
     @pytest.mark.django_db
-    def test_hidden_sites_detail_403_members(self):
+    def test_hidden_sites_not_visible_to_members_detail(self):
+        # hidden sites should not be visible to members in list or detail views
+        # due to these memberships being excluded from the my-sites queryset entirely, the detail result is a 404
         user = factories.get_non_member_user()
         instance = factories.SiteFactory.create(
             visibility=Visibility.PUBLIC, is_hidden=True
@@ -170,4 +187,4 @@ class TestMySitesEndpoint(ReadOnlyApiTests):
         self.client.force_authenticate(user=user)
 
         response = self.client.get(f"{self.get_detail_endpoint(instance.slug)}")
-        assert response.status_code == 403
+        assert response.status_code == 404

--- a/firstvoices/backend/tests/test_apis/test_sites_api.py
+++ b/firstvoices/backend/tests/test_apis/test_sites_api.py
@@ -965,6 +965,18 @@ class TestSitesEndpoints(MediaTestMixin, BaseApiTest):
         assert response.status_code == 403
 
     @pytest.mark.django_db
+    def test_hidden_site_detail_403_members(self):
+        user = factories.get_non_member_user()
+        instance = factories.SiteFactory.create(
+            visibility=Visibility.PUBLIC, is_hidden=True
+        )
+        factories.MembershipFactory.create(user=user, site=instance, role=Role.MEMBER)
+        self.client.force_authenticate(user=user)
+
+        response = self.client.get(f"{self.get_detail_endpoint(instance.slug)}")
+        assert response.status_code == 403
+
+    @pytest.mark.django_db
     @pytest.mark.parametrize("app_role", [AppRole.SUPERADMIN, AppRole.STAFF])
     def test_hidden_site_detail_staff(self, app_role):
         user = factories.get_app_admin(app_role)

--- a/firstvoices/backend/tests/test_apis/test_sites_api.py
+++ b/firstvoices/backend/tests/test_apis/test_sites_api.py
@@ -941,3 +941,54 @@ class TestSitesEndpoints(MediaTestMixin, BaseApiTest):
             data, self.get_updated_patch_instance(instance)
         )
         self.assert_update_patch_response(instance, data, response_data)
+
+    @pytest.mark.django_db
+    def test_hidden_sites_not_visible_in_list_view(self):
+        user = factories.get_app_admin(AppRole.SUPERADMIN)
+        self.client.force_authenticate(user=user)
+        factories.SiteFactory.create(visibility=Visibility.PUBLIC, is_hidden=True)
+
+        response = self.client.get(self.get_list_endpoint())
+        response_data = json.loads(response.content)
+        assert len(response_data) == 0
+        assert response_data == []
+
+    @pytest.mark.django_db
+    def test_hidden_site_detail_403(self):
+        user = factories.get_non_member_user()
+        self.client.force_authenticate(user=user)
+        instance = factories.SiteFactory.create(
+            visibility=Visibility.PUBLIC, is_hidden=True
+        )
+
+        response = self.client.get(f"{self.get_detail_endpoint(instance.slug)}")
+        assert response.status_code == 403
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize("app_role", [AppRole.SUPERADMIN, AppRole.STAFF])
+    def test_hidden_site_detail_staff(self, app_role):
+        user = factories.get_app_admin(app_role)
+        self.client.force_authenticate(user=user)
+        instance = factories.SiteFactory.create(
+            visibility=Visibility.PUBLIC, is_hidden=True
+        )
+
+        response = self.client.get(f"{self.get_detail_endpoint(instance.slug)}")
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+        assert response_data["id"] == str(instance.id)
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize("role", [Role.ASSISTANT, Role.EDITOR, Role.LANGUAGE_ADMIN])
+    def test_hidden_site_detail_team_member(self, role):
+        instance = factories.SiteFactory.create(
+            visibility=Visibility.PUBLIC, is_hidden=True
+        )
+        user = factories.get_non_member_user()
+        factories.MembershipFactory.create(user=user, site=instance, role=role)
+        self.client.force_authenticate(user=user)
+
+        response = self.client.get(f"{self.get_detail_endpoint(instance.slug)}")
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+        assert response_data["id"] == str(instance.id)

--- a/firstvoices/backend/views/sites_views.py
+++ b/firstvoices/backend/views/sites_views.py
@@ -1,4 +1,3 @@
-from django.core.exceptions import PermissionDenied
 from django.db.models import Prefetch
 from django.db.models.functions import Upper
 from django.utils.translation import gettext as _
@@ -19,7 +18,6 @@ from backend.views import doc_strings
 from backend.views.api_doc_variables import inline_site_doc_detail_serializer
 from backend.views.base_views import FVPermissionViewSetMixin
 
-from ..permissions.predicates import can_view_hidden_site
 from .utils import get_select_related_media_fields
 
 
@@ -73,13 +71,6 @@ class SiteViewSet(FVPermissionViewSetMixin, ModelViewSet):
     lookup_field = "slug"
     pagination_class = None
     serializer_class = SiteDetailWriteSerializer
-
-    def initial(self, *args, **kwargs):
-        if self.action == "retrieve":
-            obj = self.get_object()
-            if obj.is_hidden and not can_view_hidden_site(self.request.user, obj):
-                raise PermissionDenied
-        super().initial(*args, **kwargs)
 
     def get_detail_queryset(self):
         sites = (


### PR DESCRIPTION
### Description of Changes
- Hides hidden sites from the sites list API, regardless of visibility
- Allows access to detail view of hidden sites only if the user is staff or a team member of the hidden site

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Team Postman workspace has been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] ~~Pull the branch and test locally~~

### Additional Notes
N/A
