### PR TITLE
FW-5953 Add standardised logging to async tasks

### DIFF
--- a/firstvoices/backend/search/tasks/index_manager_tasks.py
+++ b/firstvoices/backend/search/tasks/index_manager_tasks.py
@@ -1,8 +1,10 @@
 from celery import shared_task
+from celery.utils.log import get_task_logger
 from django.db import transaction
 
 from backend.search import es_logging, indexing
 from backend.search.indexing import DocumentManager
+from backend.tasks.utils import ASYNC_TASK_END_TEMPLATE, ASYNC_TASK_START_TEMPLATE
 from firstvoices.celery import link_error_handler
 
 
@@ -21,24 +23,48 @@ def _get_manager(manager_name: str) -> DocumentManager:
 
 @shared_task
 def sync_in_index(document_manager_name, instance_id):
+    logger = get_task_logger(__name__)
+    logger.info(
+        ASYNC_TASK_START_TEMPLATE,
+        f"document_manager_name: {document_manager_name}, instance_id: {instance_id}",
+    )
+
     document_manager = _get_manager(document_manager_name)
     if document_manager:
         document_manager.sync_in_index(instance_id)
 
+    logger.info(ASYNC_TASK_END_TEMPLATE)
+
 
 @shared_task
 def update_in_index(document_manager_name, instance_id):
+    logger = get_task_logger(__name__)
+    logger.info(
+        ASYNC_TASK_START_TEMPLATE,
+        f"document_manager_name: {document_manager_name}, instance_id: {instance_id}",
+    )
+
     document_manager = _get_manager(document_manager_name)
     instance = document_manager.model.objects.filter(id=instance_id)
     if instance.exists() and document_manager:
         document_manager.update_in_index(instance.first())
 
+    logger.info(ASYNC_TASK_END_TEMPLATE)
+
 
 @shared_task
 def remove_from_index(document_manager_name, instance_id):
+    logger = get_task_logger(__name__)
+    logger.info(
+        ASYNC_TASK_START_TEMPLATE,
+        f"document_manager_name: {document_manager_name}, instance_id: {instance_id}",
+    )
+
     document_manager = _get_manager(document_manager_name)
     if document_manager:
         document_manager.remove_from_index(instance_id)
+
+    logger.info(ASYNC_TASK_END_TEMPLATE)
 
 
 # convenience methods for calling the async tasks

--- a/firstvoices/backend/search/tasks/site_content_indexing_tasks.py
+++ b/firstvoices/backend/search/tasks/site_content_indexing_tasks.py
@@ -1,4 +1,5 @@
 from celery import shared_task
