### PR TITLE
FW-5433 Handle missing original file in media indexing

### DIFF
--- a/firstvoices/backend/search/indexing/media_index.py
+++ b/firstvoices/backend/search/indexing/media_index.py
@@ -13,6 +13,13 @@ class MediaDocumentManager(DocumentManager):
     @classmethod
     def create_index_document(cls, instance):
         """Returns a MediaDocument populated for the given media instance."""
+
+        # Handle the case where the media instance has no original file
+        if instance.original:
+            instance_filename = instance.original.content.name
+        else:
+            instance_filename = None
+
         return cls.document(
             document_id=str(instance.id),
             document_type=type(instance).__name__,
@@ -25,7 +32,7 @@ class MediaDocumentManager(DocumentManager):
             ),
             visibility=Visibility.PUBLIC,
             title=instance.title,
-            filename=instance.original.content.name,
+            filename=instance_filename,
             description=instance.description,
             type=type(instance).__name__.lower(),
             exclude_from_games=instance.exclude_from_games,

--- a/firstvoices/backend/tests/test_search_indexing/test_media_indexing.py
+++ b/firstvoices/backend/tests/test_search_indexing/test_media_indexing.py
@@ -49,6 +49,31 @@ class BaseMediaDocumentManagerTest(BaseDocumentManagerTest):
         assert doc.created == instance.created
         assert doc.last_modified == instance.last_modified
 
+    @pytest.mark.django_db
+    def test_create_document_no_original(self):
+        site = factories.SiteFactory.create(visibility=Visibility.MEMBERS)
+        instance = self.factory.create(
+            exclude_from_kids=False, exclude_from_games=True, site=site, original=None
+        )
+        doc = self.manager.create_index_document(instance)
+
+        assert doc.document_id == str(instance.id)
+        assert doc.document_type == self.expected_type
+        assert doc.site_id == str(instance.site.id)
+        assert doc.site_visibility == Visibility.MEMBERS
+        assert doc.visibility == Visibility.PUBLIC
+
+        assert doc.title == instance.title
+        assert doc.filename is None
+        assert doc.description == instance.description
+        assert doc.type == self.expected_type.lower()
+
+        assert doc.exclude_from_games
+        assert not doc.exclude_from_kids
+
+        assert doc.created == instance.created
+        assert doc.last_modified == instance.last_modified
+
 
 class TestAudioDocumentManager(BaseMediaDocumentManagerTest):
     manager = AudioDocumentManager


### PR DESCRIPTION
### Description of Changes
Adds a conditional to the MediaDocumentManager to handle the case where the original file was missing and a matching test.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
Currently the original file can be `None` but a separate ticket has been created to determine if that should still be possible. (See https://firstvoices.atlassian.net/browse/FW-5676)
