### PR TITLE
Fw 5549 implement a length filter to prevent 1 word phrases from being returned for phrase scrambler game

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ Please briefly explain the changes here.
 - [ ] Tests have been updated / created if applicable
 - [ ] Admin Panel has been updated if models have been added or modified
 - [ ] Migrations have been updated and committed if applicable
-- [ ] Team Postman workspace has been updated if applicable
+- [ ] Insomnia workspace has been updated if applicable
 
 ### Reviewers Should Do The Following:
 - [ ] Review the code changes here

--- a/firstvoices/backend/search/documents/dictionary_entry_document.py
+++ b/firstvoices/backend/search/documents/dictionary_entry_document.py
@@ -1,4 +1,6 @@
 from elasticsearch_dsl import Boolean, Keyword, Text
+from elasticsearch_dsl.analysis import analyzer
+from elasticsearch_dsl.field import TokenCount
 
 from backend.search.documents.base_document import BaseSiteEntryWithMediaDocument
 from backend.search.utils.constants import ELASTICSEARCH_DICTIONARY_ENTRY_INDEX
@@ -6,7 +8,13 @@ from backend.search.utils.constants import ELASTICSEARCH_DICTIONARY_ENTRY_INDEX
 
 class DictionaryEntryDocument(BaseSiteEntryWithMediaDocument):
     # text search fields
-    title = Text(fields={"raw": Keyword()}, copy_to="primary_language_search_fields")
+    title = Text(
+        fields={
+            "raw": Keyword(),
+            "token_count": TokenCount(analyzer=analyzer("standard")),
+        },
+        copy_to="primary_language_search_fields",
+    )
     translation = Text(copy_to="primary_translation_search_fields")
     note = Text(copy_to="other_translation_search_fields")
     acknowledgement = Text(copy_to="other_translation_search_fields")