+from celery.utils.log import get_task_logger
 
 from backend.search.indexing import (
     AudioDocumentManager,
@@ -8,6 +9,7 @@ from backend.search.indexing import (
     StoryDocumentManager,
     VideoDocumentManager,
 )
+from backend.tasks.utils import ASYNC_TASK_END_TEMPLATE, ASYNC_TASK_START_TEMPLATE
 
 # special tasks for bulk Site content indexing actions
 
@@ -19,12 +21,17 @@ def remove_all(document_manager, queryset):
 
 @shared_task
 def remove_all_site_content_from_indexes(site):
+    logger = get_task_logger(__name__)
+    logger.info(ASYNC_TASK_START_TEMPLATE, f"site: {site}")
+
     remove_all(DictionaryEntryDocumentManager, site.dictionaryentry_set.all())
     remove_all(SongDocumentManager, site.song_set.all())
     remove_all(StoryDocumentManager, site.story_set.all())
     remove_all(AudioDocumentManager, site.audio_set.all())
     remove_all(ImageDocumentManager, site.image_set.all())
     remove_all(VideoDocumentManager, site.video_set.all())
+
+    logger.info(ASYNC_TASK_END_TEMPLATE)
 
 
 def sync_all(document_manager, queryset):
@@ -34,14 +41,24 @@ def sync_all(document_manager, queryset):
 
 @shared_task
 def sync_all_site_content_in_indexes(site):
+    logger = get_task_logger(__name__)
+    logger.info(ASYNC_TASK_START_TEMPLATE, f"site: {site}")
+
     sync_all(DictionaryEntryDocumentManager, site.dictionaryentry_set.all())
     sync_all(SongDocumentManager, site.song_set.all())
     sync_all(StoryDocumentManager, site.story_set.all())
     sync_all_media_site_content_in_indexes(site)
 
+    logger.info(ASYNC_TASK_END_TEMPLATE)
+
 
 @shared_task
 def sync_all_media_site_content_in_indexes(site):
+    logger = get_task_logger(__name__)
+    logger.info(ASYNC_TASK_START_TEMPLATE, f"site: {site}")
+
     sync_all(AudioDocumentManager, site.audio_set.all())
     sync_all(ImageDocumentManager, site.image_set.all())
     sync_all(VideoDocumentManager, site.video_set.all())
+
+    logger.info(ASYNC_TASK_END_TEMPLATE)

--- a/firstvoices/backend/tasks/alphabet_tasks.py
+++ b/firstvoices/backend/tasks/alphabet_tasks.py
@@ -1,4 +1,5 @@
 from celery import current_task, shared_task
+from celery.utils.log import get_task_logger
 
 from backend.models import (
     Alphabet,
@@ -6,6 +7,7 @@ from backend.models import (
     DictionaryEntry,
     Site,
 )
+from backend.tasks.utils import ASYNC_TASK_END_TEMPLATE, ASYNC_TASK_START_TEMPLATE
 
 
 @shared_task
@@ -14,6 +16,8 @@ def recalculate_custom_order_preview(site_slug: str):
     Generates a preview of the changes that will be made to the custom order
     and title of entries in a site's dictionary.
     """
+    logger = get_task_logger(__name__)
+    logger.info(ASYNC_TASK_START_TEMPLATE, f"site_slug: {site_slug}")
 
     site = Site.objects.get(slug=site_slug)
     alphabet = Alphabet.objects.get_or_create(site=site)[0]
@@ -72,6 +76,8 @@ def recalculate_custom_order_preview(site_slug: str):
         is_preview=True,
     )
 
+    logger.info(ASYNC_TASK_END_TEMPLATE)
+
     return preview
 
 
@@ -81,6 +87,8 @@ def recalculate_custom_order(site_slug: str):
     Returns the same format as recalculate_custom_order_preview, but actually updates the custom order and
     title of entries in a site's dictionary by saving the entries.
     """
+    logger = get_task_logger(__name__)
+    logger.info(ASYNC_TASK_START_TEMPLATE, f"site_slug: {site_slug}")
 
     site = Site.objects.get(slug=site_slug)
     alphabet = Alphabet.objects.get_or_create(site=site)[0]
@@ -140,6 +148,8 @@ def recalculate_custom_order(site_slug: str):
         task_id=task_id,
         is_preview=False,
     )
+
+    logger.info(ASYNC_TASK_END_TEMPLATE)
 
     return results
 

--- a/firstvoices/backend/tasks/import_job_tasks.py
+++ b/firstvoices/backend/tasks/import_job_tasks.py
@@ -10,6 +10,7 @@ from backend.models.import_jobs import (
     RowStatus,
 )
 from backend.resources.dictionary import DictionaryEntryResource
+from backend.tasks.utils import ASYNC_TASK_END_TEMPLATE, ASYNC_TASK_START_TEMPLATE
 
 VALID_HEADERS = [
     "title",
@@ -90,6 +91,10 @@ def execute_dry_run_import(import_job_instance_id, *args, **kwargs):
     logger = get_task_logger(__name__)
     task_id = current_task.request.id
 
+    logger.info(
+        ASYNC_TASK_START_TEMPLATE, f"import_job_instance_id: {import_job_instance_id}"
+    )
+
     import_job_instance = ImportJob.objects.get(id=import_job_instance_id)
     import_job_instance.validation_task_id = task_id
     import_job_instance.validation_status = JobStatus.STARTED
@@ -161,3 +166,5 @@ def execute_dry_run_import(import_job_instance_id, *args, **kwargs):
     # Connecting back search indexing signals
     # connect_signals()
     # logger.info("Re-connected all search index related signals")
+
+    logger.info(ASYNC_TASK_END_TEMPLATE)

--- a/firstvoices/backend/tasks/media_tasks.py
+++ b/firstvoices/backend/tasks/media_tasks.py
@@ -1,18 +1,29 @@
 from celery import shared_task
+from celery.utils.log import get_task_logger
 from django.apps import apps
 from django.db import transaction
 
+from backend.tasks.utils import ASYNC_TASK_END_TEMPLATE, ASYNC_TASK_START_TEMPLATE
+
 
 @shared_task
-def generate_media_thumbnails(model_name: str, id: str):
+def generate_media_thumbnails(model_name: str, instance_id: str):
     """
     Calls generate_resized_images on the specified media object
     """
+    logger = get_task_logger(__name__)
+    logger.info(
+        ASYNC_TASK_START_TEMPLATE,
+        f"model_name: {model_name}, instance_id: {instance_id}",
+    )
+
     model_class = apps.get_model(app_label="backend", model_name=model_name)
 
     with transaction.atomic():
         # can raise DoesNotExist, but just let it flow up
-        instance = model_class.objects.get(id=id)
+        instance = model_class.objects.get(id=instance_id)
         # again, let the exceptions be logged -- nothing useful we can do here
         instance.generate_resized_images()
         instance.save(generate_thumbnails=False)
+
+    logger.info(ASYNC_TASK_END_TEMPLATE)

--- a/firstvoices/backend/tasks/send_email_tasks.py
+++ b/firstvoices/backend/tasks/send_email_tasks.py
@@ -1,9 +1,11 @@
-import logging
 from smtplib import SMTPException
 
 from celery import shared_task
+from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.core.mail import send_mail
+
+from backend.tasks.utils import ASYNC_TASK_END_TEMPLATE, ASYNC_TASK_START_TEMPLATE
 
 
 @shared_task
@@ -11,7 +13,9 @@ def send_email_task(subject, message, to_email_list):
     """
     Sends an email using the email backend specified in settings.py
     """
-    logger = logging.getLogger(__name__)
+    logger = get_task_logger(__name__)
+    logger.info(ASYNC_TASK_START_TEMPLATE, "")
+
     try:
         message = (
             message
@@ -25,3 +29,5 @@ def send_email_task(subject, message, to_email_list):
         )
     except (ConnectionRefusedError, SMTPException) as e:
         logger.error(f"Failed to send email. Error: {e}")
+
+    logger.info(ASYNC_TASK_END_TEMPLATE)

--- a/firstvoices/backend/tasks/utils.py
+++ b/firstvoices/backend/tasks/utils.py
@@ -1,0 +1,2 @@
+ASYNC_TASK_START_TEMPLATE = "Task started. Additional info: %s."
+ASYNC_TASK_END_TEMPLATE = "Task ended."

--- a/firstvoices/backend/tasks/visibility_tasks.py
+++ b/firstvoices/backend/tasks/visibility_tasks.py
@@ -31,9 +31,9 @@ def bulk_change_visibility(job_instance_id):
         cancelled_message = "Job cancelled as another bulk visibility job is already in progress for the same site."
         job.status = JobStatus.CANCELLED
         job.message = cancelled_message
+        job.save()
         logger.info(cancelled_message)
         logger.info(ASYNC_TASK_END_TEMPLATE)
-        job.save()
         return
 
     job.status = JobStatus.STARTED
@@ -70,12 +70,13 @@ def bulk_change_visibility(job_instance_id):
         job.status = JobStatus.FAILED
         error_message = str(e)
         job.message = error_message
-        logger.error(error_message)
-        logger.info(ASYNC_TASK_END_TEMPLATE)
         job.save()
 
         indexing_paused_feature[0].is_enabled = False
         indexing_paused_feature[0].save()
+
+        logger.error(error_message)
+        logger.info(ASYNC_TASK_END_TEMPLATE)
         return
 
     # Resume search indexing for site, + reindex entire site

--- a/firstvoices/backend/tasks/visibility_tasks.py
+++ b/firstvoices/backend/tasks/visibility_tasks.py
@@ -1,4 +1,5 @@
 from celery import shared_task
+from celery.utils.log import get_task_logger
 from django.db import transaction
 
 from backend.models import DictionaryEntry, SitePage, Song, Story, StoryPage
@@ -8,6 +9,7 @@ from backend.models.widget import SiteWidget
 from backend.search.tasks.site_content_indexing_tasks import (
     sync_all_site_content_in_indexes,
 )
+from backend.tasks.utils import ASYNC_TASK_END_TEMPLATE, ASYNC_TASK_START_TEMPLATE
 
 
 @shared_task
@@ -15,6 +17,10 @@ def bulk_change_visibility(job_instance_id):
     """
     Changes the visibility of all site content from one visibility to another.
     """
+
+    logger = get_task_logger(__name__)
+    logger.info(ASYNC_TASK_START_TEMPLATE, f"job_instance_id: {job_instance_id}")
+
     job = BulkVisibilityJob.objects.get(id=job_instance_id)
     site = job.site
     indexing_paused_feature = SiteFeature.objects.get_or_create(
@@ -22,8 +28,10 @@ def bulk_change_visibility(job_instance_id):
     )
 
     if BulkVisibilityJob.objects.filter(status=JobStatus.STARTED, site=site).exists():
+        cancelled_message = "Job cancelled as another bulk visibility job is already in progress for the same site."
         job.status = JobStatus.CANCELLED
-        job.message = "Job cancelled as another bulk visibility job is already in progress for the same site."
+        job.message = cancelled_message
+        logger.error(cancelled_message)
         job.save()
         return
 
@@ -59,7 +67,9 @@ def bulk_change_visibility(job_instance_id):
         # if there’s an error during the updates:
         # add the message to the batch visibility job instance and set the status to failed
         job.status = JobStatus.FAILED
-        job.message = str(e)
+        error_message = str(e)
+        job.message = error_message
+        logger.error(error_message)
         job.save()
 
         indexing_paused_feature[0].is_enabled = False
@@ -74,3 +84,5 @@ def bulk_change_visibility(job_instance_id):
     # update status of job at each step
     job.status = JobStatus.COMPLETE
     job.save()
+
+    logger.info(ASYNC_TASK_END_TEMPLATE)

--- a/firstvoices/backend/tasks/visibility_tasks.py
+++ b/firstvoices/backend/tasks/visibility_tasks.py
@@ -31,7 +31,8 @@ def bulk_change_visibility(job_instance_id):
         cancelled_message = "Job cancelled as another bulk visibility job is already in progress for the same site."
         job.status = JobStatus.CANCELLED
         job.message = cancelled_message
-        logger.error(cancelled_message)
+        logger.info(cancelled_message)
+        logger.info(ASYNC_TASK_END_TEMPLATE)
         job.save()
         return
 
@@ -70,6 +71,7 @@ def bulk_change_visibility(job_instance_id):
         error_message = str(e)
         job.message = error_message
         logger.error(error_message)
+        logger.info(ASYNC_TASK_END_TEMPLATE)
         job.save()
 
         indexing_paused_feature[0].is_enabled = False

--- a/firstvoices/backend/tests/test_apis/test_contact_us_api.py
+++ b/firstvoices/backend/tests/test_apis/test_contact_us_api.py
@@ -95,7 +95,7 @@ class TestContactUsEndpoint(WriteApiTestMixin, BaseApiTest):
     )
     @pytest.mark.django_db
     def test_post_smtp_connection_refused(self, caplog, exception):
-        caplog.set_level("ERROR")
+        caplog.set_level("INFO")
         site = factories.SiteFactory.create(
             slug="test",
             visibility=Visibility.PUBLIC,
@@ -118,6 +118,11 @@ class TestContactUsEndpoint(WriteApiTestMixin, BaseApiTest):
             assert response.status_code == 202
             assert len(mail.outbox) == 0
             assert f"Failed to send email. Error: {exception}" in caplog.text
+
+        assert (
+            "Task started." in caplog.text
+        )  # No additional info in async send_email_task task.
+        assert "Task ended." in caplog.text
 
     @pytest.mark.parametrize("role", [Role.MEMBER, Role.EDITOR, Role.LANGUAGE_ADMIN])
     @pytest.mark.django_db

--- a/firstvoices/backend/tests/test_search_indexing/base_indexing_tests.py
+++ b/firstvoices/backend/tests/test_search_indexing/base_indexing_tests.py
@@ -753,15 +753,21 @@ class BaseSignalTest(TransactionOnCommitMixin):
         }
 
     @pytest.mark.django_db
-    def test_new_instance_is_synced(self, mock_index_methods):
+    def test_new_instance_is_synced(self, mock_index_methods, caplog):
         with self.capture_on_commit_callbacks(execute=True):
             instance = self.factory.create()
 
         mock_index_methods["mock_sync"].assert_called_with(instance.id)
         mock_index_methods["mock_remove"].assert_not_called()
 
+        assert (
+            f"Task started. Additional info: document_manager_name: {self.manager.__name__}, instance_id: {instance.id}"
+            in caplog.text
+        )
+        assert "Task ended." in caplog.text
+
     @pytest.mark.django_db
-    def test_edited_instance_is_synced(self, mock_index_methods):
+    def test_edited_instance_is_synced(self, mock_index_methods, caplog):
         with self.capture_on_commit_callbacks(execute=True):
             instance = self.factory.create()
 
@@ -774,8 +780,14 @@ class BaseSignalTest(TransactionOnCommitMixin):
         mock_index_methods["mock_sync"].assert_called_once_with(instance.id)
         mock_index_methods["mock_remove"].assert_not_called()
 
+        assert (
+            f"Task started. Additional info: document_manager_name: {self.manager.__name__}, instance_id: {instance.id}"
+            in caplog.text
+        )
+        assert "Task ended." in caplog.text
+
     @pytest.mark.django_db
-    def test_deleted_instance_is_removed(self, mock_index_methods):
+    def test_deleted_instance_is_removed(self, mock_index_methods, caplog):
         with self.capture_on_commit_callbacks(execute=True):
             instance = self.factory.create()
             instance_id = instance.id
@@ -787,6 +799,12 @@ class BaseSignalTest(TransactionOnCommitMixin):
 
         mock_index_methods["mock_remove"].assert_called_once_with(instance_id)
         mock_index_methods["mock_sync"].assert_not_called()
+
+        assert (
+            f"Task started. Additional info: document_manager_name: {self.manager.__name__}, instance_id: {instance_id}"
+            in caplog.text
+        )
+        assert "Task ended." in caplog.text
 
 
 class BaseRelatedInstanceSignalTest(BaseSignalTest):

--- a/firstvoices/backend/tests/test_search_indexing/base_indexing_tests.py
+++ b/firstvoices/backend/tests/test_search_indexing/base_indexing_tests.py
@@ -6,6 +6,7 @@ import pytest
 from django.db import DEFAULT_DB_ALIAS, connections
 from elasticsearch import ConnectionError, NotFoundError
 
+from backend.tasks.utils import ASYNC_TASK_END_TEMPLATE
 from backend.tests import factories
 
 TEST_SEARCH_INDEX_ID = "test search index id"
@@ -764,7 +765,7 @@ class BaseSignalTest(TransactionOnCommitMixin):
             f"Task started. Additional info: document_manager_name: {self.manager.__name__}, instance_id: {instance.id}"
             in caplog.text
         )
