### PR TITLE
fw-5587, prevent adding duplicate items to search index

### DIFF
--- a/firstvoices/backend/search/signals/dictionary_entry_signals.py
+++ b/firstvoices/backend/search/signals/dictionary_entry_signals.py
@@ -1,4 +1,4 @@
-from django.db.models.signals import post_delete, post_save
+from django.db.models.signals import m2m_changed, post_delete, post_save
 from django.dispatch import receiver
 
 from backend.models.dictionary import (
@@ -12,6 +12,7 @@ from backend.search.indexing.dictionary_index import DictionaryEntryDocumentMana
 from backend.search.tasks.index_manager_tasks import (
     request_remove_from_index,
     request_sync_in_index,
+    request_update_in_index,
 )
 
 
@@ -33,9 +34,16 @@ def remove_dictionary_entry_from_index(sender, instance, **kwargs):
 @receiver(post_save, sender=Acknowledgement)
 @receiver(
     post_save, sender=DictionaryEntryCategory
-)  # Category update when called through the admin site
+)  # Category update via creating m2m model (admin site does this)
 @receiver(
     post_delete, sender=DictionaryEntryCategory
-)  # Category update when called through the admin site
+)  # Category update via creating m2m model (admin site does this)
 def sync_related_dictionary_entry_in_index(sender, instance, **kwargs):
-    request_sync_in_index(DictionaryEntryDocumentManager, instance.dictionary_entry)
+    request_update_in_index(DictionaryEntryDocumentManager, instance.dictionary_entry)
+
+
+@receiver(
+    m2m_changed, sender=DictionaryEntryCategory
+)  # Category update via m2m manager (APIs do this)
+def request_update_categories_m2m_index(sender, instance, **kwargs):
+    request_update_in_index(DictionaryEntryDocumentManager, instance)

--- a/firstvoices/backend/search/signals/song_signals.py
+++ b/firstvoices/backend/search/signals/song_signals.py
@@ -6,6 +6,7 @@ from backend.search.indexing.song_index import SongDocumentManager
 from backend.search.tasks.index_manager_tasks import (
     request_remove_from_index,
     request_sync_in_index,
+    request_update_in_index,
 )
 
 
@@ -22,4 +23,4 @@ def remove_song_from_index(sender, instance, **kwargs):
 @receiver(post_delete, sender=Lyric)
 @receiver(post_save, sender=Lyric)
 def sync_song_lyrics_in_index(sender, instance, **kwargs):
-    request_sync_in_index(SongDocumentManager, instance.song)
+    request_update_in_index(SongDocumentManager, instance.song)

--- a/firstvoices/backend/search/signals/story_signals.py
+++ b/firstvoices/backend/search/signals/story_signals.py
@@ -6,6 +6,7 @@ from backend.search.indexing.story_index import StoryDocumentManager
 from backend.search.tasks.index_manager_tasks import (
     request_remove_from_index,
     request_sync_in_index,
+    request_update_in_index,
 )
 
 
@@ -22,4 +23,4 @@ def remove_story_from_index(sender, instance, **kwargs):
 @receiver(post_delete, sender=StoryPage)
 @receiver(post_save, sender=StoryPage)
 def sync_story_pages_in_index(sender, instance, **kwargs):
-    request_sync_in_index(StoryDocumentManager, instance.story)
+    request_update_in_index(StoryDocumentManager, instance.story)

--- a/firstvoices/backend/tests/test_search_indexing/base_indexing_tests.py
+++ b/firstvoices/backend/tests/test_search_indexing/base_indexing_tests.py
@@ -758,6 +758,6 @@ class BaseRelatedInstanceSignalTest(BaseSignalTest):
             self.assert_only_update_called(instance, mock_index_methods)
 
     def assert_only_update_called(self, instance, mock_index_methods):
-        mock_index_methods["mock_update"].assert_called_once_with(instance)
+        mock_index_methods["mock_update"].assert_called_with(instance)
         mock_index_methods["mock_sync"].assert_not_called()
         mock_index_methods["mock_remove"].assert_not_called()

--- a/firstvoices/backend/tests/test_search_indexing/base_indexing_tests.py
+++ b/firstvoices/backend/tests/test_search_indexing/base_indexing_tests.py
@@ -630,6 +630,7 @@ class BaseSignalTest(TransactionOnCommitMixin):
     def mock_index_methods(self, mocker):
         return {
             "mock_sync": mocker.patch.object(self.manager, "sync_in_index"),
+            "mock_update": mocker.patch.object(self.manager, "update_in_index"),
             "mock_remove": mocker.patch.object(self.manager, "remove_from_index"),
         }
 
@@ -707,21 +708,21 @@ class BaseRelatedInstanceSignalTest(BaseSignalTest):
         mock_index_methods["mock_remove"].assert_called_with(instance_id)
 
     @pytest.mark.django_db
-    def test_new_related_instance_main_instance_is_synced(self, mock_index_methods):
+    def test_new_related_instance_main_instance_is_updated(self, mock_index_methods):
         for related_factory in self.related_factories:
             with self.capture_on_commit_callbacks(execute=True):
                 instance = self.factory.create()
 
             mock_index_methods["mock_sync"].reset_mock()
+            mock_index_methods["mock_update"].reset_mock()
 
             with self.capture_on_commit_callbacks(execute=True):
                 self.create_related_instance(related_factory, instance)
 
-            mock_index_methods["mock_sync"].assert_called_with(instance.id)
-            mock_index_methods["mock_remove"].assert_not_called()
+            self.assert_only_update_called(instance, mock_index_methods)
 
     @pytest.mark.django_db
-    def test_edited_related_instance_main_instance_is_synced(self, mock_index_methods):
+    def test_edited_related_instance_main_instance_is_updated(self, mock_index_methods):
         for related_factory in self.related_factories:
             with self.capture_on_commit_callbacks(execute=True):
                 instance = self.factory.create()
