### PR TITLE
FW-5936 Move task end log out of site loop

### DIFF
--- a/firstvoices/backend/tasks/build_mtd_export_format_tasks.py
+++ b/firstvoices/backend/tasks/build_mtd_export_format_tasks.py
@@ -189,7 +189,7 @@ def check_sites_for_mtd_sync(self):
                     link_error=link_error_handler.s(),
                 )
 
-            logger.info(ASYNC_TASK_END_TEMPLATE)
+        logger.info(ASYNC_TASK_END_TEMPLATE)
 
     except Exception as e:
         self.state = "FAILURE"


### PR DESCRIPTION
### Description of Changes
Moves the "task end" logging message outside of the loop in the check_sites_for_mtd_sync task

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] ~~Tests have been updated / created if applicable~~
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