-        assert "Task ended." in caplog.text
+        assert ASYNC_TASK_END_TEMPLATE in caplog.text
 
     @pytest.mark.django_db
     def test_edited_instance_is_synced(self, mock_index_methods, caplog):
@@ -784,7 +785,7 @@ class BaseSignalTest(TransactionOnCommitMixin):
             f"Task started. Additional info: document_manager_name: {self.manager.__name__}, instance_id: {instance.id}"
             in caplog.text
         )
-        assert "Task ended." in caplog.text
+        assert ASYNC_TASK_END_TEMPLATE in caplog.text
 
     @pytest.mark.django_db
     def test_deleted_instance_is_removed(self, mock_index_methods, caplog):
@@ -804,7 +805,7 @@ class BaseSignalTest(TransactionOnCommitMixin):
             f"Task started. Additional info: document_manager_name: {self.manager.__name__}, instance_id: {instance_id}"
             in caplog.text
         )
-        assert "Task ended." in caplog.text
+        assert ASYNC_TASK_END_TEMPLATE in caplog.text
 
 
 class BaseRelatedInstanceSignalTest(BaseSignalTest):

--- a/firstvoices/backend/tests/test_search_indexing/test_site_signals.py
+++ b/firstvoices/backend/tests/test_search_indexing/test_site_signals.py
@@ -13,6 +13,7 @@ from backend.search.indexing import (
     StoryIndexManager,
     VideoDocumentManager,
 )
