### PR TITLE
FW-5417 more wordsy guesses

### DIFF
--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -20,7 +20,7 @@ from backend.search.utils.constants import (
     TYPE_VIDEO,
     TYPE_WORD,
 )
-from backend.utils.character_utils import clean_input
+from backend.utils.character_utils import UNKNOWN_FLAG, clean_input
 
 
 class SearchDomains(Enum):
@@ -137,7 +137,7 @@ def get_view_permissions_filter(user):
 
 
 def get_starts_with_query(site_id, starts_with_char):
-    unknown_character_flag = "⚑"
+    unknown_character_flag = UNKNOWN_FLAG
 
     # Check if a custom_order_character is present, if present, look up in the custom_order field
     # if not, look in the title field

--- a/firstvoices/backend/utils/character_utils.py
+++ b/firstvoices/backend/utils/character_utils.py
@@ -2,6 +2,8 @@ import logging
 import re
 import unicodedata
 
+UNKNOWN_FLAG = unicodedata.lookup("BLACK FLAG")
+
 
 # From https://github.com/roedoejet/mothertongues/blob/master/mtd/processors/sorter.py
 # with additions for ignorables and out-of-vocab chars (on branch: dev.sorter)
@@ -94,7 +96,7 @@ class CustomSorter(ArbSorter):
     max_alphabet_length = len(basic_latin) + len(extended_latin) - len(exclude_chars)
 
     space = " "
-    out_of_vocab_flag = unicodedata.lookup("BLACK FLAG")
+    out_of_vocab_flag = UNKNOWN_FLAG
 
     logger = logging.getLogger(__name__)
 

--- a/firstvoices/backend/views/games_views.py
+++ b/firstvoices/backend/views/games_views.py
@@ -14,6 +14,8 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from backend.models import Character, DictionaryEntry
+from backend.models.dictionary import TypeOfDictionaryEntry
+from backend.utils.character_utils import UNKNOWN_FLAG
 from backend.views.api_doc_variables import site_slug_parameter
 from backend.views.base_views import SiteContentViewSetMixin
 
@@ -28,6 +30,63 @@ def get_wordsy_solution_seed(num_words):
     seconds_in_day = 86400
     index = math.floor((now - epoch) / seconds_in_day)
     return index % num_words
+
+
+def get_wordsy_possible_solutions(site):
+    """Get friendly words with custom length matching the number of game letters."""
+    words_qs = (
+        # filter words based on custom length; this also filters out unknown chars
+        DictionaryEntry.objects.annotate(
+            custom_char_length=RawSQL("ARRAY_LENGTH(split_chars_base, 1)", ())
+        )
+        # visible, kid-friendly, and games-friendly words only
+        .filter(
+            site=site,
+            visibility=site.visibility,
+            type=TypeOfDictionaryEntry.WORD,
+            exclude_from_games=False,
+            exclude_from_kids=False,
+            custom_char_length__exact=SOLUTION_LENGTH,
+        )
+        # words cannot contain spaces
+        .exclude(title__contains=" ")
+        .exclude(custom_order__contains=UNKNOWN_FLAG)
+        .order_by("custom_order")
+        .distinct("custom_order")
+        .values_list("split_chars_base", flat=True)
+    )
+    solutions = []
+    for split_chars in words_qs.iterator():
+        title_as_base_chars = "".join(split_chars)
+        solutions.append(title_as_base_chars)
+    return solutions
+
+
+def get_wordsy_possible_guesses(site):
+    """Get all words with custom length matching the number of game letters."""
+    # this can be amended later to get possible tokens in more complex ways.
+    # for now, match how solution words are found but with fewer restrictions.
+    entries_qs = (
+        DictionaryEntry.objects.annotate(
+            custom_char_length=RawSQL("ARRAY_LENGTH(split_chars_base, 1)", ())
+        )
+        .filter(
+            site=site,
+            visibility=site.visibility,
+            custom_char_length=SOLUTION_LENGTH,
+        )
+        .exclude(title__contains=" ")
+        .exclude(custom_order__contains=UNKNOWN_FLAG)
+        .order_by("custom_order")
+        .distinct("custom_order")
+        .values_list("split_chars_base", flat=True)
+    )
+    guesses = []
+    for split_chars in entries_qs.iterator():
+        title_as_base_chars = "".join(split_chars)
+        if title_as_base_chars not in guesses:
+            guesses.append(title_as_base_chars)
+    return guesses
 
 
 @extend_schema_view(
@@ -68,6 +127,7 @@ class WordsyViewSet(SiteContentViewSetMixin, GenericViewSet):
         # Checking if required query sets are present in cache
         cache_key_orthography = f"{site.title}-orthography"
         cache_key_words = f"{site.title}-words"
+        cache_key_guesses = f"{site.title}-guesses"
 
         # orthography
         orthography_qs = caches[CACHE_KEY_WORDSY].get(cache_key_orthography)
@@ -81,33 +141,23 @@ class WordsyViewSet(SiteContentViewSetMixin, GenericViewSet):
                 cache_key_orthography, orthography_qs, cache_expiry
             )
 
