### PR TITLE
FW-5683 Check that from visibility is equal to site visibilityin bulk visibility API

### DIFF
--- a/firstvoices/backend/serializers/job_serializers.py
+++ b/firstvoices/backend/serializers/job_serializers.py
@@ -128,10 +128,16 @@ class BulkVisibilityJobSerializer(CreateSiteContentSerializerMixin, BaseJobSeria
     def validate(self, attrs):
         from_visibility = attrs.get("from_visibility")
         to_visibility = attrs.get("to_visibility")
+        site = self.context["site"]
 
         if from_visibility == to_visibility:
             raise serializers.ValidationError(
                 "'from_visibility' and 'to_visibility' must be different."
+            )
+
+        if site.visibility != from_visibility:
+            raise serializers.ValidationError(
+                f"'from_visibility' must match the site visibility: {site.get_visibility_display().lower()}."
             )
 
         if abs(from_visibility - to_visibility) != 10:

--- a/firstvoices/backend/tests/test_apis/test_bulkvisibility_api.py
+++ b/firstvoices/backend/tests/test_apis/test_bulkvisibility_api.py
@@ -118,7 +118,7 @@ class TestBulkVisibilityEndpoints(
 
     @pytest.mark.django_db
     def test_more_than_1_visibility_bad_request_400(self):
-        site = factories.SiteFactory.create()
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
         user = factories.get_superadmin()
         self.client.force_authenticate(user=user)
 

--- a/firstvoices/backend/tests/test_apis/test_bulkvisibility_api.py
+++ b/firstvoices/backend/tests/test_apis/test_bulkvisibility_api.py
@@ -165,6 +165,30 @@ class TestBulkVisibilityEndpoints(
         }
 
     @pytest.mark.django_db
+    def test_from_visibility_different_than_sites_bad_request_400(self):
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+        user = factories.get_superadmin()
+        self.client.force_authenticate(user=user)
+
+        data = {
+            "from_visibility": "team",
+            "to_visibility": "members",
+        }
+
+        response = self.client.post(
+            self.get_list_endpoint(site_slug=site.slug), data=data, format="json"
+        )
+
+        assert response.status_code == 400
+
+        response_data = json.loads(response.content)
+        assert response_data == {
+            "nonFieldErrors": [
+                "'from_visibility' must match the site visibility: public."
+            ]
+        }
+
+    @pytest.mark.django_db
     def test_list_403_non_member(self):
         site = factories.SiteFactory.create()
         user = factories.UserFactory.create()


### PR DESCRIPTION
### Description of Changes
- Adds a validation case and test to ensure that `from_visibility` == the site's visibility to prevent users from changing visibility by more than 1 level at a time.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