+from backend.tasks.utils import ASYNC_TASK_END_TEMPLATE
 from backend.tests import factories
 from backend.tests.test_search_indexing.base_indexing_tests import (
     TransactionOnCommitMixin,
@@ -65,7 +66,7 @@ class TestSiteSignals(TransactionOnCommitMixin):
 
     @pytest.mark.django_db
     def test_edit_site_title_does_not_affect_index(
-        self, index_manager_mocks, document_manager_mocks
+        self, index_manager_mocks, document_manager_mocks, caplog
     ):
         with self.capture_on_commit_callbacks(execute=True):
             site = factories.SiteFactory.create()
@@ -80,9 +81,12 @@ class TestSiteSignals(TransactionOnCommitMixin):
         self.assert_no_mocks_called(index_manager_mocks)
         self.assert_no_mocks_called(document_manager_mocks)
 
+        # Verify that no task from site_indexing_tasks was started
+        assert "site_content_indexing_tasks" not in caplog.text
+
     @pytest.mark.django_db
     def test_edit_site_visibility_syncs_index(
-        self, index_manager_mocks, document_manager_mocks
+        self, index_manager_mocks, document_manager_mocks, caplog
     ):
         with self.capture_on_commit_callbacks(execute=True):
             site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
@@ -109,9 +113,12 @@ class TestSiteSignals(TransactionOnCommitMixin):
         self.assert_document_synced(document_manager_mocks, ImageDocumentManager, image)
         self.assert_document_synced(document_manager_mocks, VideoDocumentManager, video)
 
+        assert f"Task started. Additional info: site: {site}" in caplog.text
+        assert ASYNC_TASK_END_TEMPLATE in caplog.text
+
     @pytest.mark.django_db
     def test_delete_site_removes_all_content_from_index(
-        self, index_manager_mocks, document_manager_mocks
+        self, index_manager_mocks, document_manager_mocks, caplog
     ):
         with self.capture_on_commit_callbacks(execute=True):
             site = factories.SiteFactory.create()
@@ -145,10 +152,13 @@ class TestSiteSignals(TransactionOnCommitMixin):
             document_manager_mocks, VideoDocumentManager, video
         )
 