--- a/firstvoices/backend/search/query_builder.py
+++ b/firstvoices/backend/search/query_builder.py
@@ -15,6 +15,8 @@ from backend.search.utils.query_builder_utils import (
     get_has_video_query,
     get_indices,
     get_kids_query,
+    get_max_words_query,
+    get_min_words_query,
     get_site_filter_query,
     get_starts_with_query,
     get_types_query,
@@ -46,6 +48,8 @@ def get_search_query(
     has_translation=None,
     has_unrecognized_chars=None,
     has_site_feature=None,
+    min_words=None,
+    max_words=None,
     random_sort=False,
 ):
     # Building initial query
@@ -123,5 +127,11 @@ def get_search_query(
 
     if has_site_feature is not None:
         search_query = search_query.query(get_has_site_feature_query(has_site_feature))
+
+    if min_words is not None:
+        search_query = search_query.query(get_min_words_query(min_words))
+
+    if max_words is not None:
+        search_query = search_query.query(get_max_words_query(max_words))
 
     return search_query

--- a/firstvoices/backend/search/utils/constants.py
+++ b/firstvoices/backend/search/utils/constants.py
@@ -1,6 +1,8 @@
 from django.db.models import TextChoices
 from django.utils.translation import gettext as _
 
+from backend.models.constants import DEFAULT_TITLE_LENGTH
+
 # retry_on_conflict for all update calls
 RETRY_ON_CONFLICT = 10
 
@@ -61,6 +63,8 @@ ES_RETRY_POLICY = {
 }
 
 UNKNOWN_CHARACTER_FLAG = "⚑"
+
+LENGTH_FILTER_MAX = DEFAULT_TITLE_LENGTH
 
 
 class SearchIndexEntryTypes(TextChoices):

--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -1,7 +1,9 @@
 from enum import Enum
 
-from django.core.exceptions import ValidationError
+from django.core import exceptions
+from django.utils.translation import gettext as _
 from elasticsearch_dsl import Q
+from rest_framework import serializers
 
 from backend.models import Membership
 from backend.models.category import Category
@@ -270,7 +272,7 @@ def get_valid_category_id(site, input_category):
             valid_category = site.category_set.filter(id=input_category)
             if len(valid_category):
                 return valid_category[0].id
-        except ValidationError:
+        except exceptions.ValidationError:
             return None
 
     return None
@@ -343,7 +345,7 @@ def get_valid_site_feature(input_site_feature_str):
 
 
 def get_valid_count(count, property_name):
-    exception_message = "Value must be a non-negative integer."
+    exception_message = _("Value must be a non-negative integer.")
     max_value = LENGTH_FILTER_MAX
 
     # If empty, return
@@ -354,10 +356,10 @@ def get_valid_count(count, property_name):
         count = int(count)
     except ValueError:
         # If anything is supplied other than a 0, raise Exception
-        raise ValidationError({property_name: [exception_message]})
+        raise serializers.ValidationError({property_name: [exception_message]})
 
     if count < 0:
-        raise ValidationError({property_name: [exception_message]})
+        raise serializers.ValidationError({property_name: [exception_message]})
 
     # If a number is supplied greater than the max value, consider max value
     if count > max_value:

--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -6,13 +6,14 @@ from elasticsearch_dsl import Q
 from backend.models import Membership
 from backend.models.category import Category
 from backend.models.characters import Alphabet
-from backend.models.constants import DEFAULT_TITLE_LENGTH, AppRole, Role, Visibility
+from backend.models.constants import AppRole, Role, Visibility
 from backend.permissions.utils import get_app_role
 from backend.search.utils.constants import (
     ELASTICSEARCH_DICTIONARY_ENTRY_INDEX,
     ELASTICSEARCH_MEDIA_INDEX,
     ELASTICSEARCH_SONG_INDEX,
     ELASTICSEARCH_STORY_INDEX,
+    LENGTH_FILTER_MAX,
     TYPE_AUDIO,
     TYPE_IMAGE,
     TYPE_PHRASE,
@@ -343,7 +344,7 @@ def get_valid_site_feature(input_site_feature_str):
 
 def get_valid_count(count, property_name):
     exception_message = "Value must be a non-negative integer."
-    max_value = DEFAULT_TITLE_LENGTH
+    max_value = LENGTH_FILTER_MAX
 
     # If empty, return
     if count is None:

--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -1,9 +1,6 @@
 from enum import Enum
 
-from django.core import exceptions
-from django.utils.translation import gettext as _
 from elasticsearch_dsl import Q
-from rest_framework import serializers
 
 from backend.models import Membership
 from backend.models.category import Category
@@ -15,7 +12,6 @@ from backend.search.utils.constants import (
     ELASTICSEARCH_MEDIA_INDEX,
     ELASTICSEARCH_SONG_INDEX,
     ELASTICSEARCH_STORY_INDEX,
-    LENGTH_FILTER_MAX,
     TYPE_AUDIO,
     TYPE_IMAGE,
     TYPE_PHRASE,
@@ -23,7 +19,6 @@ from backend.search.utils.constants import (
     TYPE_STORY,
     TYPE_VIDEO,
     TYPE_WORD,
-    VALID_DOCUMENT_TYPES,
 )
 from backend.utils.character_utils import clean_input
 
@@ -64,7 +59,7 @@ def get_cleaned_search_term(q):
     return clean_input(q)
 
 
-# SUB-QUERY GENERATORS
+# Sub Query Generators
 
 
 def get_types_query(types):
@@ -218,151 +213,3 @@ def get_min_words_query(min_words):
 
 def get_max_words_query(max_words):
     return Q("bool", filter=Q("range", title__token_count={"lte": max_words}))
-
-
-# SEARCH PARAMS VALIDATORS
-
-
-def get_valid_document_types(input_types, allowed_values=VALID_DOCUMENT_TYPES):
-    if not input_types:
-        return allowed_values
-
-    values = input_types.split(",")
-    selected_values = []
-
-    for value in values:
-        stripped_value = value.strip().lower()
-        if stripped_value in allowed_values and stripped_value not in selected_values:
-            selected_values.append(stripped_value)
-
-    if len(selected_values) == 0:
-        return None
-
-    return selected_values
-
-
-def get_valid_domain(input_domain_str):
-    string_lower = input_domain_str.strip().lower()
-
-    if not string_lower:
-        return "both"
-
-    if (
-        string_lower == SearchDomains.BOTH.value
-        or string_lower == SearchDomains.LANGUAGE.value
-        or string_lower == SearchDomains.TRANSLATION.value
-    ):
-        return string_lower
-    else:  # if invalid string is passed
-        return None
-
-
-def get_valid_starts_with_char(input_str):
-    # Starting alphabet can be a combination of characters as well
-    # taking only first word if multiple words are supplied
-    valid_str = str(input_str).strip().split(" ")[0]
-    return valid_str
-
-
-def get_valid_category_id(site, input_category):
-    # If input_category is empty, category filter should not be added
-    if input_category:
-        try:
-            # If category does not belong to the site specified, return empty result set
-            valid_category = site.category_set.filter(id=input_category)
-            if len(valid_category):
-                return valid_category[0].id
-        except exceptions.ValidationError:
-            return None
-
-    return None
-
-
-def get_valid_boolean(input_val):
-    # Python treats bool("False") as true, thus manual verification
-    cleaned_input = str(input_val).strip().lower()
-
-    if cleaned_input == "true":
-        return True
-    elif cleaned_input == "false":
-        return False
-    else:
-        return None
-
-
-def get_valid_visibility(input_visibility_str):
-    if not input_visibility_str:
-        return ""
-
-    input_visibility = input_visibility_str.split(",")
-    selected_values = []
-
-    for value in input_visibility:
-        string_upper = value.strip().upper()
-        if (
-            string_upper == Visibility.TEAM.label.upper()
-            or string_upper == Visibility.MEMBERS.label.upper()
-            or string_upper == Visibility.PUBLIC.label.upper()
-        ) and Visibility[string_upper] not in selected_values:
-            selected_values.append(Visibility[string_upper])
-
-    if len(selected_values) == 0:
-        return None
-    return selected_values
-
-
-def get_valid_sort(input_sort_by_str):
-    input_string = input_sort_by_str.lower().strip().split("_")
-
-    descending = len(input_string) > 1 and input_string[1] == "desc"
-
-    if len(input_string) > 0 and (
-        input_string[0] == "created"
-        or input_string[0] == "modified"
-        or input_string[0] == "title"
-        or input_string[0] == "random"
-    ):
-        return input_string[0], descending
-    else:  # if invalid string is passed
-        return None, None
-
-
-def get_valid_site_feature(input_site_feature_str):
-    if not input_site_feature_str:
-        return None
-
-    input_site_feature = input_site_feature_str.split(",")
-    selected_values = []
-
-    for value in input_site_feature:
-        cleaned_value = value.strip().lower()
-        if cleaned_value not in selected_values:
-            selected_values.append(cleaned_value)
-
-    if len(selected_values) == 0:
-        return None
-    return selected_values
-
-
-def get_valid_count(count, property_name):
-    exception_message = _("Value must be a non-negative integer.")
-    max_value = LENGTH_FILTER_MAX
-
-    # If empty, return
-    if count is None:
-        return count
-
-    try:
-        count = int(count)
-    except ValueError:
-        # If anything is supplied other than a 0, raise Exception
-        raise serializers.ValidationError({property_name: [exception_message]})
-
-    if count < 0:
-        raise serializers.ValidationError({property_name: [exception_message]})
-
-    # If a number is supplied greater than the max value, consider max value
-    if count > max_value:
-        count = max_value
-
-    return count

--- a/firstvoices/backend/search/utils/validators.py
+++ b/firstvoices/backend/search/utils/validators.py
@@ -1,0 +1,152 @@
+from django.core import exceptions
+from django.utils.translation import gettext as _
+from rest_framework import serializers
+
+from backend.models.constants import Visibility
+from backend.search.utils.constants import LENGTH_FILTER_MAX, VALID_DOCUMENT_TYPES
+from backend.search.utils.query_builder_utils import SearchDomains
+
+
+def get_valid_count(count, property_name):
+    exception_message = _("Value must be a non-negative integer.")
+    max_value = LENGTH_FILTER_MAX
+
+    # If empty, return
+    if count is None:
+        return count
+
+    try:
+        count = int(count)
+    except ValueError:
+        # If a non integer value is passed, raise Exception
+        raise serializers.ValidationError({property_name: [exception_message]})
+
+    if count < 0:
+        raise serializers.ValidationError({property_name: [exception_message]})
+
+    # If a number is supplied greater than the max value, consider max value
+    if count > max_value:
+        count = max_value
+
+    return count
+
+
+def get_valid_document_types(input_types, allowed_values=VALID_DOCUMENT_TYPES):
+    if not input_types:
+        return allowed_values
+
+    values = input_types.split(",")
+    selected_values = []
+
+    for value in values:
+        stripped_value = value.strip().lower()
+        if stripped_value in allowed_values and stripped_value not in selected_values:
+            selected_values.append(stripped_value)
+
+    if len(selected_values) == 0:
+        return None
+
+    return selected_values
+
+
+def get_valid_domain(input_domain_str):
+    string_lower = input_domain_str.strip().lower()
+
+    if not string_lower:
+        return "both"
+
+    if (
+        string_lower == SearchDomains.BOTH.value
+        or string_lower == SearchDomains.LANGUAGE.value
+        or string_lower == SearchDomains.TRANSLATION.value
+    ):
+        return string_lower
+    else:  # if invalid string is passed
+        return None
+
+
+def get_valid_starts_with_char(input_str):
+    # Starting alphabet can be a combination of characters as well
+    # taking only first word if multiple words are supplied
+    valid_str = str(input_str).strip().split(" ")[0]
+    return valid_str
+
+
+def get_valid_category_id(site, input_category):
+    # If input_category is empty, category filter should not be added
+    if input_category:
+        try:
+            # If category does not belong to the site specified, return empty result set
+            valid_category = site.category_set.filter(id=input_category)
+            if len(valid_category):
+                return valid_category[0].id
+        except exceptions.ValidationError:
+            return None
+
+    return None
+
+
+def get_valid_boolean(input_val):
+    # Python treats bool("False") as true, thus manual verification
+    cleaned_input = str(input_val).strip().lower()
+
+    if cleaned_input == "true":
+        return True
+    elif cleaned_input == "false":
+        return False
+    else:
+        return None
+
+
+def get_valid_visibility(input_visibility_str):
+    if not input_visibility_str:
+        return ""
+
+    input_visibility = input_visibility_str.split(",")
+    selected_values = []
+
+    for value in input_visibility:
+        string_upper = value.strip().upper()
+        if (
+            string_upper == Visibility.TEAM.label.upper()
+            or string_upper == Visibility.MEMBERS.label.upper()
+            or string_upper == Visibility.PUBLIC.label.upper()
+        ) and Visibility[string_upper] not in selected_values:
+            selected_values.append(Visibility[string_upper])
+
+    if len(selected_values) == 0:
+        return None
+    return selected_values
+
+
+def get_valid_sort(input_sort_by_str):
+    input_string = input_sort_by_str.lower().strip().split("_")
+
+    descending = len(input_string) > 1 and input_string[1] == "desc"
+
+    if len(input_string) > 0 and (
+        input_string[0] == "created"
+        or input_string[0] == "modified"
+        or input_string[0] == "title"
+        or input_string[0] == "random"
+    ):
+        return input_string[0], descending
+    else:  # if invalid string is passed
+        return None, None
+
+
+def get_valid_site_feature(input_site_feature_str):
+    if not input_site_feature_str:
+        return None
+
+    input_site_feature = input_site_feature_str.split(",")
+    selected_values = []
+
+    for value in input_site_feature:
+        cleaned_value = value.strip().lower()
+        if cleaned_value not in selected_values:
+            selected_values.append(cleaned_value)
+
+    if len(selected_values) == 0:
+        return None
+    return selected_values

--- a/firstvoices/backend/tests/test_apis/test_search_api.py
+++ b/firstvoices/backend/tests/test_apis/test_search_api.py
@@ -2,6 +2,7 @@ import json
 from unittest.mock import patch
 
 import pytest
+from django.core.exceptions import ValidationError
 from elasticsearch.exceptions import ConnectionError
 from elasticsearch_dsl import Search
 
@@ -237,6 +238,13 @@ class TestSearchAPI(SearchMocksMixin, BaseApiTest):
                 data[0]["searchResultId"] == mock_es_results["hits"]["hits"][0]["_id"]
             )
             assert data[0]["entry"]["id"] == str(entry.id)
+
+    @pytest.mark.django_db
+    def test_words_length_filter_invalid_combination(self, mock_search_query_execute):
+        # Testing out scenario where a invalid combination of max and min words is supplied,
+        # i.e. where maxWords < minWords
+        with pytest.raises(ValidationError):
+            _ = self.client.get(self.get_list_endpoint() + "?minWords=5&maxWords=2")
 
 
 @pytest.mark.django_db

--- a/firstvoices/backend/tests/test_apis/test_search_api.py
+++ b/firstvoices/backend/tests/test_apis/test_search_api.py
@@ -2,7 +2,6 @@ import json
 from unittest.mock import patch
 
 import pytest
-from django.core.exceptions import ValidationError
 from elasticsearch.exceptions import ConnectionError
 from elasticsearch_dsl import Search
 
@@ -243,8 +242,11 @@ class TestSearchAPI(SearchMocksMixin, BaseApiTest):
     def test_words_length_filter_invalid_combination(self, mock_search_query_execute):
         # Testing out scenario where a invalid combination of max and min words is supplied,
         # i.e. where maxWords < minWords
-        with pytest.raises(ValidationError):
-            _ = self.client.get(self.get_list_endpoint() + "?minWords=5&maxWords=2")
+        response = self.client.get(self.get_list_endpoint() + "?minWords=5&maxWords=2")
+        response_data = json.loads(response.content)
+
+        assert response.status_code == 400
+        assert response_data["maxWords"] == ["maxWords cannot be lower than minWords."]
 
 
 @pytest.mark.django_db

--- a/firstvoices/backend/tests/test_search_querying/test_query_builder_utils.py
+++ b/firstvoices/backend/tests/test_search_querying/test_query_builder_utils.py
@@ -3,7 +3,7 @@ from rest_framework.serializers import ValidationError
 
 from backend.models.constants import Visibility
 from backend.search.utils.constants import LENGTH_FILTER_MAX, VALID_DOCUMENT_TYPES
-from backend.search.utils.query_builder_utils import (
+from backend.search.utils.validators import (
     get_valid_category_id,
     get_valid_count,
     get_valid_document_types,

--- a/firstvoices/backend/tests/test_search_querying/test_query_builder_utils.py
+++ b/firstvoices/backend/tests/test_search_querying/test_query_builder_utils.py
@@ -1,9 +1,11 @@
 import pytest
+from django.core.exceptions import ValidationError
 
 from backend.models.constants import Visibility
-from backend.search.utils.constants import VALID_DOCUMENT_TYPES
+from backend.search.utils.constants import LENGTH_FILTER_MAX, VALID_DOCUMENT_TYPES
 from backend.search.utils.query_builder_utils import (
     get_valid_category_id,
+    get_valid_count,
     get_valid_document_types,
     get_valid_domain,
     get_valid_sort,
@@ -128,3 +130,18 @@ class TestValidSort:
         actual_sort, descending = get_valid_sort("bananas")
         assert actual_sort is None
         assert descending is None
+
+
+class TestValidCount:
+    @pytest.mark.parametrize("input_count", [0, 5, 10, 1000])
+    def test_valid_input(self, input_count):
+        valid_count = get_valid_count(input_count, "random_property")
+        if input_count > LENGTH_FILTER_MAX:
+            assert valid_count == LENGTH_FILTER_MAX
+        else:
+            assert valid_count == input_count
+
+    @pytest.mark.parametrize("input_count", [-1, "abc"])
+    def test_invalid_count(self, input_count):
+        with pytest.raises(ValidationError):
+            _ = get_valid_count(input_count, "random_property")

--- a/firstvoices/backend/tests/test_search_querying/test_query_builder_utils.py
+++ b/firstvoices/backend/tests/test_search_querying/test_query_builder_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from django.core.exceptions import ValidationError
+from rest_framework.serializers import ValidationError
 
 from backend.models.constants import Visibility
 from backend.search.utils.constants import LENGTH_FILTER_MAX, VALID_DOCUMENT_TYPES
@@ -129,6 +129,7 @@ class TestValidSort:
     def test_invalid_input(self):
         actual_sort, descending = get_valid_sort("bananas")
         assert actual_sort is None
+        assert descending is None
         assert descending is None
 
 

--- a/firstvoices/backend/tests/test_search_querying/test_validators.py
+++ b/firstvoices/backend/tests/test_search_querying/test_validators.py
@@ -8,6 +8,7 @@ from backend.search.utils.validators import (
     get_valid_count,
     get_valid_document_types,
     get_valid_domain,
+    get_valid_site_feature,
     get_valid_sort,
     get_valid_visibility,
 )
@@ -146,3 +147,13 @@ class TestValidCount:
     def test_invalid_count(self, input_count):
         with pytest.raises(ValidationError):
             _ = get_valid_count(input_count, "random_property")
+
+
+class TestValidSiteFeatures:
+    @pytest.mark.parametrize(
+        "valid_input, expected_output",
+        [("VALID_KEY, SHARED_MEDIA", ["valid_key", "shared_media"]), ("", None)],
+    )
+    def test_valid_input(self, valid_input, expected_output):
+        valid_site_features = get_valid_site_feature(valid_input)
+        assert valid_site_features == expected_output

--- a/firstvoices/backend/views/category_views.py
+++ b/firstvoices/backend/views/category_views.py
@@ -14,7 +14,7 @@ from rest_framework.viewsets import ModelViewSet
 
 from backend.models.category import Category
 from backend.models.dictionary import TypeOfDictionaryEntry
-from backend.search.utils.query_builder_utils import get_valid_boolean
+from backend.search.utils.validators import get_valid_boolean
 from backend.serializers.category_serializers import (
     CategoryDetailSerializer,
     ParentCategoryFlatListSerializer,

--- a/firstvoices/backend/views/search_all_entries_views.py
+++ b/firstvoices/backend/views/search_all_entries_views.py
@@ -425,11 +425,6 @@ from backend.views.exceptions import ElasticSearchConnectionError
                         value="2",
                         description="Only return dictionary entries which have at least 2 words in their title.",
                     ),
-                    OpenApiExample(
-                        "-1",
-                        value="None",
-                        description="Invalid value.",
-                    ),
                 ],
             ),
             OpenApiParameter(
@@ -452,11 +447,6 @@ from backend.views.exceptions import ElasticSearchConnectionError
                         value=str(LENGTH_FILTER_MAX),
                         description="If any value greater than the max value is supplied, "
                         "the maxWords filter scales back to the maximum value to filter.",
-                    ),
-                    OpenApiExample(
-                        "-1",
-                        value="None",
-                        description="Invalid value.",
                     ),
                 ],
             ),

--- a/firstvoices/backend/views/search_all_entries_views.py
+++ b/firstvoices/backend/views/search_all_entries_views.py
@@ -1,4 +1,4 @@
-from django.core.exceptions import ValidationError
+from django.utils.translation import gettext as _
 from drf_spectacular.utils import (
     OpenApiExample,
     OpenApiParameter,
@@ -588,8 +588,8 @@ class SearchAllEntriesViewSet(ThrottlingMixin, viewsets.GenericViewSet):
             and search_params["max_words"]
             and search_params["max_words"] < search_params["min_words"]
         ):
-            raise ValidationError(
-                {"maxWords": ["maxWords cannot be lower than minWords."]}
+            raise serializers.ValidationError(
+                {"maxWords": [_("maxWords cannot be lower than minWords.")]}
             )
 
         # Get search query

--- a/firstvoices/backend/views/search_all_entries_views.py
+++ b/firstvoices/backend/views/search_all_entries_views.py
@@ -15,7 +15,7 @@ from backend.pagination import SearchPageNumberPagination
 from backend.search.query_builder import get_search_query
 from backend.search.utils.constants import SearchIndexEntryTypes
 from backend.search.utils.hydration_utils import hydrate_objects
-from backend.search.utils.query_builder_utils import (
+from backend.search.utils.validators import (
     get_valid_boolean,
     get_valid_count,
     get_valid_document_types,

--- a/firstvoices/backend/views/search_all_entries_views.py
+++ b/firstvoices/backend/views/search_all_entries_views.py
@@ -13,7 +13,7 @@ from rest_framework.response import Response
 
 from backend.pagination import SearchPageNumberPagination
 from backend.search.query_builder import get_search_query
-from backend.search.utils.constants import SearchIndexEntryTypes
+from backend.search.utils.constants import LENGTH_FILTER_MAX, SearchIndexEntryTypes
 from backend.search.utils.hydration_utils import hydrate_objects
 from backend.search.utils.validators import (
     get_valid_boolean,
@@ -409,6 +409,54 @@ from backend.views.exceptions import ElasticSearchConnectionError
                         "invalid site feature key",
                         value="None",
                         description="If invalid site feature key is passed, the API returns an empty set of results.",
+                    ),
+                ],
+            ),
+            OpenApiParameter(
+                name="minWords",
+                description="Filter dictionary entries on the minimum number of words in their title."
+                " Only non-negative integer values are allowed.",
+                required=False,
+                default="",
+                type=int,
+                examples=[
+                    OpenApiExample(
+                        "2",
+                        value="2",
+                        description="Only return dictionary entries which have at least 2 words in their title.",
+                    ),
+                    OpenApiExample(
+                        "-1",
+                        value="None",
+                        description="Invalid value.",
+                    ),
+                ],
+            ),
+            OpenApiParameter(
+                name="maxWords",
+                description="Filter dictionary entries on the maximum number of words in their title. "
+                "Only non-negative integer values are allowed. "
+                f"The maximum value is capped at {LENGTH_FILTER_MAX}. "
+                "The value in maxWords should always be greater than or equal to the minWords filter.",
+                required=False,
+                default="",
+                type=int,
+                examples=[
+                    OpenApiExample(
+                        "5",
+                        value="5",
+                        description="Only return dictionary entries which have at the most 5 words in their title.",
+                    ),
+                    OpenApiExample(
+                        "1000",
+                        value=str(LENGTH_FILTER_MAX),
+                        description="If any value greater than the max value is supplied, "
+                        "the maxWords filter scales back to the maximum value to filter.",
+                    ),
+                    OpenApiExample(
+                        "-1",
+                        value="None",
+                        description="Invalid value.",
                     ),
                 ],
             ),

--- a/firstvoices/backend/views/search_site_entries_views.py
+++ b/firstvoices/backend/views/search_site_entries_views.py
@@ -1,6 +1,6 @@
 from drf_spectacular.utils import extend_schema, extend_schema_view
 
-from backend.search.utils.query_builder_utils import (
+from backend.search.utils.validators import (
     get_valid_category_id,
     get_valid_starts_with_char,
 )


### PR DESCRIPTION
### Description of Changes
- Added `token_count` as a sub-field to the dictionary entry search documents.
- Added `LENGTH_FILTER_MAX` constant to cap the `maxWords` filter, which points to the `DEFAULT_TITLE_LENGTH` for now.
- Added `minWords` and `maxWords` as a query parameter to the search API. Added relevant filters, sub-query generators, tests and updated documentation accordingly.
- Moved all the validation methods from the `search/utils/query_builder_utils.py` into `search/utils/validators.py`. 
- Updated the github PR templated file to say `insomnia` instead of `Team Postman`.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- [x] Insomnia workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
