### PR TITLE
FW-5685 Allow site indexing signals to be paused

### DIFF
--- a/firstvoices/backend/search/signals/dictionary_entry_signals.py
+++ b/firstvoices/backend/search/signals/dictionary_entry_signals.py
@@ -19,13 +19,13 @@ from backend.search.tasks.index_manager_tasks import (
 
 @receiver(post_save, sender=DictionaryEntry)
 def sync_dictionary_entry_in_index(sender, instance, **kwargs):
-    if not indexing_signals_paused(instance):
+    if not indexing_signals_paused(instance.site):
         request_sync_in_index(DictionaryEntryDocumentManager, instance)
 
 
 @receiver(post_delete, sender=DictionaryEntry)
 def remove_dictionary_entry_from_index(sender, instance, **kwargs):
-    if not indexing_signals_paused(instance):
+    if not indexing_signals_paused(instance.site):
         request_remove_from_index(DictionaryEntryDocumentManager, instance)
 
 
@@ -42,7 +42,7 @@ def remove_dictionary_entry_from_index(sender, instance, **kwargs):
     post_delete, sender=DictionaryEntryCategory
 )  # Category update via creating m2m model (admin site does this)
 def sync_related_dictionary_entry_in_index(sender, instance, **kwargs):
-    if not indexing_signals_paused(instance):
+    if not indexing_signals_paused(instance.site):
         request_update_in_index(
             DictionaryEntryDocumentManager, instance.dictionary_entry
         )
@@ -52,5 +52,5 @@ def sync_related_dictionary_entry_in_index(sender, instance, **kwargs):
     m2m_changed, sender=DictionaryEntryCategory
 )  # Category update via m2m manager (APIs do this)
 def request_update_categories_m2m_index(sender, instance, **kwargs):
-    if not indexing_signals_paused(instance):
+    if not indexing_signals_paused(instance.site):
         request_update_in_index(DictionaryEntryDocumentManager, instance)

--- a/firstvoices/backend/search/signals/site_signals.py
+++ b/firstvoices/backend/search/signals/site_signals.py
@@ -40,7 +40,7 @@ def sync_site_features_in_media_indexes(sender, instance, **kwargs):
     sync_all_media_site_content_in_indexes(site)
 
 
-def indexing_signals_paused(instance):
-    if not instance.site.sitefeature_set.filter(key="indexing_paused").exists():
+def indexing_signals_paused(site):
+    if not site.sitefeature_set.filter(key="indexing_paused").exists():
         return False
-    return instance.site.sitefeature_set.get(key="indexing_paused").is_enabled
+    return site.sitefeature_set.get(key="indexing_paused").is_enabled

--- a/firstvoices/backend/search/signals/site_signals.py
+++ b/firstvoices/backend/search/signals/site_signals.py
@@ -38,3 +38,9 @@ def remove_all_site_content(sender, instance, **kwargs):
 def sync_site_features_in_media_indexes(sender, instance, **kwargs):
     site = instance.site
     sync_all_media_site_content_in_indexes(site)
+
+
+def indexing_signals_paused(instance):
+    if not instance.site.sitefeature_set.filter(key="indexing_paused").exists():
+        return False
+    return instance.site.sitefeature_set.get(key="indexing_paused").is_enabled

--- a/firstvoices/backend/search/signals/song_signals.py
+++ b/firstvoices/backend/search/signals/song_signals.py
@@ -3,6 +3,7 @@ from django.dispatch import receiver
 
 from backend.models import Lyric, Song
 from backend.search.indexing.song_index import SongDocumentManager
