### PR TITLE
FW-5730 Pause MTD dictionary entry indexing when "indexing_paused" is enabled

### DIFF
--- a/firstvoices/backend/models/signals/mtd_signals.py
+++ b/firstvoices/backend/models/signals/mtd_signals.py
@@ -4,6 +4,7 @@ from django.dispatch import receiver
 
 from backend.models import Category, DictionaryEntry
 from backend.models.constants import Visibility
+from backend.search.signals import indexing_signals_paused
 from backend.tasks.build_mtd_export_format import build_index_and_calculate_scores
 from firstvoices.celery import link_error_handler
 
@@ -31,11 +32,12 @@ def store_current_visibility(sender, instance, **kwargs):
 def request_update_mtd_index(sender, instance, **kwargs):
     # Checking for both previous and current visibility
     # this covers the case when a word is changed from public to members/team
-    if (
-        hasattr(instance, "old_visibility")
-        and instance.old_visibility == Visibility.PUBLIC
-    ) or instance.visibility == Visibility.PUBLIC:
-        rebuild_mtd_index(instance.site.slug)
+    if not indexing_signals_paused(instance.site):
+        if (
+            hasattr(instance, "old_visibility")
+            and instance.old_visibility == Visibility.PUBLIC
+        ) or instance.visibility == Visibility.PUBLIC:
+            rebuild_mtd_index(instance.site.slug)
 
 
 @receiver(post_save, sender=Category)

--- a/firstvoices/backend/models/signals/mtd_signals.py
+++ b/firstvoices/backend/models/signals/mtd_signals.py
@@ -21,10 +21,11 @@ def rebuild_mtd_index(site_slug):
 @receiver(pre_save, sender=DictionaryEntry)
 def store_current_visibility(sender, instance, **kwargs):
     # Adding old visibility to check later in post_save signal, if entry exists in the db
-    dictionary_entry = DictionaryEntry.objects.filter(id=instance.id)
-    if len(dictionary_entry):
-        old_visibility = dictionary_entry[0].visibility
-        instance.old_visibility = old_visibility
+    if not indexing_signals_paused(instance.site):
+        dictionary_entry = DictionaryEntry.objects.filter(id=instance.id)
+        if len(dictionary_entry):
+            old_visibility = dictionary_entry[0].visibility
+            instance.old_visibility = old_visibility
 
 
 @receiver(post_save, sender=DictionaryEntry)

--- a/firstvoices/backend/tests/test_tasks/test_mtd_index_rebuild.py
+++ b/firstvoices/backend/tests/test_tasks/test_mtd_index_rebuild.py
@@ -3,6 +3,7 @@ import pytest
 from backend.models import Category, DictionaryEntry, Site, Translation
 from backend.models.constants import AppRole, Visibility
 from backend.models.media import Audio, Image
+from backend.models.sites import SiteFeature
 from backend.tests.factories import get_app_admin
 
 
@@ -196,3 +197,15 @@ class TestMtdIndexRebuild:
 
         assert self.mocked_func.call_count == 3
         self.mocked_func.assert_called_with(self.site.slug)
+
+    def test_mtd_rebuld_not_run_on_entry_if_indexing_paused(self):
+        SiteFeature.objects.create(
+            site=self.site, key="indexing_paused", is_enabled=True
+        )
+
+        entry = DictionaryEntry(
+            title="test_entry", site=self.site, visibility=Visibility.PUBLIC
+        )
+        entry.save()
+
+        assert self.mocked_func.call_count == 0


### PR DESCRIPTION
### Description of Changes
- Pauses the `request_update_mtd_index` and `store_current_visibility` functions if `indexing_paused` is an enabled feature on the site

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] Admin Panel has been updated if models have been added or modified
- [x] Migrations have been updated and committed if applicable
- [x] Insomnia workspace has been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
