### PR TITLE
fw-5529, handle hidden sites in views and serializers

### DIFF
--- a/firstvoices/backend/models/sites.py
+++ b/firstvoices/backend/models/sites.py
@@ -26,6 +26,16 @@ class LanguageFamilyManager(PermissionsManager):
         return self.get(title=title)
 
 
+class SiteManager(PermissionsManager):
+    def explorable(self):
+        """Returns instances that are suitable for listing in a directory of Sites."""
+        return (
+            self.get_queryset()
+            .filter(visibility__gte=Visibility.MEMBERS)
+            .filter(is_hidden=False)
+        )
+
+
 class LanguageFamily(BaseModel):
     """
     Represents a Language Family.
@@ -93,6 +103,8 @@ class Site(BaseModel):
     """
 
     # from fvdialect type
+
+    objects = SiteManager()
 
     class Meta:
         verbose_name = _("site")

--- a/firstvoices/backend/search/indexing/language_index.py
+++ b/firstvoices/backend/search/indexing/language_index.py
@@ -14,11 +14,7 @@ class LanguageDocumentManager(DocumentManager):
     @classmethod
     def create_index_document(cls, instance: Language):
         """Returns a LanguageDocument populated for the given Language instance."""
-        visible_sites = (
-            instance.sites.all()
-            .filter(visibility__gte=Visibility.MEMBERS)
-            .filter(is_hidden=False)
-        )
+        visible_sites = instance.sites.explorable()
 
         return cls.document(
             document_id=str(instance.id),
@@ -42,9 +38,7 @@ class LanguageDocumentManager(DocumentManager):
         Conditions for indexing a Language:
          * has at least one non-hidden Site with visibility of Members or Public
         """
-        visible_sites = instance.sites.filter(
-            visibility__gte=Visibility.MEMBERS
-        ).filter(is_hidden=False)
+        visible_sites = instance.sites.explorable()
         return visible_sites.exists()
 
 

--- a/firstvoices/backend/tests/test_apis/test_languages_api.py
+++ b/firstvoices/backend/tests/test_apis/test_languages_api.py
@@ -136,6 +136,9 @@ class TestLanguagesEndpoints(MediaTestMixin, SearchMocksMixin, BaseApiTest):
             language=language, visibility=Visibility.MEMBERS
         )
         site_team = factories.SiteFactory(language=language, visibility=Visibility.TEAM)
+        site_hidden = factories.SiteFactory(
+            language=language, visibility=Visibility.PUBLIC, is_hidden=True
+        )
 
         response = getattr(self, get_response)(mock_search_query_execute, [language])
 
@@ -147,6 +150,7 @@ class TestLanguagesEndpoints(MediaTestMixin, SearchMocksMixin, BaseApiTest):
         assert str(site_public.id) in site_id_list
         assert str(site_members.id) in site_id_list
         assert str(site_team.id) not in site_id_list
+        assert str(site_hidden.id) not in site_id_list
 
     @pytest.mark.parametrize(
         "get_response", ["get_list_response", "get_search_response"]
@@ -252,13 +256,11 @@ class TestLanguagesEndpoints(MediaTestMixin, SearchMocksMixin, BaseApiTest):
 
         language_response = response_data["results"][0]
         self.assert_language_response(language, language_response)
-
         assert len(language_response["sites"]) == 1
         self.assert_site_response(site, language_response["sites"][0])
 
         more_sites_response = response_data["results"][1]
         self.assert_language_placeholder_response(more_sites_response)
-
         assert len(more_sites_response["sites"]) == 1
         self.assert_site_response(site2, more_sites_response["sites"][0])
 
@@ -305,6 +307,9 @@ class TestLanguagesEndpoints(MediaTestMixin, SearchMocksMixin, BaseApiTest):
             language=None, visibility=Visibility.MEMBERS
         )
         site_team = factories.SiteFactory(language=None, visibility=Visibility.TEAM)
+        site_hidden = factories.SiteFactory(
+            language=None, visibility=Visibility.PUBLIC, is_hidden=True
+        )
 
         response = self.get_list_response(mock_search_query_execute, [])
 
@@ -313,9 +318,12 @@ class TestLanguagesEndpoints(MediaTestMixin, SearchMocksMixin, BaseApiTest):
         response_data = json.loads(response.content)
         site_id_list = [site["id"] for site in response_data["results"][0]["sites"]]
         assert len(site_id_list) == 2
+
         assert str(site_public.id) in site_id_list
         assert str(site_members.id) in site_id_list
+
         assert str(site_team.id) not in site_id_list
+        assert str(site_hidden.id) not in site_id_list
 
     @pytest.mark.django_db
     def test_search_mixed_sites_and_languages(self, db, mock_search_query_execute):

--- a/firstvoices/backend/views/search_languages_views.py
+++ b/firstvoices/backend/views/search_languages_views.py
@@ -7,7 +7,6 @@ from drf_spectacular.utils import (
 )
 from elasticsearch_dsl import Q, Search
 
-from backend.models.constants import Visibility
 from backend.models.sites import Language, Site
 from backend.search.queries.text_matching import (
     exact_match,
@@ -124,7 +123,7 @@ class LanguageViewSet(ThrottlingMixin, BaseSearchViewSet):
 
     def make_queryset_eager(self, model_name, queryset):
         if model_name == "Language":
-            visible_sites = Site.objects.filter(visibility__gte=Visibility.MEMBERS)
+            visible_sites = Site.objects.explorable()
             return LanguageSerializer.make_queryset_eager(
                 queryset, visible_sites=visible_sites
             )
@@ -148,9 +147,7 @@ class LanguageViewSet(ThrottlingMixin, BaseSearchViewSet):
         return serialized_data
 
     def get_other_sites_data(self):
-        other_sites = Site.objects.filter(visibility__gte=Visibility.MEMBERS).filter(
-            language=None
-        )
+        other_sites = Site.objects.explorable().filter(language=None)
 
         if other_sites:
             queryset = LanguagePlaceholderSerializer.make_queryset_eager(other_sites)


### PR DESCRIPTION
### Description of Changes
* Added a standard filter for "explorable" sites in a new manager for the Site model, to keep this info in one place

### Checklist
- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
