### PR TITLE
FW-5021 Add usage field to media retrieve view

### DIFF
--- a/firstvoices/backend/serializers/media_detail_serializers.py
+++ b/firstvoices/backend/serializers/media_detail_serializers.py
@@ -2,17 +2,34 @@ from rest_framework import serializers
 from rest_framework_nested.serializers import NestedHyperlinkedModelSerializer
 
 from backend.models import Character, DictionaryEntry, Gallery, SitePage, Song, Story
-from backend.models.media import Image, Video
 from backend.serializers.base_serializers import (
     LinkedSiteSerializer,
     SiteContentLinkedTitleSerializer,
 )
 from backend.serializers.fields import SiteHyperlinkedIdentityField
+from backend.serializers.media_serializers import (
+    AudioSerializer,
+    ImageSerializer,
+    VideoSerializer,
+)
 
 
 def usage_related_set(self, model, related_set, many=True):
     GenericUsageSerializer.Meta.model = model
     return GenericUsageSerializer(related_set, many=many, context=self.context).data
+
+
+def get_usages_total(usages_dict):
+    # Get total count of all objects a media file is used in
+    total = 0
+    for usage in usages_dict.values():
+        if isinstance(
+            usage, list
+        ):  # adding a check as some keys contain objects and not arrays
+            total += len(usage)
+        else:
+            total += 1
+    return total
 
 
 class GenericUsageSerializer(
@@ -36,97 +53,108 @@ class SitePageUsageSerializer(serializers.ModelSerializer):
         )
 
 
-def get_media_detail_serializer(base_media_class):
-    class MediaDetailSerializer(base_media_class):
-        usage = serializers.SerializerMethodField()
+class BaseUsageFieldMixin(serializers.ModelSerializer):
+    usage = serializers.SerializerMethodField()
 
-        class Meta(base_media_class.Meta):
-            fields = base_media_class.Meta.fields + ("usage",)
+    class Meta:
+        fields = ("usage",)
 