+        assert f"Task started. Additional info: site: {site}" in caplog.text
+        assert ASYNC_TASK_END_TEMPLATE in caplog.text
+
     @pytest.mark.parametrize("action", ["save", "delete"])
     @pytest.mark.django_db
     def test_edit_site_features_syncs_media_index(
-        self, index_manager_mocks, document_manager_mocks, action
+        self, index_manager_mocks, document_manager_mocks, action, caplog
     ):
         with self.capture_on_commit_callbacks(execute=True):
             site = factories.SiteFactory.create()
@@ -171,24 +181,32 @@ class TestSiteSignals(TransactionOnCommitMixin):
         self.assert_document_synced(document_manager_mocks, ImageDocumentManager, image)
         self.assert_document_synced(document_manager_mocks, VideoDocumentManager, video)
 
-    def reset_all_mocks(self, mocks):
+        assert f"Task started. Additional info: site: {site}" in caplog.text
+        assert ASYNC_TASK_END_TEMPLATE in caplog.text
+
+    @staticmethod
+    def reset_all_mocks(mocks):
         for mock in mocks.values():
             mock.reset_mock()
 
-    def assert_no_mocks_called(self, mocks):
+    @staticmethod
+    def assert_no_mocks_called(mocks):
         for mock in mocks.values():
             mock.assert_not_called()
 