@@ -730,27 +731,33 @@ class BaseRelatedInstanceSignalTest(BaseSignalTest):
                 )
 
             mock_index_methods["mock_sync"].reset_mock()
+            mock_index_methods["mock_update"].reset_mock()
 
             with self.capture_on_commit_callbacks(execute=True):
                 self.edit_related_instance(related_instance)
 
-            mock_index_methods["mock_sync"].assert_called_once_with(instance.id)
-            mock_index_methods["mock_remove"].assert_not_called()
+            self.assert_only_update_called(instance, mock_index_methods)
 
     @pytest.mark.django_db
-    def test_deleted_related_instance_main_instance_is_synced(self, mock_index_methods):
+    def test_deleted_related_instance_main_instance_is_updated(
+        self, mock_index_methods
+    ):
         for related_factory in self.related_factories:
             with self.capture_on_commit_callbacks(execute=True):
                 instance = self.factory.create()
-                instance_id = instance.id
                 related_instance = self.create_related_instance(
                     related_factory, instance
                 )
 
             mock_index_methods["mock_sync"].reset_mock()
+            mock_index_methods["mock_update"].reset_mock()
 
             with self.capture_on_commit_callbacks(execute=True):
                 related_instance.delete()
 
-            mock_index_methods["mock_sync"].assert_called_with(instance_id)
-            mock_index_methods["mock_remove"].assert_not_called()
+            self.assert_only_update_called(instance, mock_index_methods)
+
+    def assert_only_update_called(self, instance, mock_index_methods):
+        mock_index_methods["mock_update"].assert_called_once_with(instance)
+        mock_index_methods["mock_sync"].assert_not_called()
+        mock_index_methods["mock_remove"].assert_not_called()

--- a/firstvoices/backend/tests/test_search_indexing/test_dictionary_signals.py
+++ b/firstvoices/backend/tests/test_search_indexing/test_dictionary_signals.py
@@ -49,11 +49,14 @@ class TestDictionaryEntryIndexingSignals(BaseRelatedInstanceSignalTest):
     def test_assign_category_main_instance_is_synced(self, mock_index_methods):
         with self.capture_on_commit_callbacks(execute=True):
             instance = self.factory.create()
-            mock_index_methods["mock_sync"].reset_mock()
+
+        mock_index_methods["mock_sync"].reset_mock()
+        mock_index_methods["mock_update"].reset_mock()
+
+        with self.capture_on_commit_callbacks(execute=True):
             self.assign_new_category(instance)
 
-        mock_index_methods["mock_sync"].assert_called_with(instance.id)
-        mock_index_methods["mock_remove"].assert_not_called()
+        self.assert_only_update_called(instance, mock_index_methods)
 
     @pytest.mark.django_db
     def test_remove_category_main_instance_is_synced(self, mock_index_methods):
@@ -62,12 +65,12 @@ class TestDictionaryEntryIndexingSignals(BaseRelatedInstanceSignalTest):
             category_link = self.assign_new_category(instance)
 
         mock_index_methods["mock_sync"].reset_mock()
+        mock_index_methods["mock_update"].reset_mock()
 
         with self.capture_on_commit_callbacks(execute=True):
             category_link.delete()
 
-        mock_index_methods["mock_sync"].assert_called_once_with(instance.id)
-        mock_index_methods["mock_remove"].assert_not_called()
+        self.assert_only_update_called(instance, mock_index_methods)
 
     @pytest.mark.django_db
     def test_assign_category_m2m_main_instance_is_synced(self, mock_index_methods):
@@ -75,11 +78,12 @@ class TestDictionaryEntryIndexingSignals(BaseRelatedInstanceSignalTest):
             instance = self.factory.create()
 
         mock_index_methods["mock_sync"].reset_mock()
+        mock_index_methods["mock_update"].reset_mock()
 
         with self.capture_on_commit_callbacks(execute=True):
             self.assign_new_category_via_manager(instance)
 
-        mock_index_methods["mock_sync"].assert_called_with(instance.id)
+        mock_index_methods["mock_update"].assert_called_with(instance)
         mock_index_methods["mock_remove"].assert_not_called()
 
     @pytest.mark.django_db
@@ -89,11 +93,12 @@ class TestDictionaryEntryIndexingSignals(BaseRelatedInstanceSignalTest):
             category = self.assign_new_category_via_manager(instance)
 
         mock_index_methods["mock_sync"].reset_mock()
+        mock_index_methods["mock_update"].reset_mock()
 
         with self.capture_on_commit_callbacks(execute=True):
             instance.categories.remove(category)
 
-        mock_index_methods["mock_sync"].assert_called_once_with(instance.id)
+        mock_index_methods["mock_update"].assert_called_with(instance)
         mock_index_methods["mock_remove"].assert_not_called()
 
     @pytest.mark.django_db
@@ -103,9 +108,9 @@ class TestDictionaryEntryIndexingSignals(BaseRelatedInstanceSignalTest):
             category = self.assign_new_category_via_manager(instance)
 
         mock_index_methods["mock_sync"].reset_mock()
+        mock_index_methods["mock_update"].reset_mock()
 
         with self.capture_on_commit_callbacks(execute=True):
             category.delete()
 
-        mock_index_methods["mock_sync"].assert_called_once_with(instance.id)
-        mock_index_methods["mock_remove"].assert_not_called()
+        self.assert_only_update_called(instance, mock_index_methods)


### PR DESCRIPTION
### Description of Changes
* for the signals on related models, only *update* the index, don't sync it which might call "add_to_index" if the original isn't finished adding yet

### Checklist
- [ ] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Team Postman workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