+from backend.search.signals.site_signals import indexing_signals_paused
 from backend.search.tasks.index_manager_tasks import (
     request_remove_from_index,
     request_sync_in_index,
@@ -12,15 +13,18 @@ from backend.search.tasks.index_manager_tasks import (
 
 @receiver(post_save, sender=Song)
 def sync_song_in_index(sender, instance, **kwargs):
-    request_sync_in_index(SongDocumentManager, instance)
+    if not indexing_signals_paused(instance):
+        request_sync_in_index(SongDocumentManager, instance)
 
 
 @receiver(post_delete, sender=Song)
 def remove_song_from_index(sender, instance, **kwargs):
-    request_remove_from_index(SongDocumentManager, instance)
+    if not indexing_signals_paused(instance):
+        request_remove_from_index(SongDocumentManager, instance)
 
 
 @receiver(post_delete, sender=Lyric)
 @receiver(post_save, sender=Lyric)
 def sync_song_lyrics_in_index(sender, instance, **kwargs):
-    request_update_in_index(SongDocumentManager, instance.song)
+    if not indexing_signals_paused(instance):
+        request_update_in_index(SongDocumentManager, instance.song)

--- a/firstvoices/backend/search/signals/song_signals.py
+++ b/firstvoices/backend/search/signals/song_signals.py
@@ -13,18 +13,18 @@ from backend.search.tasks.index_manager_tasks import (
 
 @receiver(post_save, sender=Song)
 def sync_song_in_index(sender, instance, **kwargs):
-    if not indexing_signals_paused(instance):
+    if not indexing_signals_paused(instance.site):
         request_sync_in_index(SongDocumentManager, instance)
 
 
 @receiver(post_delete, sender=Song)
 def remove_song_from_index(sender, instance, **kwargs):
-    if not indexing_signals_paused(instance):
+    if not indexing_signals_paused(instance.site):
         request_remove_from_index(SongDocumentManager, instance)
 
 
 @receiver(post_delete, sender=Lyric)
 @receiver(post_save, sender=Lyric)
 def sync_song_lyrics_in_index(sender, instance, **kwargs):
-    if not indexing_signals_paused(instance):
+    if not indexing_signals_paused(instance.song.site):
         request_update_in_index(SongDocumentManager, instance.song)

--- a/firstvoices/backend/search/signals/story_signals.py
+++ b/firstvoices/backend/search/signals/story_signals.py
@@ -3,6 +3,7 @@ from django.dispatch import receiver
 
 from backend.models.story import Story, StoryPage
 from backend.search.indexing.story_index import StoryDocumentManager
+from backend.search.signals.site_signals import indexing_signals_paused
 from backend.search.tasks.index_manager_tasks import (
     request_remove_from_index,
     request_sync_in_index,
@@ -12,15 +13,18 @@ from backend.search.tasks.index_manager_tasks import (
 
 @receiver(post_save, sender=Story)
 def sync_story_in_index(sender, instance, **kwargs):
-    request_sync_in_index(StoryDocumentManager, instance)
+    if not indexing_signals_paused(instance):
+        request_sync_in_index(StoryDocumentManager, instance)
 
 
 @receiver(post_delete, sender=Story)
 def remove_story_from_index(sender, instance, **kwargs):
-    request_remove_from_index(StoryDocumentManager, instance)
+    if not indexing_signals_paused(instance):
+        request_remove_from_index(StoryDocumentManager, instance)
 
 
 @receiver(post_delete, sender=StoryPage)
 @receiver(post_save, sender=StoryPage)
 def sync_story_pages_in_index(sender, instance, **kwargs):
-    request_update_in_index(StoryDocumentManager, instance.story)
+    if not indexing_signals_paused(instance):
+        request_update_in_index(StoryDocumentManager, instance.story)

--- a/firstvoices/backend/search/signals/story_signals.py
+++ b/firstvoices/backend/search/signals/story_signals.py
@@ -13,18 +13,18 @@ from backend.search.tasks.index_manager_tasks import (
 
 @receiver(post_save, sender=Story)
 def sync_story_in_index(sender, instance, **kwargs):
-    if not indexing_signals_paused(instance):
+    if not indexing_signals_paused(instance.site):
         request_sync_in_index(StoryDocumentManager, instance)
 
 
 @receiver(post_delete, sender=Story)
 def remove_story_from_index(sender, instance, **kwargs):
-    if not indexing_signals_paused(instance):
+    if not indexing_signals_paused(instance.site):
         request_remove_from_index(StoryDocumentManager, instance)
 
 
 @receiver(post_delete, sender=StoryPage)
 @receiver(post_save, sender=StoryPage)
 def sync_story_pages_in_index(sender, instance, **kwargs):
-    if not indexing_signals_paused(instance):
+    if not indexing_signals_paused(instance.site):
         request_update_in_index(StoryDocumentManager, instance.story)

--- a/firstvoices/backend/tests/test_search_indexing/base_indexing_tests.py
+++ b/firstvoices/backend/tests/test_search_indexing/base_indexing_tests.py
@@ -6,6 +6,8 @@ import pytest
 from django.db import DEFAULT_DB_ALIAS, connections
 from elasticsearch import ConnectionError, NotFoundError
 
+from backend.tests import factories
+
 TEST_SEARCH_INDEX_ID = "test search index id"
 
 
@@ -615,6 +617,102 @@ class TransactionOnCommitMixin:
                 )
         else:
             callback()
+
+
+class PauseIndexingSignalMixin:
+    """
+    Tests for entry types that support the indexing_paused site feature.
+    """
+
+    @pytest.mark.django_db
+    def test_indexing_signals_paused_create(self, mock_index_methods):
+        paused_site = factories.SiteFactory.create()
+        factories.SiteFeatureFactory.create(
+            site=paused_site, key="indexing_paused", is_enabled=True
+        )
+
+        with self.capture_on_commit_callbacks(execute=True):
+            self.factory.create(site=paused_site)
+
+        mock_index_methods["mock_sync"].assert_not_called()
+        mock_index_methods["mock_update"].assert_not_called()
+
+    @pytest.mark.django_db
+    def test_indexing_signals_paused_delete(self, mock_index_methods):
+        paused_site = factories.SiteFactory.create()
+        factories.SiteFeatureFactory.create(
+            site=paused_site, key="indexing_paused", is_enabled=True
+        )
+
+        with self.capture_on_commit_callbacks(execute=True):
+            instance = self.factory.create(site=paused_site)
+
+        mock_index_methods["mock_sync"].reset_mock()
+
+        with self.capture_on_commit_callbacks(execute=True):
+            instance.delete()
+
+        mock_index_methods["mock_remove"].assert_not_called()
+        mock_index_methods["mock_sync"].assert_not_called()
+
+
+class PauseIndexingSignalRelatedMixin(PauseIndexingSignalMixin):
+    """
+    Tests for entry types that support the indexing_paused site feature and have related models.
+    """
+
+    @pytest.mark.django_db
+    def test_indexing_signals_paused_related_create(self, mock_index_methods):
+        paused_site = factories.SiteFactory.create()
+        factories.SiteFeatureFactory.create(
+            site=paused_site, key="indexing_paused", is_enabled=True
+        )
+
+        with self.capture_on_commit_callbacks(execute=True):
+            instance = self.factory.create(site=paused_site)
+            self.create_all_related_instances(instance)
+
+        mock_index_methods["mock_sync"].assert_not_called()
+        mock_index_methods["mock_update"].assert_not_called()
+
+    @pytest.mark.django_db
+    def test_indexing_signals_paused_related_delete(self, mock_index_methods):
+        paused_site = factories.SiteFactory.create()
+        factories.SiteFeatureFactory.create(
+            site=paused_site, key="indexing_paused", is_enabled=True
+        )
+
+        with self.capture_on_commit_callbacks(execute=True):
+            instance = self.factory.create(site=paused_site)
+            self.create_all_related_instances(instance)
+
+        mock_index_methods["mock_sync"].reset_mock()
+
+        with self.capture_on_commit_callbacks(execute=True):
+            instance.delete()
+
+        mock_index_methods["mock_remove"].assert_not_called()
+        mock_index_methods["mock_sync"].assert_not_called()
+
+    @pytest.mark.django_db
+    def test_indexing_signals_paused_related_edit(self, mock_index_methods):
+        paused_site = factories.SiteFactory.create()
+        factories.SiteFeatureFactory.create(
+            site=paused_site, key="indexing_paused", is_enabled=True
+        )
+
+        with self.capture_on_commit_callbacks(execute=True):
+            instance = self.factory.create(site=paused_site)
+            self.create_all_related_instances(instance)
+
+        mock_index_methods["mock_sync"].reset_mock()
+        mock_index_methods["mock_update"].reset_mock()
+
+        with self.capture_on_commit_callbacks(execute=True):
+            self.edit_related_instance(instance)
+
+        mock_index_methods["mock_sync"].assert_not_called()
+        mock_index_methods["mock_update"].assert_not_called()
 
 
 class BaseSignalTest(TransactionOnCommitMixin):

--- a/firstvoices/backend/tests/test_search_indexing/base_indexing_tests.py
+++ b/firstvoices/backend/tests/test_search_indexing/base_indexing_tests.py
@@ -655,6 +655,26 @@ class PauseIndexingSignalMixin:
         mock_index_methods["mock_remove"].assert_not_called()
         mock_index_methods["mock_sync"].assert_not_called()
 
+    @pytest.mark.django_db
+    def test_indexing_signals_paused_edit(self, mock_index_methods):
+        paused_site = factories.SiteFactory.create()
+        factories.SiteFeatureFactory.create(
+            site=paused_site, key="indexing_paused", is_enabled=True
+        )
+
+        with self.capture_on_commit_callbacks(execute=True):
+            instance = self.factory.create(site=paused_site)
+
+        mock_index_methods["mock_sync"].reset_mock()
+        mock_index_methods["mock_update"].reset_mock()
+
+        with self.capture_on_commit_callbacks(execute=True):
+            instance.title = "New Title"
+            instance.save()
+
+        mock_index_methods["mock_sync"].assert_not_called()
+        mock_index_methods["mock_update"].assert_not_called()
+
 
 class PauseIndexingSignalRelatedMixin(PauseIndexingSignalMixin):
     """

--- a/firstvoices/backend/tests/test_search_indexing/test_dictionary_signals.py
+++ b/firstvoices/backend/tests/test_search_indexing/test_dictionary_signals.py
@@ -4,10 +4,13 @@ from backend.search.indexing.dictionary_index import DictionaryEntryDocumentMana
 from backend.tests import factories
 from backend.tests.test_search_indexing.base_indexing_tests import (
     BaseRelatedInstanceSignalTest,
+    PauseIndexingSignalRelatedMixin,
 )
 
 
-class TestDictionaryEntryIndexingSignals(BaseRelatedInstanceSignalTest):
+class TestDictionaryEntryIndexingSignals(
+    PauseIndexingSignalRelatedMixin, BaseRelatedInstanceSignalTest
+):
     manager = DictionaryEntryDocumentManager
     factory = factories.DictionaryEntryFactory
     related_factories = [

--- a/firstvoices/backend/tests/test_search_indexing/test_song_signals.py
+++ b/firstvoices/backend/tests/test_search_indexing/test_song_signals.py
@@ -2,10 +2,13 @@ from backend.search.indexing.song_index import SongDocumentManager
 from backend.tests import factories
 from backend.tests.test_search_indexing.base_indexing_tests import (
     BaseRelatedInstanceSignalTest,
+    PauseIndexingSignalRelatedMixin,
 )
 
 
-class TestSongIndexingSignals(BaseRelatedInstanceSignalTest):
+class TestSongIndexingSignals(
+    PauseIndexingSignalRelatedMixin, BaseRelatedInstanceSignalTest
+):
     manager = SongDocumentManager
     factory = factories.SongFactory
     related_factories = [factories.LyricsFactory]

--- a/firstvoices/backend/tests/test_search_indexing/test_story_signals.py
+++ b/firstvoices/backend/tests/test_search_indexing/test_story_signals.py
@@ -2,10 +2,13 @@ from backend.search.indexing.story_index import StoryDocumentManager
 from backend.tests import factories
 from backend.tests.test_search_indexing.base_indexing_tests import (
     BaseRelatedInstanceSignalTest,
+    PauseIndexingSignalRelatedMixin,
 )
 
 
-class TestStoryIndexingSignals(BaseRelatedInstanceSignalTest):
+class TestStoryIndexingSignals(
+    PauseIndexingSignalRelatedMixin, BaseRelatedInstanceSignalTest
+):
     manager = StoryDocumentManager
     factory = factories.StoryFactory
     related_factories = [factories.StoryPageFactory]


### PR DESCRIPTION
### Description of Changes
- Adds the ability to skip search indexing signals if a site has the feature `indexing_paused` enabled
- This pausing applies to all non-media site content that is currently indexed (this is due to the pausing feature being for bulk visibility updates)

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
Please disregard the test re-runs, sonarcloud is currently having an outage.
