### PR TITLE
FW-5565 Enable hasVideo flag for video links

### DIFF
--- a/firstvoices/backend/search/indexing/dictionary_index.py
+++ b/firstvoices/backend/search/indexing/dictionary_index.py
@@ -32,7 +32,8 @@ class DictionaryEntryDocumentManager(DocumentManager):
             custom_order=instance.custom_order,
             visibility=instance.visibility,
             has_audio=instance.related_audio.exists(),
-            has_video=instance.related_videos.exists(),
+            has_video=instance.related_videos.exists()
+            or instance.related_video_links.exists(),
             has_image=instance.related_images.exists(),
             created=instance.created,
             last_modified=instance.last_modified,

--- a/firstvoices/backend/search/indexing/dictionary_index.py
+++ b/firstvoices/backend/search/indexing/dictionary_index.py
@@ -33,7 +33,7 @@ class DictionaryEntryDocumentManager(DocumentManager):
             visibility=instance.visibility,
             has_audio=instance.related_audio.exists(),
             has_video=instance.related_videos.exists()
-            or instance.related_video_links.exists(),
+            or bool(instance.related_video_links),
             has_image=instance.related_images.exists(),
             created=instance.created,
             last_modified=instance.last_modified,

--- a/firstvoices/backend/search/indexing/song_index.py
+++ b/firstvoices/backend/search/indexing/song_index.py
@@ -30,7 +30,7 @@ class SongDocumentManager(DocumentManager):
             acknowledgement=instance.acknowledgements,
             has_audio=instance.related_audio.exists(),
             has_video=instance.related_videos.exists()
-            or instance.related_video_links.exists(),
+            or bool(instance.related_video_links),
             has_image=instance.related_images.exists(),
             exclude_from_games=instance.exclude_from_games,
             exclude_from_kids=instance.exclude_from_kids,

--- a/firstvoices/backend/search/indexing/song_index.py
+++ b/firstvoices/backend/search/indexing/song_index.py
@@ -29,7 +29,8 @@ class SongDocumentManager(DocumentManager):
             note=instance.notes,
             acknowledgement=instance.acknowledgements,
             has_audio=instance.related_audio.exists(),
-            has_video=instance.related_videos.exists(),
+            has_video=instance.related_videos.exists()
+            or instance.related_video_links.exists(),
             has_image=instance.related_images.exists(),
             exclude_from_games=instance.exclude_from_games,
             exclude_from_kids=instance.exclude_from_kids,

--- a/firstvoices/backend/search/indexing/story_index.py
+++ b/firstvoices/backend/search/indexing/story_index.py
@@ -30,7 +30,8 @@ class StoryDocumentManager(DocumentManager):
             note=instance.notes,
             acknowledgement=instance.acknowledgements,
             has_audio=instance.related_audio.exists(),
-            has_video=instance.related_videos.exists(),
+            has_video=instance.related_videos.exists()
+            or instance.related_video_links.exists(),
             has_image=instance.related_images.exists(),
             exclude_from_games=instance.exclude_from_games,
             exclude_from_kids=instance.exclude_from_kids,

--- a/firstvoices/backend/search/indexing/story_index.py
+++ b/firstvoices/backend/search/indexing/story_index.py
@@ -31,7 +31,7 @@ class StoryDocumentManager(DocumentManager):
             acknowledgement=instance.acknowledgements,
             has_audio=instance.related_audio.exists(),
             has_video=instance.related_videos.exists()
-            or instance.related_video_links.exists(),
+            or bool(instance.related_video_links),
             has_image=instance.related_images.exists(),
             exclude_from_games=instance.exclude_from_games,
             exclude_from_kids=instance.exclude_from_kids,


### PR DESCRIPTION
### Description of Changes
- sets the hasVideo flag to `true` if a search item with media has an embedded video link

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
