### PR TITLE
FW-5954 Media thumbnail generation to not update last modified datetime

### DIFF
--- a/firstvoices/backend/tasks/media_tasks.py
+++ b/firstvoices/backend/tasks/media_tasks.py
@@ -24,6 +24,6 @@ def generate_media_thumbnails(model_name: str, instance_id: str):
         instance = model_class.objects.get(id=instance_id)
         # again, let the exceptions be logged -- nothing useful we can do here
         instance.generate_resized_images()
-        instance.save(generate_thumbnails=False)
+        instance.save(generate_thumbnails=False, set_modified_date=False)
 
     logger.info(ASYNC_TASK_END_TEMPLATE)

--- a/firstvoices/backend/tests/test_tasks/test_media_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_media_tasks.py
@@ -1,6 +1,13 @@
 import pytest
 
-from backend.tests.factories import ImageFactory, SiteFactory, VideoFactory
+from backend.models.media import Image, Video
+from backend.tests.factories import (
+    ImageFactory,
+    ImageFileFactory,
+    SiteFactory,
+    VideoFactory,
+    VideoFileFactory,
+)
 
 
 class TestThumbnailGeneration:
@@ -11,10 +18,34 @@ class TestThumbnailGeneration:
     )
     def test_thumbnail_generation_started(self, model_factory, model, caplog):
         site = SiteFactory()
-        media_item = model_factory.create(site=site, title="Test media item")
+        media_item = model_factory.create(site=site)
 
         assert (
             f"Task started. Additional info: "
             f"model_name: {model}, instance_id: {media_item.id}." in caplog.text
         )
         assert "Task ended." in caplog.text
+
+    @pytest.mark.django_db
+    @pytest.mark.disable_thumbnail_mocks
+    @pytest.mark.parametrize(
+        "model, model_factory, model_file_factory",
+        [
+            (Image, ImageFactory, ImageFileFactory),
+            (Video, VideoFactory, VideoFileFactory),
+        ],
+    )
+    def test_thumbnail_generation_does_not_update_last_modified(
+        self, model, model_factory, model_file_factory
+    ):
+        site = SiteFactory()
+
+        media_file = model_file_factory.create()
+        media_item = model_factory.create(site=site, original=media_file)
+        original_last_modified = media_item.last_modified
+
+        media_item = model.objects.get(id=media_item.id)
+
+        new_last_modified = media_item.last_modified
+
+        assert new_last_modified == original_last_modified

--- a/firstvoices/backend/tests/test_tasks/test_media_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_media_tasks.py
@@ -44,6 +44,8 @@ class TestThumbnailGeneration:
         media_item = model_factory.create(site=site, original=media_file)
         original_last_modified = media_item.last_modified
 
+        media_item._request_thumbnail_generation()
+
         media_item = model.objects.get(id=media_item.id)
 
         new_last_modified = media_item.last_modified


### PR DESCRIPTION
### Description of Changes
- Media thumbnail generation to not update last modified datetime

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Insomnia workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