-    def assert_all_called_once_with(self, mocks, called_with):
+    @staticmethod
+    def assert_all_called_once_with(mocks, called_with):
         for mock in mocks.values():
             mock.assert_called_once_with(**called_with)
 
-    def assert_document_removed(self, mocks, document_manager, instance):
+    @staticmethod
+    def assert_document_removed(mocks, document_manager, instance):
         mocks[document_manager.__name__ + "_remove_from_index"].assert_called_once_with(
             instance.id
         )
 
-    def assert_document_synced(self, mocks, document_manager, instance):
+    @staticmethod
+    def assert_document_synced(mocks, document_manager, instance):
         mocks[document_manager.__name__ + "_sync_in_index"].assert_called_once_with(
             instance.id
         )

--- a/firstvoices/backend/tests/test_tasks/test_build_mtd.py
+++ b/firstvoices/backend/tests/test_tasks/test_build_mtd.py
@@ -1,30 +1,34 @@
-import logging
-
 import pytest
 
 from backend.models import MTDExportFormat
 from backend.models.constants import Visibility
 from backend.models.dictionary import TypeOfDictionaryEntry
 from backend.tasks.build_mtd_export_format import build_index_and_calculate_scores
+from backend.tasks.utils import ASYNC_TASK_END_TEMPLATE
 from backend.tests import factories