-        # words
+        # friendly words
         words = caches[CACHE_KEY_WORDSY].get(cache_key_words)
         if words is None:
-            # Filtering words based on their length excluding spaces
-            words_qs = (
-                DictionaryEntry.objects.annotate(
-                    chars_length=RawSQL("ARRAY_LENGTH(split_chars_base, 1)", ())
-                )
-                .filter(
-                    site=site,
-                    visibility=site.visibility,
-                    exclude_from_games=False,
-                    exclude_from_kids=False,
-                    chars_length__exact=SOLUTION_LENGTH,
-                )
-                .exclude(title__contains=" ")
-                .order_by("title", "custom_order")
-                .distinct("title")
-                .values_list("split_chars_base", flat=True)
-            )
-            words = []
-            for split_chars in words_qs.iterator():
-                title_from_base_chars = "".join(split_chars)
-                if title_from_base_chars not in words:
-                    words.append(title_from_base_chars)
+            words = get_wordsy_possible_solutions(site=site)
             caches[CACHE_KEY_WORDSY].set(cache_key_words, words, cache_expiry)
 
+        # possible guesses
+        guesses = caches[CACHE_KEY_WORDSY].get(cache_key_guesses)
+        if guesses is None:
+            # don't bother searching for guesses if there are no friendly words
+            if len(words):
+                guesses = get_wordsy_possible_guesses(site=site)
+                caches[CACHE_KEY_WORDSY].set(cache_key_words, words, cache_expiry)
+            else:
+                guesses = words
+
+        # today's solution
         if len(words):
             seed = get_wordsy_solution_seed(len(words))
             solution = words[seed]
@@ -118,7 +168,7 @@ class WordsyViewSet(SiteContentViewSetMixin, GenericViewSet):
             data={
                 "orthography": orthography_qs,
                 "words": words,
-                "valid_guesses": words,  # to be expanded later with phrases that satisfy criteria
+                "valid_guesses": guesses,
                 "solution": solution,
             }
         )


### PR DESCRIPTION
### Description of Changes

Refactoring Wordsy calculations to fix restrictions on the possible solution words, and create a separate, larger list of guessable words. Uses a less restrictive way of splitting characters  with regex - though this takes some time to process (on a site with ~13k words, took ~5 seconds locally).

Also includes minor refactors of the custom character flag.

### Checklist
- README / documentation has been updated if needed
- [X] PR title / commit messages contain Jira ticket number if applicable
- [X] Tests have been updated / created if applicable
- Admin Panel has been updated if models have been added or modified
- Migrations have been updated and committed if applicable
- Insomnia workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
To test locally, your data will need to be processed for games (have the character splitting data stored).

I'm not sure if this is too detailed/lengthy a process to be feasible. I could return to the original splitting method which could be done with only 1 query, sacrificing possible guesses for more faster speed. Thoughts?
