### PR TITLE
FW-5935 Remove site feature signal syncing media indexes

### DIFF
--- a/firstvoices/backend/search/signals/signal_utils.py
+++ b/firstvoices/backend/search/signals/signal_utils.py
@@ -11,7 +11,7 @@ from backend.models import (
 )
 from backend.models.dictionary import DictionaryEntryCategory
 from backend.models.media import Audio, Image, Video
-from backend.models.sites import LanguageFamily, SiteFeature
+from backend.models.sites import LanguageFamily
 from backend.search.signals import (
     change_site_visibility,
     remove_all_site_content,
@@ -29,7 +29,6 @@ from backend.search.signals import (
     sync_language_family_in_index,
     sync_language_in_index,
     sync_related_dictionary_entry_in_index,
-    sync_site_features_in_media_indexes,
     sync_site_in_language_index,
     sync_song_in_index,
     sync_song_lyrics_in_index,
@@ -54,7 +53,6 @@ signal_details = {
         (sync_audio_in_index, Audio),
         (sync_image_in_index, Image),
         (sync_video_in_index, Video),
-        (sync_site_features_in_media_indexes, SiteFeature),
     ],
     "pre_delete": [
         (remove_language_from_index, Language),
@@ -71,7 +69,6 @@ signal_details = {
         (remove_audio_from_index, Audio),
         (remove_image_from_index, Image),
         (remove_video_from_index, Video),
-        (sync_site_features_in_media_indexes, SiteFeature),
     ],
 }
 

--- a/firstvoices/backend/search/signals/site_signals.py
+++ b/firstvoices/backend/search/signals/site_signals.py
@@ -1,10 +1,9 @@
-from django.db.models.signals import post_delete, post_save, pre_save
+from django.db.models.signals import post_delete, pre_save
 from django.dispatch import receiver
 
-from backend.models.sites import Site, SiteFeature
+from backend.models.sites import Site
 from backend.search.tasks.site_content_indexing_tasks import (
     remove_all_site_content_from_indexes,
-    sync_all_media_site_content_in_indexes,
     sync_all_site_content_in_indexes,
 )
 
@@ -31,13 +30,6 @@ def change_site_visibility(sender, instance, **kwargs):
 @receiver(post_delete, sender=Site)
 def remove_all_site_content(sender, instance, **kwargs):
     remove_all_site_content_from_indexes(instance)
-
-
-@receiver(post_save, sender=SiteFeature)
-@receiver(post_delete, sender=SiteFeature)
-def sync_site_features_in_media_indexes(sender, instance, **kwargs):
-    site = instance.site
-    sync_all_media_site_content_in_indexes(site)
 
 
 def indexing_signals_paused(site):

--- a/firstvoices/backend/tests/test_apis/test_site_features_api.py
+++ b/firstvoices/backend/tests/test_apis/test_site_features_api.py
@@ -18,6 +18,12 @@ class TestSiteFeatureEndpoints(BaseUncontrolledSiteContentApiTest):
 
     model = SiteFeature
 
+    @pytest.fixture(scope="function", autouse=True)
+    def mocked_media_sync_func(self, mocker):
+        self.mocked_func = mocker.patch(
+            "backend.views.site_feature_views.sync_all_media_site_content_in_indexes"
+        )
+
     def get_lookup_key(self, instance):
         return instance.key
 
@@ -201,3 +207,75 @@ class TestSiteFeatureEndpoints(BaseUncontrolledSiteContentApiTest):
         )
 
         assert response.status_code == 201
+
+    @pytest.mark.django_db
+    def test_api_create_triggers_media_sync(self, mocked_media_sync_func):
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+        self.client.force_authenticate(user=factories.get_app_admin(AppRole.SUPERADMIN))
+
+        data = {
+            "key": self.TEST_KEY,
+            "isEnabled": True,
+        }
+
+        response = self.client.post(
+            self.get_list_endpoint(site_slug=site.slug),
+            format="json",
+            data=data,
+        )
+
+        assert response.status_code == 201
+        assert self.mocked_func.call_count == 1
+
+    @pytest.mark.django_db
+    def test_api_update_triggers_media_sync(self):
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+        feature = factories.SiteFeatureFactory.create(site=site)
+        self.client.force_authenticate(user=factories.get_app_admin(AppRole.SUPERADMIN))
+
+        data = {
+            "key": feature.key,
+            "isEnabled": False,
+        }
+
+        response = self.client.put(
+            self.get_detail_endpoint(key=feature.key, site_slug=site.slug),
+            format="json",
+            data=data,
+        )
+
+        assert response.status_code == 200
+        assert self.mocked_func.call_count == 1
+
+    @pytest.mark.django_db
+    def test_api_delete_triggers_media_sync(self):
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+        feature = factories.SiteFeatureFactory.create(site=site)
+        self.client.force_authenticate(user=factories.get_app_admin(AppRole.SUPERADMIN))
+
+        response = self.client.delete(
+            self.get_detail_endpoint(key=feature.key, site_slug=site.slug),
+            format="json",
+        )
+
+        assert response.status_code == 204
+        assert self.mocked_func.call_count == 1
+
+    @pytest.mark.django_db
+    def test_api_patch_triggers_media_sync(self):
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+        feature = factories.SiteFeatureFactory.create(site=site)
+        self.client.force_authenticate(user=factories.get_app_admin(AppRole.SUPERADMIN))
+
+        data = {
+            "isEnabled": False,
+        }
+
+        response = self.client.patch(
+            self.get_detail_endpoint(key=feature.key, site_slug=site.slug),
+            format="json",
+            data=data,
+        )
+
+        assert response.status_code == 200
+        assert self.mocked_func.call_count == 1

--- a/firstvoices/backend/tests/test_models/test_site_feature_model.py
+++ b/firstvoices/backend/tests/test_models/test_site_feature_model.py
@@ -1,0 +1,39 @@
+import pytest
+
+from backend.models.sites import SiteFeature
+from backend.tests.factories import SiteFactory
+
+
+class TestSiteFeatureModel:
+    """
+    Tests for the SiteFeature model.
+    Primarily tests that the model does not trigger a media sync outside of the API.
+    """
+
+    @pytest.fixture(scope="function", autouse=True)
+    def mocked_media_sync_func(self, mocker):
+        self.mocked_func = mocker.patch(
+            "backend.search.tasks.site_content_indexing_tasks.sync_all_media_site_content_in_indexes"
+        )
+
+    @pytest.fixture
+    def site(self):
+        return SiteFactory.create(slug="test")
+
+    @pytest.mark.django_db
+    def test_create_does_not_trigger_media_sync(self, site):
+        SiteFeature.objects.create(site=site, key="test_key", is_enabled=True)
+        assert self.mocked_func.call_count == 0
+
+    @pytest.mark.django_db
+    def test_update_does_not_trigger_media_sync(self, site):
+        feature = SiteFeature.objects.create(site=site, key="test_key", is_enabled=True)
+        feature.is_enabled = False
+        feature.save()
+        assert self.mocked_func.call_count == 0
+
+    @pytest.mark.django_db
+    def test_delete_does_not_trigger_media_sync(self, site):
+        feature = SiteFeature.objects.create(site=site, key="test_key", is_enabled=True)
+        feature.delete()
+        assert self.mocked_func.call_count == 0

--- a/firstvoices/backend/tests/test_search_indexing/test_site_signals.py
+++ b/firstvoices/backend/tests/test_search_indexing/test_site_signals.py
@@ -145,32 +145,6 @@ class TestSiteSignals(TransactionOnCommitMixin):
             document_manager_mocks, VideoDocumentManager, video
         )
 
