### PR TITLE
FW-5583 Fix Thumbnail Orientation

### DIFF
--- a/firstvoices/backend/models/media.py
+++ b/firstvoices/backend/models/media.py
@@ -16,6 +16,7 @@ from django.utils.translation import gettext as _
 from django_better_admin_arrayfield.models.fields import ArrayField
 from embed_video.fields import EmbedVideoField
 from PIL import Image as PILImage
+from PIL import ImageOps
 
 from backend.permissions import predicates
 from backend.tasks.media_tasks import generate_media_thumbnails
@@ -479,6 +480,7 @@ class Image(ThumbnailMixin, MediaBase):
 
     def create_thumbnail(self, img, output_size):
         output_img = BytesIO()
+        img = ImageOps.exif_transpose(img)  # Handle orientation
         img.thumbnail(output_size)
         # Remove transparency values if they exist so that the image can be converted to JPEG.
         try:


### PR DESCRIPTION
### Description of Changes
- Adds `ImageOps.exif_transpose()` to thumbnail generation to remove exif orientation data from original images when generating thumbnails.
- Adds a test to ensure exif orientation data is removed

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