-        def get_usage(self, obj):
-            characters = usage_related_set(self, Character, obj.character_set.all())
-            dictionary_entries = usage_related_set(
-                self, DictionaryEntry, obj.dictionaryentry_set.all()
+    def get_usage(self, obj):
+        characters = usage_related_set(self, Character, obj.character_set.all())
+        dictionary_entries = usage_related_set(
+            self, DictionaryEntry, obj.dictionaryentry_set.all()
+        )
+        songs = usage_related_set(self, Song, obj.song_set.all())
+
+        # Returning only stories and not pages, whether the media is on the cover or in any page
+        parent_stories = []
+        for story_page in obj.storypage_set.all():
+            parent_stories.append(
+                usage_related_set(self, Story, story_page.story, many=False)
             )
-            songs = usage_related_set(self, Song, obj.song_set.all())
+        story_covers = usage_related_set(self, Story, obj.story_set.all())
+        # Returning only unique values
+        stories = list(
+            {story["id"]: story for story in (parent_stories + story_covers)}.values()
+        )
 
-            # Returning only stories and not pages, whether the media is on the cover or in any page
-            parent_stories = []
-            for story_page in obj.storypage_set.all():
-                parent_stories.append(
-                    usage_related_set(self, Story, story_page.story, many=False)
-                )
-            story_covers = usage_related_set(self, Story, obj.story_set.all())
-            # Returning only unique values
-            stories = list(
-                {
-                    story["id"]: story for story in (parent_stories + story_covers)
-                }.values()
+        response_dict = {
+            "characters": characters,
+            "dictionary_entries": dictionary_entries,
+            "songs": songs,
+            "stories": stories,
+        }
+
+        response_dict["total"] = get_usages_total(response_dict)
+
+        return response_dict
+
+
+class VisualMediaUsageFieldMixin(BaseUsageFieldMixin):
+    def get_usage(self, obj):
+        response_dict = BaseUsageFieldMixin.get_usage(
+            self, obj
+        )  # Can we do super() here ?
+
+        site_pages = SitePageUsageSerializer(
+            obj.sitepage_set.all(), context=self.context, many=True
+        ).data
+
+        response_dict = {
+            **response_dict,
+            "custom_pages": site_pages,
+        }
+
+        del response_dict["total"]
+        response_dict["total"] = get_usages_total(response_dict)
+        return response_dict
+
+
+class AudioDetailSerializer(BaseUsageFieldMixin, AudioSerializer):
+    class Meta(AudioSerializer.Meta):
+        fields = AudioSerializer.Meta.fields + BaseUsageFieldMixin.Meta.fields
+
+
+class VideoDetailSerializer(VisualMediaUsageFieldMixin, VideoSerializer):
+    class Meta(VideoSerializer.Meta):
+        fields = VideoSerializer.Meta.fields + VisualMediaUsageFieldMixin.Meta.fields
+
+
+class ImageDetailSerializer(VisualMediaUsageFieldMixin, ImageSerializer):
+    class Meta(ImageSerializer.Meta):
+        fields = ImageSerializer.Meta.fields + VisualMediaUsageFieldMixin.Meta.fields
+
+    def get_usage(self, obj):
+        response_dict = VisualMediaUsageFieldMixin.get_usage(self, obj)
+        gallery_cover_image_of = usage_related_set(
+            self, Gallery, obj.gallery_cover_image.all()
+        )
+        site_banner_of = LinkedSiteSerializer(
+            obj.site_banner_of, context=self.context
+        ).data
+        site_logo_of = LinkedSiteSerializer(obj.site_logo_of, context=self.context).data
+
+        gallery_images = []
+        for gallery_item in obj.gallery_images.all():
+            gallery_images.append(
+                usage_related_set(self, Gallery, gallery_item.gallery, many=False)
             )
 
-            response_dict = {
-                "characters": characters,
-                "dictionary_entries": dictionary_entries,
-                "songs": songs,
-                "stories": stories,
-            }
+        # returning only unique values
+        gallery = list(
+            {
+                gallery["id"]: gallery
+                for gallery in (gallery_cover_image_of + gallery_images)
+            }.values()
+        )
 
-            if type(obj) in [Image, Video]:
-                site_pages = SitePageUsageSerializer(
-                    obj.sitepage_set.all(), context=self.context, many=True
-                ).data
+        response_dict = {
+            **response_dict,
+            "gallery": gallery,
+            "site_banner": site_banner_of,
+            "site_logo": site_logo_of,
+        }
 
-                response_dict = {
-                    **response_dict,
-                    "custom_pages": site_pages,
-                }
-
-            if type(obj) == Image:
-                gallery_cover_image_of = usage_related_set(
-                    self, Gallery, obj.gallery_cover_image.all()
-                )
-                site_banner_of = LinkedSiteSerializer(
-                    obj.site_banner_of, context=self.context
-                ).data
-                site_logo_of = LinkedSiteSerializer(
-                    obj.site_logo_of, context=self.context
-                ).data
-
-                gallery_images = []
-                for gallery_item in obj.gallery_images.all():
-                    gallery_images.append(
-                        usage_related_set(
-                            self, Gallery, gallery_item.gallery, many=False
-                        )
-                    )
-
-                # returning only unique values
-                gallery = list(
-                    {
-                        gallery["id"]: gallery
-                        for gallery in (gallery_cover_image_of + gallery_images)
-                    }.values()
-                )
-
-                response_dict = {
-                    **response_dict,
-                    "gallery": gallery,
-                    "site_banner": site_banner_of,
-                    "site_logo": site_logo_of,
-                }
-
-            total = 0
-
-            for usage in response_dict.values():
-                if isinstance(
-                    usage, list
-                ):  # adding a check as some keys contain objects and not arrays
-                    total += len(usage)
-                else:
-                    total += 1
-
-            response_dict["total"] = total
-
-            return response_dict
-
-    return MediaDetailSerializer
+        del response_dict["total"]
+        response_dict["total"] = get_usages_total(response_dict)
+        return response_dict

--- a/firstvoices/backend/serializers/media_detail_serializers.py
+++ b/firstvoices/backend/serializers/media_detail_serializers.py
@@ -1,0 +1,132 @@
+from rest_framework import serializers
+from rest_framework_nested.serializers import NestedHyperlinkedModelSerializer
+
+from backend.models import Character, DictionaryEntry, Gallery, SitePage, Song, Story
+from backend.models.media import Image, Video
+from backend.serializers.base_serializers import (
+    LinkedSiteSerializer,
+    SiteContentLinkedTitleSerializer,
+)
+from backend.serializers.fields import SiteHyperlinkedIdentityField
+
+
+def usage_related_set(self, model, related_set, many=True):
+    GenericUsageSerializer.Meta.model = model
+    return GenericUsageSerializer(related_set, many=many, context=self.context).data
+
+
+class GenericUsageSerializer(
+    SiteContentLinkedTitleSerializer, NestedHyperlinkedModelSerializer
+):
+    class Meta(SiteContentLinkedTitleSerializer.Meta):
+        model = None
+
+
+class SitePageUsageSerializer(serializers.ModelSerializer):
+    url = SiteHyperlinkedIdentityField(
+        view_name="api:sitepage-detail", lookup_field="slug", read_only=True
+    )
+
+    class Meta:
+        model = SitePage
+        fields = (
+            "id",
+            "url",
+            "title",
+        )
+
+
+def get_media_detail_serializer(base_media_class):
+    class MediaDetailSerializer(base_media_class):
+        usage = serializers.SerializerMethodField()
+
+        class Meta(base_media_class.Meta):
+            fields = base_media_class.Meta.fields + ("usage",)
+
+        def get_usage(self, obj):
+            characters = usage_related_set(self, Character, obj.character_set.all())
+            dictionary_entries = usage_related_set(
+                self, DictionaryEntry, obj.dictionaryentry_set.all()
+            )
+            songs = usage_related_set(self, Song, obj.song_set.all())
+
+            # Returning only stories and not pages, whether the media is on the cover or in any page
+            parent_stories = []
+            for story_page in obj.storypage_set.all():
+                parent_stories.append(
+                    usage_related_set(self, Story, story_page.story, many=False)
+                )
+            story_covers = usage_related_set(self, Story, obj.story_set.all())
+            # Returning only unique values
+            stories = list(
+                {
+                    story["id"]: story for story in (parent_stories + story_covers)
+                }.values()
+            )
+
+            response_dict = {
+                "characters": characters,
+                "dictionary_entries": dictionary_entries,
+                "songs": songs,
+                "stories": stories,
+            }
+
+            if type(obj) in [Image, Video]:
+                site_pages = SitePageUsageSerializer(
+                    obj.sitepage_set.all(), context=self.context, many=True
+                ).data
+
+                response_dict = {
+                    **response_dict,
+                    "custom_pages": site_pages,
+                }
+
+            if type(obj) == Image:
+                gallery_cover_image_of = usage_related_set(
+                    self, Gallery, obj.gallery_cover_image.all()
+                )
+                site_banner_of = LinkedSiteSerializer(
+                    obj.site_banner_of, context=self.context
+                ).data
+                site_logo_of = LinkedSiteSerializer(
+                    obj.site_logo_of, context=self.context
+                ).data
+
+                gallery_images = []
+                for gallery_item in obj.gallery_images.all():
+                    gallery_images.append(
+                        usage_related_set(
+                            self, Gallery, gallery_item.gallery, many=False
+                        )
+                    )
+
+                # returning only unique values
+                gallery = list(
+                    {
+                        gallery["id"]: gallery
+                        for gallery in (gallery_cover_image_of + gallery_images)
+                    }.values()
+                )
+
+                response_dict = {
+                    **response_dict,
+                    "gallery": gallery,
+                    "site_banner": site_banner_of,
+                    "site_logo": site_logo_of,
+                }
+
+            total = 0
+
+            for usage in response_dict.values():
+                if isinstance(
+                    usage, list
+                ):  # adding a check as some keys contain objects and not arrays
+                    total += len(usage)
+                else:
+                    total += 1
+
+            response_dict["total"] = total
+
+            return response_dict
+
+    return MediaDetailSerializer

--- a/firstvoices/backend/serializers/media_detail_serializers.py
+++ b/firstvoices/backend/serializers/media_detail_serializers.py
@@ -27,7 +27,8 @@ def get_usages_total(usages_dict):
             usage, list
         ):  # adding a check as some keys contain objects and not arrays
             total += len(usage)
-        else:
+        elif hasattr(usage, "id"):
+            # If there is a site the image is a banner/logo of
             total += 1
     return total
 
@@ -92,9 +93,7 @@ class BaseUsageFieldMixin(serializers.ModelSerializer):
 
 class VisualMediaUsageFieldMixin(BaseUsageFieldMixin):
     def get_usage(self, obj):
-        response_dict = BaseUsageFieldMixin.get_usage(
-            self, obj
-        )  # Can we do super() here ?
+        response_dict = BaseUsageFieldMixin.get_usage(self, obj)
 
         site_pages = SitePageUsageSerializer(
             obj.sitepage_set.all(), context=self.context, many=True
@@ -129,10 +128,18 @@ class ImageDetailSerializer(VisualMediaUsageFieldMixin, ImageSerializer):
         gallery_cover_image_of = usage_related_set(
             self, Gallery, obj.gallery_cover_image.all()
         )
-        site_banner_of = LinkedSiteSerializer(
-            obj.site_banner_of, context=self.context
-        ).data
-        site_logo_of = LinkedSiteSerializer(obj.site_logo_of, context=self.context).data
+
+        site_banner_of = {}
+        if hasattr(obj, "site_banner_of"):
+            site_banner_of = LinkedSiteSerializer(
+                obj.site_banner_of, context=self.context
+            ).data
+
+        site_logo_of = {}
+        if hasattr(obj, "site_logo_of"):
+            site_logo_of = LinkedSiteSerializer(
+                obj.site_logo_of, context=self.context
+            ).data
 
         gallery_images = []
         for gallery_item in obj.gallery_images.all():

--- a/firstvoices/backend/serializers/page_serializers.py
+++ b/firstvoices/backend/serializers/page_serializers.py
@@ -120,3 +120,18 @@ class SitePageDetailWriteSerializer(WritableControlledSiteContentSerializer):
             "banner_image",
             "banner_video",
         )
+
+
+class SitePageUsageSerializer(serializers.ModelSerializer):
+    # Minimal serializer to fetch details about media usages on any custom page
+    url = SiteHyperlinkedIdentityField(
+        view_name="api:sitepage-detail", lookup_field="slug", read_only=True
+    )
+
+    class Meta:
+        model = SitePage
+        fields = (
+            "id",
+            "url",
+            "title",
+        )

--- a/firstvoices/backend/serializers/utils.py
+++ b/firstvoices/backend/serializers/utils.py
@@ -38,3 +38,17 @@ def get_story_from_context(serializer):
             "The required 'story' property was not found in the serializer context"
         )
         raise APIException