-    @pytest.mark.parametrize("action", ["save", "delete"])
-    @pytest.mark.django_db
-    def test_edit_site_features_syncs_media_index(
-        self, index_manager_mocks, document_manager_mocks, action
-    ):
-        with self.capture_on_commit_callbacks(execute=True):
-            site = factories.SiteFactory.create()
-            audio = factories.AudioFactory.create(site=site)
-            image = factories.ImageFactory.create(site=site)
-            video = factories.VideoFactory.create(site=site)
-            feature = factories.SiteFeatureFactory.create(site=site, is_enabled=False)
-
-        self.reset_all_mocks(index_manager_mocks)
-        self.reset_all_mocks(document_manager_mocks)
-
-        with self.capture_on_commit_callbacks(execute=True):
-            if action == "save":
-                feature.is_enabled = True
-                feature.save()
-            else:
-                feature.delete()
-
-        self.assert_document_synced(document_manager_mocks, AudioDocumentManager, audio)
-        self.assert_document_synced(document_manager_mocks, ImageDocumentManager, image)
-        self.assert_document_synced(document_manager_mocks, VideoDocumentManager, video)
-
     def reset_all_mocks(self, mocks):
         for mock in mocks.values():
             mock.reset_mock()

--- a/firstvoices/backend/views/site_feature_views.py
+++ b/firstvoices/backend/views/site_feature_views.py
@@ -2,6 +2,9 @@ from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_
 from rest_framework.viewsets import ModelViewSet
 
 from backend.models.sites import SiteFeature