-
-LOGGER = logging.getLogger(__name__)
 
 
 class TestMTDIndexAndScoreTask:
     sample_entry_title = "title_one word"
+
+    @staticmethod
+    def assert_async_task_logs(site, caplog):
+        assert f"Task started. Additional info: site: {site.slug}." in caplog.text
+        assert ASYNC_TASK_END_TEMPLATE in caplog.text
 
     @pytest.fixture
     def site(self):
         return factories.SiteFactory.create(slug="test")
 
     @pytest.mark.django_db
-    def test_build_empty(self, site):
+    def test_build_empty(self, site, caplog):
         result = build_index_and_calculate_scores(site.slug)
         assert result["config"]["L1"] == site.title
         assert len(result["data"]) == 0
         assert len(result["l1_index"]) == 0
         assert len(result["l2_index"]) == 0
+
+        self.assert_async_task_logs(site, caplog)
 
     @pytest.mark.django_db
     def test_validation_error(self, site, caplog):
@@ -46,6 +50,8 @@ class TestMTDIndexAndScoreTask:
         assert str(entry_one.id) in caplog.text
         # Logs the type of error, in this case, Definition (str, required) is None
         assert "type=string_type, input_value=None" in caplog.text
+
+        self.assert_async_task_logs(site, caplog)
 
     @pytest.mark.django_db
     def test_only_include_public_entries(self, site):
@@ -78,7 +84,7 @@ class TestMTDIndexAndScoreTask:
         assert not saved_export_format.latest().is_preview
 
     @pytest.mark.django_db
-    def test_build_and_score(self, site):
+    def test_build_and_score(self, site, caplog):
         # Add some entries
         speaker = factories.PersonFactory.create(site=site)
         audio = factories.AudioFactory.create(site=site)
@@ -146,6 +152,8 @@ class TestMTDIndexAndScoreTask:
         assert len(result["data"][1]["audio"]) == 1
         assert result["data"][1]["img"] is not None
         assert len(result["data"][1]["video"]) == 1
+
+        self.assert_async_task_logs(site, caplog)
 
     @pytest.mark.django_db
     def test_old_results_removed(self, site):

--- a/firstvoices/backend/tests/test_tasks/test_import_job_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_import_job_tasks.py
@@ -14,9 +14,7 @@ class TestDryRunImport:
     def test_import_task_logs(self, caplog):
         site = SiteFactory(visibility=Visibility.PUBLIC)
 
-        file_content = get_sample_file(
-            "import_job/import_job_minimal.csv", self.MIMETYPE
-        )
+        file_content = get_sample_file("import_job/minimal.csv", self.MIMETYPE)
         file = FileFactory(content=file_content)
         import_job_instance = ImportJobFactory(site=site, data=file)
 