+
+
+def get_usages_total(usages_dict):
+    # Get total count of all objects a media file is used in
+    total = 0
+    for usage in usages_dict.values():
+        if isinstance(
+            usage, list
+        ):  # adding a check as some keys contain objects and not arrays
+            total += len(usage)
+        elif hasattr(usage, "id"):
+            # If there is a site the image is a banner/logo of
+            total += 1
+    return total

--- a/firstvoices/backend/serializers/utils.py
+++ b/firstvoices/backend/serializers/utils.py
@@ -48,7 +48,7 @@ def get_usages_total(usages_dict):
             usage, list
         ):  # adding a check as some keys contain objects and not arrays
             total += len(usage)
-        elif hasattr(usage, "id"):
+        elif isinstance(usage, dict) and "id" in usage:
             # If there is a site the image is a banner/logo of
             total += 1
     return total

--- a/firstvoices/backend/tests/test_apis/base_api_test.py
+++ b/firstvoices/backend/tests/test_apis/base_api_test.py
@@ -156,7 +156,7 @@ class SiteContentListApiTestMixin:
     """
 
     def get_expected_list_response_item(self, instance, site):
-        return self.get_expected_response(instance, site)
+        return self.get_expected_response(instance, site, detail_view=False)
 
     @pytest.mark.django_db
     def test_list_404_site_not_found(self):
@@ -243,7 +243,7 @@ class SiteContentDetailApiTestMixin:
     """
 
     def get_expected_detail_response(self, instance, site):
