### PR TITLE
FW-5870 Handle bad image data in site data serializer

### DIFF
--- a/firstvoices/backend/serializers/site_data_serializers.py
+++ b/firstvoices/backend/serializers/site_data_serializers.py
@@ -108,7 +108,8 @@ class DictionaryEntryDataSerializer(serializers.ModelSerializer):
         # NOTE: MTD currently only allows one image. As a heuristic, I'm selecting the first one.
         image = dictionaryentry.related_images.first()
 
-        if image is None:
+        # If no small image is available (possibly due to the wrong file type), return None
+        if image is None or image.small is None:
             return None
 
         return ImageDataSerializer(image).data["filename"]


### PR DESCRIPTION
### Description of Changes
- Slightly edits the `get_img` function of the DictionaryEntryDataSerializer to ignore images that do not have small image thumbnails. This allows bad data in the db to be ignored.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