--- a/firstvoices/backend/tests/test_tasks/test_import_job_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_import_job_tasks.py
@@ -11,6 +11,23 @@ from backend.tests.utils import get_sample_file
 class TestDryRunImport:
     MIMETYPE = "text/csv"
 
+    def test_import_task_logs(self, caplog):
+        site = SiteFactory(visibility=Visibility.PUBLIC)
+
+        file_content = get_sample_file(
+            "import_job/import_job_minimal.csv", self.MIMETYPE
+        )
+        file = FileFactory(content=file_content)
+        import_job_instance = ImportJobFactory(site=site, data=file)
+
+        execute_dry_run_import(import_job_instance.id)
+
+        assert (
+            f"Task started. Additional info: import_job_instance_id: {import_job_instance.id}."
+            in caplog.text
+        )
+        assert "Task ended." in caplog.text
+
     def test_base_case_dictionary_entries(self):
         site = SiteFactory(visibility=Visibility.PUBLIC)
 

--- a/firstvoices/backend/tests/test_tasks/test_media_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_media_tasks.py
@@ -1,0 +1,20 @@
+import pytest
+
+from backend.tests.factories import ImageFactory, SiteFactory, VideoFactory
+
+
+class TestThumbnailGeneration:
+    @pytest.mark.django_db
+    @pytest.mark.disable_thumbnail_mocks
+    @pytest.mark.parametrize(
+        "model_factory, model", [(ImageFactory, "image"), (VideoFactory, "video")]
+    )
+    def test_thumbnail_generation_started(self, model_factory, model, caplog):
+        site = SiteFactory()
+        media_item = model_factory.create(site=site, title="Test media item")
+
+        assert (
+            f"Task started. Additional info: "
+            f"model_name: {model}, instance_id: {media_item.id}." in caplog.text
+        )
+        assert "Task ended." in caplog.text

--- a/firstvoices/firstvoices/celery.py
+++ b/firstvoices/firstvoices/celery.py
@@ -14,11 +14,6 @@ app.autodiscover_tasks()
 log = logging.getLogger("celery")
 
 
-@app.task(bind=True)
-def debug_task(self):
-    log.info(f"Request: {self.request!r}")
-
-
 @app.task(ignore_result=True)
 def link_error_handler(request, exc, traceback):
     log.error(f"Task {request.id} failed\n{exc}")

--- a/firstvoices/firstvoices/celery.py
+++ b/firstvoices/firstvoices/celery.py
@@ -2,7 +2,6 @@ import logging
 import os
 
 from celery import Celery
-from celery.schedules import crontab
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "firstvoices.settings")
 
@@ -17,18 +16,9 @@ log = logging.getLogger("celery")
 
 @app.task(bind=True)
 def debug_task(self):
-    print(f"Request: {self.request!r}")
+    log.info(f"Request: {self.request!r}")
 
 
 @app.task(ignore_result=True)
 def link_error_handler(request, exc, traceback):
     log.error(f"Task {request.id} failed\n{exc}")
-
-
-@app.on_after_finalize.connect
-def setup_periodic_tasks(sender, **kwargs):
-    # print a debug message every 3 minutes
-    sender.add_periodic_task(
-        crontab(minute="*/3"),
-        debug_task.s(),
-    )

--- a/firstvoices/firstvoices/settings.py
+++ b/firstvoices/firstvoices/settings.py
@@ -260,6 +260,7 @@ else:
     )
 CELERY_RESULT_BACKEND = os.getenv("CELERY_RESULT_BACKEND", "redis://localhost/0")
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
+CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
 # Celery tasks are not picked up by autodiscover_tasks() if they are not globally imported. This adds missing tasks.
 # CELERY_IMPORTS = ("backend.tasks.my_task",)
 


### PR DESCRIPTION
### Description of Changes
- Updated celery settings to let it retry on startup, to fix the deprecation warning
- Added logging templates for start and end of a celery task
- Updated all async tasks to log at the start/end/error scenario

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Insomnia workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [x] Pull the branch and test locally

### Additional Notes
N/A