+from backend.search.tasks.site_content_indexing_tasks import (
+    sync_all_media_site_content_in_indexes,
+)
 from backend.serializers.site_feature_serializers import SiteFeatureDetailSerializer
 from backend.views import doc_strings
 from backend.views.api_doc_variables import key_parameter, site_slug_parameter
@@ -37,7 +40,8 @@ from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSe
         ],
     ),
     create=extend_schema(
-        description="Create a new feature flag for the site. Site feature keys cannot be changed after creation.",
+        description="Create a new feature flag for the site. Site feature keys cannot be changed after creation. "
+        "Triggers a reindex of all media content in the site.",
         responses={
             201: OpenApiResponse(
                 description=doc_strings.success_201,
@@ -50,7 +54,8 @@ from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSe
         parameters=[site_slug_parameter],
     ),
     update=extend_schema(
-        description="Edit a feature flag for the specified site. Site feature keys cannot be changed after creation.",
+        description="Edit a feature flag for the specified site. Site feature keys cannot be changed after creation."
+        "Triggers a reindex of all media content in the site.",
         responses={
             200: OpenApiResponse(
                 description=doc_strings.success_200_edit,
@@ -66,7 +71,8 @@ from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSe
         ],
     ),
     partial_update=extend_schema(
-        description="Edit a feature flag for the specified site. Any omitted fields will be unchanged.",
+        description="Edit a feature flag for the specified site. Any omitted fields will be unchanged."
+        "Triggers a reindex of all media content in the site.",
         responses={
             200: OpenApiResponse(
                 description=doc_strings.success_200_edit,
@@ -82,7 +88,8 @@ from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSe
         ],
     ),
     destroy=extend_schema(
-        description="Delete a feature flag from the specified site.",
+        description="Delete a feature flag from the specified site. "
+        "Triggers a reindex of all media content in the site.",
         responses={
             204: OpenApiResponse(description=doc_strings.success_204_deleted),
             403: OpenApiResponse(description=doc_strings.error_403),
@@ -109,3 +116,21 @@ class SiteFeatureViewSet(
             "created_by",
             "last_modified_by",
         )
+
+    def perform_create(self, serializer):
+        # Once a site feature is created via the API, sync all media content in indexes
+        instance = serializer.save()
+        site = instance.site
+        sync_all_media_site_content_in_indexes(site)
+
+    def perform_update(self, serializer):
+        # Once a site feature is updated via the API, sync all media content in indexes
+        instance = serializer.save()
+        site = instance.site
+        sync_all_media_site_content_in_indexes(site)
+
+    def perform_destroy(self, instance):
+        # Once a site feature is deleted via the API, sync all media content in indexes
+        site = instance.site
+        instance.delete()
+        sync_all_media_site_content_in_indexes(site)


### PR DESCRIPTION
### Description of Changes
- Removes the signal tied to site features that re-indexed a site's media on create and delete
- Added synchronous media indexing that runs only when the site feature API is used
- Added tests to ensure the media sync does not occur when site features are created/modified/deleted directly in the django db
- Added tests to ensure the reindexing does occur when using the site feature API

### Checklist
- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Insomnia workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