-        return self.get_expected_response(instance, site)
+        return self.get_expected_response(instance, site, detail_view=True)
 
     def get_expected_standard_fields(self, instance, site):
         return {
@@ -506,7 +506,7 @@ class SiteContentCreateApiTestMixin:
         pk = response_data["id"]
 
         self.assert_created_instance(pk, data)
-        self.assert_created_response(data, response_data)
+        self.assert_created_response(data, response_data, detail_view=False)
 
     @pytest.mark.django_db
     def test_create_with_nulls_success_201(self):
@@ -527,7 +527,7 @@ class SiteContentCreateApiTestMixin:
 
         expected_data = self.add_expected_defaults(data)
         self.assert_created_instance(pk, expected_data)
-        self.assert_created_response(expected_data, response_data)
+        self.assert_created_response(expected_data, response_data, detail_view=False)
 
     def assert_created_instance(self, pk, data):
         raise NotImplementedError()

--- a/firstvoices/backend/tests/test_apis/base_api_test.py
+++ b/firstvoices/backend/tests/test_apis/base_api_test.py
@@ -156,7 +156,7 @@ class SiteContentListApiTestMixin:
     """
 
     def get_expected_list_response_item(self, instance, site):
-        return self.get_expected_response(instance, site, detail_view=False)
+        return self.get_expected_response(instance, site)
 
     @pytest.mark.django_db
     def test_list_404_site_not_found(self):
@@ -243,7 +243,7 @@ class SiteContentDetailApiTestMixin:
     """
 
     def get_expected_detail_response(self, instance, site):
-        return self.get_expected_response(instance, site, detail_view=True)
+        return self.get_expected_response(instance, site)
 
     def get_expected_standard_fields(self, instance, site):
         return {
@@ -506,7 +506,7 @@ class SiteContentCreateApiTestMixin:
         pk = response_data["id"]
 
         self.assert_created_instance(pk, data)
-        self.assert_created_response(data, response_data, detail_view=False)
+        self.assert_created_response(data, response_data)
 
     @pytest.mark.django_db
     def test_create_with_nulls_success_201(self):
@@ -527,7 +527,7 @@ class SiteContentCreateApiTestMixin:
 
         expected_data = self.add_expected_defaults(data)
         self.assert_created_instance(pk, expected_data)
-        self.assert_created_response(expected_data, response_data, detail_view=False)
+        self.assert_created_response(expected_data, response_data)
 
     def assert_created_instance(self, pk, data):
         raise NotImplementedError()

--- a/firstvoices/backend/tests/test_apis/base_media_test.py
+++ b/firstvoices/backend/tests/test_apis/base_media_test.py
@@ -527,14 +527,14 @@ class BaseMediaApiTest(
 
         assert response.status_code == 400
 
-    def add_related_media_to_objects(self, site):
+    def add_related_media_to_objects(self, visibility):
         # Add media file as related media to objects to verify that they show up correctly
         # in usage field when a media item is requested via detail view
         raise NotImplementedError
 
     @pytest.mark.django_db
     def test_usages_field_base(self):
-        expected_data = self.add_related_media_to_objects()
+        expected_data = self.add_related_media_to_objects(visibility=Visibility.PUBLIC)
 
         response = self.client.get(
             self.get_detail_endpoint(

--- a/firstvoices/backend/tests/test_apis/base_media_test.py
+++ b/firstvoices/backend/tests/test_apis/base_media_test.py
@@ -564,9 +564,14 @@ class BaseMediaApiTest(
         # usage in stories
         # Story pages point to the story, so the response here should only contain id's of both stories exactly once
         story_usage = response_data["usage"]["stories"]
+        expected_stories_ids = [
+            str(expected_data["stories"][0].id),
+            str(expected_data["stories"][1].id),
+        ]
+
         assert len(story_usage) == len(expected_data["stories"])
-        assert story_usage[0]["id"] == str(expected_data["stories"][0].id)
-        assert story_usage[1]["id"] == str(expected_data["stories"][1].id)
+        assert story_usage[0]["id"] in expected_stories_ids
+        assert story_usage[1]["id"] in expected_stories_ids
 
         assert response_data["usage"]["total"] == expected_data["total"]
 

--- a/firstvoices/backend/tests/test_apis/base_media_test.py
+++ b/firstvoices/backend/tests/test_apis/base_media_test.py
@@ -570,6 +570,28 @@ class BaseMediaApiTest(
 
         assert response_data["usage"]["total"] == expected_data["total"]
 
+    @pytest.mark.django_db
+    def test_usages_field_permissions(self):
+        expected_data = self.add_related_media_to_objects(visibility=Visibility.TEAM)
+
+        response = self.client.get(
+            self.get_detail_endpoint(
+                key=expected_data["media_instance"].id,
+                site_slug=expected_data["site"].slug,
+            )
+        )
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+
+        # Characters visibility depends on the site's visibility, PUBLIC in this case
+        assert len(response_data["usage"]["characters"]) == 1
+
+        # controlled content should be available
+        assert len(response_data["usage"]["dictionaryEntries"]) == 0
+        assert len(response_data["usage"]["songs"]) == 0
+        assert len(response_data["usage"]["stories"]) == 0
+
 
 class BaseVisualMediaAPITest(BaseMediaApiTest):
     @pytest.fixture()

--- a/firstvoices/backend/tests/test_apis/base_media_test.py
+++ b/firstvoices/backend/tests/test_apis/base_media_test.py
@@ -385,47 +385,6 @@ class BaseMediaApiTest(
     def get_expected_list_response_item(self, instance, site):
         return self.get_expected_response(instance, site, detail_view=False)
 
-    @pytest.mark.django_db
-    def test_create_success_201(self):
-        site = self.create_site_with_app_admin(Visibility.PUBLIC)
-
-        data = self.get_valid_data(site)
-
-        response = self.client.post(
-            self.get_list_endpoint(site_slug=site.slug),
-            data=self.format_upload_data(data),
-            content_type=self.content_type,
-        )
-
-        assert response.status_code == 201
-
-        response_data = json.loads(response.content)
-        pk = response_data["id"]
-
-        self.assert_created_instance(pk, data)
-        self.assert_created_response(data, response_data, detail_view=False)
-
-    @pytest.mark.django_db
-    def test_create_with_nulls_success_201(self):
-        site = self.create_site_with_app_admin(Visibility.PUBLIC)
-
-        data = self.get_valid_data_with_nulls(site)
-
-        response = self.client.post(
-            self.get_list_endpoint(site_slug=site.slug),
-            data=self.format_upload_data(data),
-            content_type=self.content_type,
-        )
-
-        assert response.status_code == 201
-
-        response_data = json.loads(response.content)
-        pk = response_data["id"]
-
-        expected_data = self.add_expected_defaults(data)
-        self.assert_created_instance(pk, expected_data)
-        self.assert_created_response(expected_data, response_data, detail_view=False)
-
     def get_valid_data(self, site=None):
         """Returns a valid data object suitable for create/update requests"""
         return {

--- a/firstvoices/backend/tests/test_apis/base_media_test.py
+++ b/firstvoices/backend/tests/test_apis/base_media_test.py
@@ -47,12 +47,12 @@ class MediaTestMixin:
             None,
         )
 
-    def get_basic_media_data(self, instance, view_name):
+    def get_basic_media_data(self, instance, view_name, detail_view):
         url = reverse(
             view_name, current_app=self.APP_NAME, args=[instance.site.slug, instance.id]
         )
 
-        return {
+        data = {
             "id": str(instance.id),
             "url": f"http://testserver{url}",
             "title": instance.title,
@@ -61,6 +61,19 @@ class MediaTestMixin:
             "excludeFromGames": instance.exclude_from_games,
             "excludeFromKids": instance.exclude_from_kids,
         }
+        if detail_view:
+            data["usage"] = {
+                "characters": [],
+                "dictionaryEntries": [],
+                "songs": [],
+                "stories": [],
+                "customPages": [],
+                "gallery": [],
+                "siteBanner": {},
+                "siteLogo": {},
+                "total": 0,
+            }
+        return data
 
     def get_file_data(self, file):
         return {
@@ -86,8 +99,10 @@ class MediaTestMixin:
             "medium": self.get_visual_file_data(instance.medium),
         }
 
-    def get_visual_media_data(self, instance, view_name):
-        data = self.get_basic_media_data(instance, view_name=view_name)
+    def get_visual_media_data(self, instance, view_name, detail_view):
+        data = self.get_basic_media_data(
+            instance, view_name=view_name, detail_view=detail_view
+        )
         thumbnail_data = self.get_media_thumbnail_data(instance)
         return {
             **data,
@@ -95,11 +110,15 @@ class MediaTestMixin:
             "original": self.get_visual_file_data(instance.original),
         }
 
-    def get_expected_image_data(self, instance):
-        return self.get_visual_media_data(instance, view_name="api:image-detail")
+    def get_expected_image_data(self, instance, detail_view):
+        return self.get_visual_media_data(
+            instance, view_name="api:image-detail", detail_view=detail_view
+        )
 
-    def get_expected_video_data(self, instance):
-        return self.get_visual_media_data(instance, view_name="api:video-detail")
+    def get_expected_video_data(self, instance, detail_view):
+        return self.get_visual_media_data(
+            instance, view_name="api:video-detail", detail_view=detail_view
+        )
 
     def get_expected_audio_data(self, instance, speaker):
         data = self.get_basic_media_data(instance, view_name="api:audio-detail")

--- a/firstvoices/backend/tests/test_apis/test_audio_api.py
+++ b/firstvoices/backend/tests/test_apis/test_audio_api.py
@@ -266,8 +266,7 @@ class TestAudioEndpoint(BaseMediaApiTest):
             },
         )
 
-    @pytest.mark.django_db
-    def test_usages_field_base(self):
+    def add_related_media_to_objects(self):
         site = self.create_site_with_app_admin(Visibility.PUBLIC)
         instance = self.create_minimal_instance(site, visibility=Visibility.PUBLIC)
 
@@ -280,24 +279,24 @@ class TestAudioEndpoint(BaseMediaApiTest):
         song = factories.SongFactory(site=site)
         song.related_audio.add(instance)
 
-        response = self.client.get(
-            self.get_detail_endpoint(key=instance.id, site_slug=site.slug)
-        )
+        story_1 = factories.StoryFactory(site=site)
+        story_1.related_audio.add(instance)
 
-        assert response.status_code == 200
-        response_data = json.loads(response.content)
+        story_page_1 = factories.StoryPageFactory(site=site, story=story_1)
+        story_page_1.related_audio.add(instance)
 
-        # usage in characters
-        character_usage = response_data["usage"]["characters"]
-        assert len(character_usage) == 1
-        assert character_usage[0]["id"] == str(character.id)
+        story_2 = factories.StoryFactory(site=site)
+        story_page_2 = factories.StoryPageFactory(site=site, story=story_2)
+        story_page_2.related_audio.add(instance)
 
-        # usage in dictionary entries
-        dict_entry_usage = response_data["usage"]["dictionaryEntries"]
-        assert len(dict_entry_usage) == 1
-        assert dict_entry_usage[0]["id"] == str(dict_entry.id)
+        total = 5
 
-        # usage in songs
-        song_usage = response_data["usage"]["songs"]
-        assert len(song_usage) == 1
-        assert song_usage[0]["id"] == str(song.id)
+        return {
+            "site": site,
+            "media_instance": instance,
+            "character": character,
+            "dict_entry": dict_entry,
+            "song": song,
+            "stories": [story_1, story_2],
+            "total": total,
+        }

--- a/firstvoices/backend/tests/test_apis/test_audio_api.py
+++ b/firstvoices/backend/tests/test_apis/test_audio_api.py
@@ -266,27 +266,35 @@ class TestAudioEndpoint(BaseMediaApiTest):
             },
         )
 
-    def add_related_media_to_objects(self):
-        site = self.create_site_with_app_admin(Visibility.PUBLIC)
-        instance = self.create_minimal_instance(site, visibility=Visibility.PUBLIC)
+    def add_related_media_to_objects(self, visibility=Visibility.PUBLIC):
+        if visibility == Visibility.TEAM:
+            site = self.create_site_with_non_member(Visibility.PUBLIC)
+        else:
+            site = self.create_site_with_app_admin(Visibility.PUBLIC)
+
+        instance = self.create_minimal_instance(site, visibility)
 
         character = factories.CharacterFactory(site=site, title="a", sort_order=1)
         character.related_audio.add(instance)
 
-        dict_entry = factories.DictionaryEntryFactory(site=site)
+        dict_entry = factories.DictionaryEntryFactory(site=site, visibility=visibility)
         dict_entry.related_audio.add(instance)
 
-        song = factories.SongFactory(site=site)
+        song = factories.SongFactory(site=site, visibility=visibility)
         song.related_audio.add(instance)
 
-        story_1 = factories.StoryFactory(site=site)
+        story_1 = factories.StoryFactory(site=site, visibility=visibility)
         story_1.related_audio.add(instance)
 
-        story_page_1 = factories.StoryPageFactory(site=site, story=story_1)
+        story_page_1 = factories.StoryPageFactory(
+            site=site, story=story_1, visibility=visibility
+        )
         story_page_1.related_audio.add(instance)
 
-        story_2 = factories.StoryFactory(site=site)
-        story_page_2 = factories.StoryPageFactory(site=site, story=story_2)
+        story_2 = factories.StoryFactory(site=site, visibility=visibility)
+        story_page_2 = factories.StoryPageFactory(
+            site=site, story=story_2, visibility=visibility
+        )
         story_page_2.related_audio.add(instance)
 
         total = 5

--- a/firstvoices/backend/tests/test_apis/test_audio_api.py
+++ b/firstvoices/backend/tests/test_apis/test_audio_api.py
@@ -55,9 +55,7 @@ class TestAudioEndpoint(BaseMediaApiTest):
 
         assert response.status_code == 200
         response_data = json.loads(response.content)
-        assert response_data == self.get_expected_audio_data(
-            instance, speaker, detail_view=True
-        )
+        assert response_data == self.get_expected_audio_data(instance, speaker, True)
 
     def assert_related_objects_deleted(self, instance):
         self.assert_instance_deleted(instance.original)

--- a/firstvoices/backend/tests/test_apis/test_audio_api.py
+++ b/firstvoices/backend/tests/test_apis/test_audio_api.py
@@ -62,10 +62,12 @@ class TestAudioEndpoint(BaseMediaApiTest):
     def assert_related_objects_deleted(self, instance):
         self.assert_instance_deleted(instance.original)
 
-    def assert_created_response(self, expected_data, actual_response, detail_view):
+    def assert_created_response(
+        self, expected_data, actual_response, detail_view=False
+    ):
         instance = Audio.objects.get(pk=actual_response["id"])
         assert actual_response == self.get_expected_audio_data(
-            instance, None, detail_view=detail_view
+            instance, None, detail_view
         )
 
     @pytest.mark.django_db

--- a/firstvoices/backend/tests/test_apis/test_audio_api.py
+++ b/firstvoices/backend/tests/test_apis/test_audio_api.py
@@ -37,8 +37,10 @@ class TestAudioEndpoint(BaseMediaApiTest):
         audio.save()
         return audio
 
-    def get_expected_response(self, instance, site):
-        return self.get_expected_audio_data(instance, speaker=None)
+    def get_expected_response(self, instance, site, detail_view):
+        return self.get_expected_audio_data(
+            instance, speaker=None, detail_view=detail_view
+        )
 
     @pytest.mark.django_db
     def test_detail_with_speakers(self):
@@ -53,14 +55,18 @@ class TestAudioEndpoint(BaseMediaApiTest):
 
         assert response.status_code == 200
         response_data = json.loads(response.content)
-        assert response_data == self.get_expected_audio_data(instance, speaker)
+        assert response_data == self.get_expected_audio_data(
+            instance, speaker, detail_view=True
+        )
 
     def assert_related_objects_deleted(self, instance):
         self.assert_instance_deleted(instance.original)
 
-    def assert_created_response(self, expected_data, actual_response):
+    def assert_created_response(self, expected_data, actual_response, detail_view):
         instance = Audio.objects.get(pk=actual_response["id"])
-        assert actual_response == self.get_expected_audio_data(instance, None)
+        assert actual_response == self.get_expected_audio_data(
+            instance, None, detail_view=detail_view
+        )
 
     @pytest.mark.django_db
     def test_create_with_speakers(self):

--- a/firstvoices/backend/tests/test_apis/test_images_api.py
+++ b/firstvoices/backend/tests/test_apis/test_images_api.py
@@ -35,12 +35,12 @@ class TestImagesEndpoint(BaseVisualMediaAPITest):
         image.save()
         return image
 
-    def get_expected_response(self, instance, site):
-        return self.get_expected_image_data(instance)
+    def get_expected_response(self, instance, site, detail_view=False):
+        return self.get_expected_image_data(instance, detail_view)
 
-    def assert_created_response(self, expected_data, actual_response):
+    def assert_created_response(self, expected_data, actual_response, detail_view):
         instance = Image.objects.get(pk=actual_response["id"])
-        expected = self.get_expected_image_data(instance)
+        expected = self.get_expected_image_data(instance, detail_view=detail_view)
         for ignored_field in ("thumbnail", "small", "medium"):
             if ignored_field in actual_response:
                 actual_response.pop(ignored_field)

--- a/firstvoices/backend/tests/test_apis/test_images_api.py
+++ b/firstvoices/backend/tests/test_apis/test_images_api.py
@@ -38,9 +38,11 @@ class TestImagesEndpoint(BaseVisualMediaAPITest):
     def get_expected_response(self, instance, site, detail_view):
         return self.get_expected_image_data(instance, detail_view)
 
-    def assert_created_response(self, expected_data, actual_response, detail_view):
+    def assert_created_response(
+        self, expected_data, actual_response, detail_view=False
+    ):
         instance = Image.objects.get(pk=actual_response["id"])
-        expected = self.get_expected_image_data(instance, detail_view=detail_view)
+        expected = self.get_expected_image_data(instance, detail_view)
         for ignored_field in ("thumbnail", "small", "medium"):
             if ignored_field in actual_response:
                 actual_response.pop(ignored_field)

--- a/firstvoices/backend/tests/test_apis/test_images_api.py
+++ b/firstvoices/backend/tests/test_apis/test_images_api.py
@@ -124,7 +124,7 @@ class TestImagesEndpoint(BaseVisualMediaAPITest):
 
     @pytest.mark.django_db
     def test_usages_field_extra_fields(self):
-        expected_data = self.add_related_media_to_objects()
+        expected_data = self.add_related_media_to_objects(visibility=Visibility.PUBLIC)
 
         custom_page = factories.SitePageFactory(
             site=expected_data["site"], banner_image=expected_data["media_instance"]

--- a/firstvoices/backend/tests/test_apis/test_images_api.py
+++ b/firstvoices/backend/tests/test_apis/test_images_api.py
@@ -35,7 +35,7 @@ class TestImagesEndpoint(BaseVisualMediaAPITest):
         image.save()
         return image
 
-    def get_expected_response(self, instance, site, detail_view=False):
+    def get_expected_response(self, instance, site, detail_view):
         return self.get_expected_image_data(instance, detail_view)
 
     def assert_created_response(self, expected_data, actual_response, detail_view):

--- a/firstvoices/backend/tests/test_apis/test_images_api.py
+++ b/firstvoices/backend/tests/test_apis/test_images_api.py
@@ -79,3 +79,92 @@ class TestImagesEndpoint(BaseVisualMediaAPITest):
         # Check that old files have been deleted
         assert ImageFile.objects.count() == 4
         assert not ImageFile.objects.filter(id=old_original_file_id).exists()
+
+    def add_related_media_to_objects(self):
+        site = self.create_site_with_app_admin(Visibility.PUBLIC)
+        instance = self.create_minimal_instance(site, visibility=Visibility.PUBLIC)
+
+        character = factories.CharacterFactory(site=site, title="a", sort_order=1)
+        character.related_images.add(instance)
+
+        dict_entry = factories.DictionaryEntryFactory(site=site)
+        dict_entry.related_images.add(instance)
+
+        song = factories.SongFactory(site=site)
+        song.related_images.add(instance)
+
+        story_1 = factories.StoryFactory(site=site)
+        story_1.related_images.add(instance)
+
+        story_page_1 = factories.StoryPageFactory(site=site, story=story_1)
+        story_page_1.related_images.add(instance)
+
+        story_2 = factories.StoryFactory(site=site)
+        story_page_2 = factories.StoryPageFactory(site=site, story=story_2)
+        story_page_2.related_images.add(instance)
+
+        total = 5
+
+        return {
+            "site": site,
+            "media_instance": instance,
+            "character": character,
+            "dict_entry": dict_entry,
+            "song": song,
+            "stories": [story_1, story_2],
+            "total": total,
+        }
+
+    @pytest.mark.django_db
+    def test_usages_field_extra_fields(self):
+        expected_data = self.add_related_media_to_objects()
+
+        custom_page = factories.SitePageFactory(
+            site=expected_data["site"], banner_image=expected_data["media_instance"]
+        )
+
+        # logo and banner
+        expected_data["site"].logo = expected_data["media_instance"]
+        expected_data["site"].banner_image = expected_data["media_instance"]
+        expected_data["site"].save()
+
+        # Gallery
+        gallery = factories.GalleryFactory(
+            site=expected_data["site"], cover_image=expected_data["media_instance"]
+        )
+        factories.GalleryItemFactory(
+            gallery=gallery, image=expected_data["media_instance"]
+        )
+
+        gallery_2 = factories.GalleryFactory(
+            site=expected_data["site"], cover_image=expected_data["media_instance"]
+        )
+
+        response = self.client.get(
+            self.get_detail_endpoint(
+                key=expected_data["media_instance"].id,
+                site_slug=expected_data["site"].slug,
+            )
+        )
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+
+        # usage in custom pages
+        custom_pages = response_data["usage"]["customPages"]
+        assert len(custom_pages) == 1
+        assert custom_pages[0]["id"] == str(custom_page.id)
+
+        # usage in sites
+        assert response_data["usage"]["siteBanner"]["id"] == str(
+            expected_data["site"].id
+        )
+        assert response_data["usage"]["siteLogo"]["id"] == str(expected_data["site"].id)
+
+        # usage in gallery
+        # should only return unique galleries, and gallery items should point to parent gallery
+        gallery_usage = response_data["usage"]["gallery"]
+        assert len(gallery_usage) == 2
+        assert gallery_usage[0]["id"] == str(gallery.id)
+        assert gallery_usage[1]["id"] == str(gallery_2.id)
+
+        assert response_data["usage"]["total"] == expected_data["total"] + 5

--- a/firstvoices/backend/tests/test_apis/test_images_api.py
+++ b/firstvoices/backend/tests/test_apis/test_images_api.py
@@ -80,27 +80,34 @@ class TestImagesEndpoint(BaseVisualMediaAPITest):
         assert ImageFile.objects.count() == 4
         assert not ImageFile.objects.filter(id=old_original_file_id).exists()
 
-    def add_related_media_to_objects(self):
-        site = self.create_site_with_app_admin(Visibility.PUBLIC)
+    def add_related_media_to_objects(self, visibility=Visibility.PUBLIC):
+        if visibility == Visibility.TEAM:
+            site = self.create_site_with_non_member(Visibility.PUBLIC)
+        else:
+            site = self.create_site_with_app_admin(Visibility.PUBLIC)
         instance = self.create_minimal_instance(site, visibility=Visibility.PUBLIC)
 
         character = factories.CharacterFactory(site=site, title="a", sort_order=1)
         character.related_images.add(instance)
 
-        dict_entry = factories.DictionaryEntryFactory(site=site)
+        dict_entry = factories.DictionaryEntryFactory(site=site, visibility=visibility)
         dict_entry.related_images.add(instance)
 
-        song = factories.SongFactory(site=site)
+        song = factories.SongFactory(site=site, visibility=visibility)
         song.related_images.add(instance)
 
-        story_1 = factories.StoryFactory(site=site)
+        story_1 = factories.StoryFactory(site=site, visibility=visibility)
         story_1.related_images.add(instance)
 
-        story_page_1 = factories.StoryPageFactory(site=site, story=story_1)
+        story_page_1 = factories.StoryPageFactory(
+            site=site, story=story_1, visibility=visibility
+        )
         story_page_1.related_images.add(instance)
 
-        story_2 = factories.StoryFactory(site=site)
-        story_page_2 = factories.StoryPageFactory(site=site, story=story_2)
+        story_2 = factories.StoryFactory(site=site, visibility=visibility)
+        story_page_2 = factories.StoryPageFactory(
+            site=site, story=story_2, visibility=visibility
+        )
         story_page_2.related_images.add(instance)
 
         total = 5

--- a/firstvoices/backend/tests/test_apis/test_videos_api.py
+++ b/firstvoices/backend/tests/test_apis/test_videos_api.py
@@ -125,7 +125,7 @@ class TestVideosEndpoint(BaseVisualMediaAPITest):
 
     @pytest.mark.django_db
     def test_usages_field_extra_fields(self):
-        expected_data = self.add_related_media_to_objects()
+        expected_data = self.add_related_media_to_objects(visibility=Visibility.PUBLIC)
 
         custom_page = factories.SitePageFactory(
             site=expected_data["site"], banner_video=expected_data["media_instance"]

--- a/firstvoices/backend/tests/test_apis/test_videos_api.py
+++ b/firstvoices/backend/tests/test_apis/test_videos_api.py
@@ -35,12 +35,12 @@ class TestVideosEndpoint(BaseVisualMediaAPITest):
         video.save()
         return video
 
-    def get_expected_response(self, instance, site):
-        return self.get_expected_video_data(instance)
+    def get_expected_response(self, instance, site, detail_view):
+        return self.get_expected_video_data(instance, detail_view)
 
-    def assert_created_response(self, expected_data, actual_response):
+    def assert_created_response(self, expected_data, actual_response, detail_view):
         instance = Video.objects.get(pk=actual_response["id"])
-        expected = self.get_expected_video_data(instance)
+        expected = self.get_expected_video_data(instance, detail_view=detail_view)
 
         for ignored_field in ("thumbnail", "small", "medium"):
             if ignored_field in actual_response:

--- a/firstvoices/backend/tests/test_apis/test_videos_api.py
+++ b/firstvoices/backend/tests/test_apis/test_videos_api.py
@@ -81,27 +81,34 @@ class TestVideosEndpoint(BaseVisualMediaAPITest):
         assert VideoFile.objects.count() == 1
         assert not VideoFile.objects.filter(id=old_original_file_id).exists()
 
-    def add_related_media_to_objects(self):
-        site = self.create_site_with_app_admin(Visibility.PUBLIC)
+    def add_related_media_to_objects(self, visibility=Visibility.PUBLIC):
+        if visibility == Visibility.TEAM:
+            site = self.create_site_with_non_member(Visibility.PUBLIC)
+        else:
+            site = self.create_site_with_app_admin(Visibility.PUBLIC)
         instance = self.create_minimal_instance(site, visibility=Visibility.PUBLIC)
 
         character = factories.CharacterFactory(site=site, title="a", sort_order=1)
         character.related_videos.add(instance)
 
-        dict_entry = factories.DictionaryEntryFactory(site=site)
+        dict_entry = factories.DictionaryEntryFactory(site=site, visibility=visibility)
         dict_entry.related_videos.add(instance)
 
-        song = factories.SongFactory(site=site)
+        song = factories.SongFactory(site=site, visibility=visibility)
         song.related_videos.add(instance)
 
-        story_1 = factories.StoryFactory(site=site)
+        story_1 = factories.StoryFactory(site=site, visibility=visibility)
         story_1.related_videos.add(instance)
 
-        story_page_1 = factories.StoryPageFactory(site=site, story=story_1)
+        story_page_1 = factories.StoryPageFactory(
+            site=site, story=story_1, visibility=visibility
+        )
         story_page_1.related_videos.add(instance)
 
-        story_2 = factories.StoryFactory(site=site)
-        story_page_2 = factories.StoryPageFactory(site=site, story=story_2)
+        story_2 = factories.StoryFactory(site=site, visibility=visibility)
+        story_page_2 = factories.StoryPageFactory(
+            site=site, story=story_2, visibility=visibility
+        )
         story_page_2.related_videos.add(instance)
 
         total = 5
@@ -139,3 +146,25 @@ class TestVideosEndpoint(BaseVisualMediaAPITest):
         assert custom_pages[0]["id"] == str(custom_page.id)
 
         assert response_data["usage"]["total"] == expected_data["total"] + 1
+
+    @pytest.mark.django_db
+    def test_usages_field_permissions_extra_fields(self):
+        expected_data = self.add_related_media_to_objects(visibility=Visibility.TEAM)
+
+        factories.SitePageFactory(
+            site=expected_data["site"],
+            banner_video=expected_data["media_instance"],
+            visibility=Visibility.TEAM,
+        )
+
+        response = self.client.get(
+            self.get_detail_endpoint(
+                key=expected_data["media_instance"].id,
+                site_slug=expected_data["site"].slug,
+            )
+        )
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+
+        assert len(response_data["usage"]["customPages"]) == 0

--- a/firstvoices/backend/tests/test_apis/test_videos_api.py
+++ b/firstvoices/backend/tests/test_apis/test_videos_api.py
@@ -38,9 +38,11 @@ class TestVideosEndpoint(BaseVisualMediaAPITest):
     def get_expected_response(self, instance, site, detail_view):
         return self.get_expected_video_data(instance, detail_view)
 
-    def assert_created_response(self, expected_data, actual_response, detail_view):
+    def assert_created_response(
+        self, expected_data, actual_response, detail_view=False
+    ):
         instance = Video.objects.get(pk=actual_response["id"])
-        expected = self.get_expected_video_data(instance, detail_view=detail_view)
+        expected = self.get_expected_video_data(instance, detail_view)
 
         for ignored_field in ("thumbnail", "small", "medium"):
             if ignored_field in actual_response:

--- a/firstvoices/backend/views/audio_views.py
+++ b/firstvoices/backend/views/audio_views.py
@@ -3,7 +3,7 @@ from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_
 from rest_framework import parsers, viewsets
 
 from backend.models.media import Audio
-from backend.serializers.media_detail_serializers import get_media_detail_serializer
+from backend.serializers.media_detail_serializers import AudioDetailSerializer
 from backend.serializers.media_serializers import AudioSerializer
 from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSetMixin
 
@@ -91,5 +91,5 @@ class AudioViewSet(
 
     def get_serializer_class(self):
         if self.action == "retrieve":
-            return get_media_detail_serializer(AudioSerializer)
+            return AudioDetailSerializer
         return AudioSerializer

--- a/firstvoices/backend/views/audio_views.py
+++ b/firstvoices/backend/views/audio_views.py
@@ -3,6 +3,7 @@ from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_
 from rest_framework import parsers, viewsets
 
 from backend.models.media import Audio
+from backend.serializers.media_detail_serializers import get_media_detail_serializer
 from backend.serializers.media_serializers import AudioSerializer
 from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSetMixin
 
@@ -87,3 +88,8 @@ class AudioViewSet(
                 "last_modified",
             )
         )
+
+    def get_serializer_class(self):
+        if self.action == "retrieve":
+            return get_media_detail_serializer(AudioSerializer)
+        return AudioSerializer

--- a/firstvoices/backend/views/image_views.py
+++ b/firstvoices/backend/views/image_views.py
@@ -3,7 +3,7 @@ from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_
 from rest_framework import parsers, viewsets
 
 from backend.models.media import Image
-from backend.serializers.media_detail_serializers import get_media_detail_serializer
+from backend.serializers.media_detail_serializers import ImageDetailSerializer
 from backend.serializers.media_serializers import ImageSerializer
 from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSetMixin
 
@@ -92,5 +92,5 @@ class ImageViewSet(
 
     def get_serializer_class(self):
         if self.action == "retrieve":
-            return get_media_detail_serializer(ImageSerializer)
+            return ImageDetailSerializer
         return ImageSerializer

--- a/firstvoices/backend/views/image_views.py
+++ b/firstvoices/backend/views/image_views.py
@@ -3,6 +3,7 @@ from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_
 from rest_framework import parsers, viewsets
 
 from backend.models.media import Image
+from backend.serializers.media_detail_serializers import get_media_detail_serializer
 from backend.serializers.media_serializers import ImageSerializer
 from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSetMixin
 
@@ -88,3 +89,8 @@ class ImageViewSet(
                 "last_modified",
             )
         )
+
+    def get_serializer_class(self):
+        if self.action == "retrieve":
+            return get_media_detail_serializer(ImageSerializer)
+        return ImageSerializer

--- a/firstvoices/backend/views/video_views.py
+++ b/firstvoices/backend/views/video_views.py
@@ -3,6 +3,7 @@ from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_
 from rest_framework import parsers, viewsets
 
 from backend.models.media import Video
+from backend.serializers.media_detail_serializers import get_media_detail_serializer
 from backend.serializers.media_serializers import VideoSerializer
 from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSetMixin
 
@@ -88,3 +89,8 @@ class VideoViewSet(
                 "last_modified",
             )
         )
+
+    def get_serializer_class(self):
+        if self.action == "retrieve":
+            return get_media_detail_serializer(VideoSerializer)
+        return VideoSerializer

--- a/firstvoices/backend/views/video_views.py
+++ b/firstvoices/backend/views/video_views.py
@@ -3,7 +3,7 @@ from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_
 from rest_framework import parsers, viewsets
 
 from backend.models.media import Video
-from backend.serializers.media_detail_serializers import get_media_detail_serializer
+from backend.serializers.media_detail_serializers import VideoDetailSerializer
 from backend.serializers.media_serializers import VideoSerializer
 from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSetMixin
 
@@ -92,5 +92,5 @@ class VideoViewSet(
 
     def get_serializer_class(self):
         if self.action == "retrieve":
-            return get_media_detail_serializer(VideoSerializer)
+            return VideoDetailSerializer
         return VideoSerializer


### PR DESCRIPTION
### Description of Changes
- media detail view now returns a `usage` field which contains instances where the media is used

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Team Postman workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [x] Pull the branch and test locally

### Additional Notes
N/A
