### PR TITLE
fw-5326, allow assistants to add/edit media, with tests

### DIFF
--- a/firstvoices/backend/models/galleries.py
+++ b/firstvoices/backend/models/galleries.py
@@ -23,9 +23,9 @@ class Gallery(TranslatedTitleMixin, TranslatedIntroMixin, BaseSiteContentModel):
         verbose_name_plural = _("galleries")
         rules_permissions = {
             "view": predicates.has_visible_site,
-            "add": predicates.can_add_core_uncontrolled_data,
-            "change": predicates.can_edit_core_uncontrolled_data,
-            "delete": predicates.can_delete_core_uncontrolled_data,
+            "add": predicates.is_at_least_assistant_or_super,
+            "change": predicates.is_at_least_assistant_or_super,
+            "delete": predicates.can_delete_media,
         }
 
     cover_image = models.ForeignKey(

--- a/firstvoices/backend/models/media.py
+++ b/firstvoices/backend/models/media.py
@@ -33,8 +33,8 @@ class Person(BaseSiteContentModel):
         verbose_name_plural = _("People")
         rules_permissions = {
             "view": predicates.has_visible_site,
-            "add": predicates.can_add_core_uncontrolled_data,
-            "change": predicates.can_edit_core_uncontrolled_data,
+            "add": predicates.is_at_least_assistant_or_super,
+            "change": predicates.is_at_least_assistant_or_super,
             "delete": predicates.can_delete_core_uncontrolled_data,
         }
 
@@ -104,8 +104,8 @@ class File(FileBase):
         verbose_name_plural = _("Files")
         rules_permissions = {
             "view": predicates.has_visible_site,
-            "add": predicates.can_add_core_uncontrolled_data,
-            "change": predicates.can_edit_core_uncontrolled_data,
+            "add": predicates.is_at_least_assistant_or_super,
+            "change": predicates.is_at_least_assistant_or_super,
             "delete": predicates.can_delete_core_uncontrolled_data,
         }
 
@@ -131,8 +131,8 @@ class ImageFile(VisualFileBase):
         verbose_name_plural = _("Image Files")
         rules_permissions = {
             "view": predicates.has_visible_site,
-            "add": predicates.can_add_core_uncontrolled_data,
-            "change": predicates.can_edit_core_uncontrolled_data,
+            "add": predicates.is_at_least_assistant_or_super,
+            "change": predicates.is_at_least_assistant_or_super,
             "delete": predicates.can_delete_core_uncontrolled_data,
         }
 
@@ -173,8 +173,8 @@ class VideoFile(VisualFileBase):
         verbose_name_plural = _("Video Files")
         rules_permissions = {
             "view": predicates.has_visible_site,
-            "add": predicates.can_add_core_uncontrolled_data,
-            "change": predicates.can_edit_core_uncontrolled_data,
+            "add": predicates.is_at_least_assistant_or_super,
+            "change": predicates.is_at_least_assistant_or_super,
             "delete": predicates.can_delete_core_uncontrolled_data,
         }
 
@@ -298,8 +298,8 @@ class Audio(MediaBase):
         verbose_name_plural = _("Audio")
         rules_permissions = {
             "view": predicates.has_visible_site,
-            "add": predicates.can_add_core_uncontrolled_data,
-            "change": predicates.can_edit_core_uncontrolled_data,
+            "add": predicates.is_at_least_assistant_or_super,
+            "change": predicates.is_at_least_assistant_or_super,
             "delete": predicates.can_delete_core_uncontrolled_data,
         }
 
@@ -444,8 +444,8 @@ class Image(ThumbnailMixin, MediaBase):
         verbose_name_plural = _("Images")
         rules_permissions = {
             "view": predicates.has_visible_site,
-            "add": predicates.can_add_core_uncontrolled_data,
-            "change": predicates.can_edit_core_uncontrolled_data,
+            "add": predicates.is_at_least_assistant_or_super,
+            "change": predicates.is_at_least_assistant_or_super,
             "delete": predicates.can_delete_core_uncontrolled_data,
         }
 
@@ -511,8 +511,8 @@ class Video(ThumbnailMixin, MediaBase):
         verbose_name_plural = _("Videos")
         rules_permissions = {
             "view": predicates.has_visible_site,
-            "add": predicates.can_add_core_uncontrolled_data,
-            "change": predicates.can_edit_core_uncontrolled_data,
+            "add": predicates.is_at_least_assistant_or_super,
+            "change": predicates.is_at_least_assistant_or_super,
             "delete": predicates.can_delete_core_uncontrolled_data,
         }
 

--- a/firstvoices/backend/models/media.py
+++ b/firstvoices/backend/models/media.py
@@ -33,9 +33,9 @@ class Person(BaseSiteContentModel):
         verbose_name_plural = _("People")
         rules_permissions = {
             "view": predicates.has_visible_site,
-            "add": predicates.is_at_least_assistant_or_super,
-            "change": predicates.is_at_least_assistant_or_super,
-            "delete": predicates.can_delete_core_uncontrolled_data,
+            "add": predicates.is_at_least_editor_or_super,
+            "change": predicates.is_at_least_editor_or_super,
+            "delete": predicates.can_delete_media,
         }
 
     name = models.CharField(max_length=200)
@@ -106,7 +106,7 @@ class File(FileBase):
             "view": predicates.has_visible_site,
             "add": predicates.is_at_least_assistant_or_super,
             "change": predicates.is_at_least_assistant_or_super,
-            "delete": predicates.can_delete_core_uncontrolled_data,
+            "delete": predicates.can_delete_media,
         }
 
 
@@ -133,7 +133,7 @@ class ImageFile(VisualFileBase):
             "view": predicates.has_visible_site,
             "add": predicates.is_at_least_assistant_or_super,
             "change": predicates.is_at_least_assistant_or_super,
-            "delete": predicates.can_delete_core_uncontrolled_data,
+            "delete": predicates.can_delete_media,
         }
 
     def get_image_dimensions(self):
@@ -175,7 +175,7 @@ class VideoFile(VisualFileBase):
             "view": predicates.has_visible_site,
             "add": predicates.is_at_least_assistant_or_super,
             "change": predicates.is_at_least_assistant_or_super,
-            "delete": predicates.can_delete_core_uncontrolled_data,
+            "delete": predicates.can_delete_media,
         }
 
     def save(self, update_file_metadata=False, **kwargs):
@@ -300,7 +300,7 @@ class Audio(MediaBase):
             "view": predicates.has_visible_site,
             "add": predicates.is_at_least_assistant_or_super,
             "change": predicates.is_at_least_assistant_or_super,
-            "delete": predicates.can_delete_core_uncontrolled_data,
+            "delete": predicates.can_delete_media,
         }
 
     # acknowledgment from fvm:recorder
@@ -446,7 +446,7 @@ class Image(ThumbnailMixin, MediaBase):
             "view": predicates.has_visible_site,
             "add": predicates.is_at_least_assistant_or_super,
             "change": predicates.is_at_least_assistant_or_super,
-            "delete": predicates.can_delete_core_uncontrolled_data,
+            "delete": predicates.can_delete_media,
         }
 
     # acknowledgement from fvm:recorder, fvm:source
@@ -513,7 +513,7 @@ class Video(ThumbnailMixin, MediaBase):
             "view": predicates.has_visible_site,
             "add": predicates.is_at_least_assistant_or_super,
             "change": predicates.is_at_least_assistant_or_super,
-            "delete": predicates.can_delete_core_uncontrolled_data,
+            "delete": predicates.can_delete_media,
         }
 
     # from fvm:content

--- a/firstvoices/backend/permissions/predicates/edit.py
+++ b/firstvoices/backend/permissions/predicates/edit.py
@@ -24,30 +24,12 @@ is_language_admin_or_super = Predicate(
     name="is_language_admin_or_super",
 )
 
-"""
-Same as ``can_edit_core_uncontrolled_data`` but does not check the visibility of the object that is saved in the db.
 
+"""
 - Assistant has permission for Team-visibility data
 - Editor, Language Admin, and Superadmin have permission
 """
-can_add_core_uncontrolled_data = Predicate(
-    base.has_at_least_editor_membership
-    | base.is_superadmin
-    | (
-        base.has_at_least_assistant_membership
-        & base.is_team_obj  # will be called with a site object
-    ),
-    name="can_add_core_uncontrolled_data",
-)
-
-
-"""
-Same as ``can_add_core_uncontrolled_data`` but also checks the visibility of the object that is saved in the db.
-
-- Assistant has permission for Team-visibility data
-- Editor, Language Admin, and Superadmin have permission
-"""
-can_edit_core_uncontrolled_data = Predicate(
+can_delete_media = Predicate(
     base.has_at_least_editor_membership
     | base.is_superadmin
     | (
@@ -56,11 +38,6 @@ can_edit_core_uncontrolled_data = Predicate(
         & base.has_saved_team_site
     ),
     name="can_edit_core_uncontrolled_data",
-)
-
-# just a convenient alias
-can_delete_core_uncontrolled_data = Predicate(
-    is_at_least_editor_or_super, name="can_edit_core_uncontrolled_data"
 )
 
 # This predicate must be combined with the CreateControlledSiteContentSerializerMixin in

--- a/firstvoices/backend/tests/factories/access.py
+++ b/firstvoices/backend/tests/factories/access.py
@@ -4,8 +4,9 @@ from django.contrib.auth.models import AnonymousUser
 from factory.django import DjangoModelFactory
 
 from backend.models.app import AppMembership
-from backend.models.constants import AppRole
+from backend.models.constants import AppRole, Role, Visibility
 from backend.models.sites import Language, LanguageFamily, Membership, Site
+from backend.tests import factories
 
 
 class AnonymousUserFactory(DjangoModelFactory):
@@ -92,3 +93,37 @@ def get_app_admin(role):
 
 def get_superadmin():
     return get_app_admin(AppRole.SUPERADMIN)
+
+
+def get_member_of_other_site():
+    _, user = get_site_with_member(Visibility.PUBLIC, Role.LANGUAGE_ADMIN)
+    return user
+
+
+def get_site_with_authenticated_member(
+    client, visibility=Visibility.PUBLIC, role=Role.MEMBER
+):
+    site, user = factories.get_site_with_member(visibility, role)
+    client.force_authenticate(user=user)
+    return site, user
+
+
+def get_site_with_authenticated_nonmember(client, visibility=Visibility.PUBLIC):
+    site = factories.SiteFactory.create(visibility=visibility)
+    user = factories.get_non_member_user()
+    client.force_authenticate(user=user)
+    return site, user
+
+
+def get_site_with_staff_user(client=None, visibility=Visibility.PUBLIC):
+    site = factories.SiteFactory.create(visibility=visibility)
+    user = factories.get_app_admin(AppRole.STAFF)
+    client.force_authenticate(user=user)
+    return site, user
+
+
+def get_site_with_anonymous_user(client=None, visibility=Visibility.PUBLIC):
+    # client is intentionally ignored so all these site_with_user functions can have the same signature
+    site = factories.SiteFactory.create(visibility=visibility)
+    user = factories.get_anonymous_user()
+    return site, user

--- a/firstvoices/backend/tests/test_apis/base_api_test.py
+++ b/firstvoices/backend/tests/test_apis/base_api_test.py
@@ -659,7 +659,7 @@ class SiteContentUpdateApiTestMixin:
 
         assert response.status_code == 404
 
-    def perform_detail_request(self, instance, site, data):
+    def perform_successful_detail_request(self, instance, site, data):
         response = self.client.put(
             self.get_detail_endpoint(
                 key=self.get_lookup_key(instance), site_slug=site.slug
@@ -667,8 +667,9 @@ class SiteContentUpdateApiTestMixin:
             data=self.format_upload_data(data),
             content_type=self.content_type,
         )
-        response_data = json.loads(response.content)
+        assert response.status_code == 200
 
+        response_data = json.loads(response.content)
         return response_data
 
     @pytest.mark.django_db
@@ -677,7 +678,7 @@ class SiteContentUpdateApiTestMixin:
         instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
         data = self.get_valid_data(site)
 
-        response_data = self.perform_detail_request(instance, site, data)
+        response_data = self.perform_successful_detail_request(instance, site, data)
         self.assert_updated_instance(data, self.get_updated_instance(instance))
         self.assert_update_response(data, response_data)
 
@@ -688,7 +689,7 @@ class SiteContentUpdateApiTestMixin:
         data = self.get_valid_data_with_nulls(site)
         expected_data = self.add_expected_defaults(data)
 
-        response_data = self.perform_detail_request(instance, site, data)
+        response_data = self.perform_successful_detail_request(instance, site, data)
         self.assert_updated_instance(expected_data, self.get_updated_instance(instance))
         self.assert_update_response(expected_data, response_data)
 

--- a/firstvoices/backend/tests/test_apis/base_media_test.py
+++ b/firstvoices/backend/tests/test_apis/base_media_test.py
@@ -4,8 +4,14 @@ import pytest
 from django.test.client import encode_multipart
 from rest_framework.reverse import reverse
 
-from backend.models.constants import AppRole, Role, Visibility
+from backend.models.constants import Role, Visibility
 from backend.tests import factories
+from backend.tests.factories import (
+    get_site_with_anonymous_user,
+    get_site_with_authenticated_member,
+    get_site_with_authenticated_nonmember,
+    get_site_with_staff_user,
+)
 from backend.tests.test_apis import base_api_test
 from backend.tests.utils import get_sample_file
 
@@ -13,36 +19,6 @@ VIMEO_VIDEO_LINK = "https://vimeo.com/226053498"
 YOUTUBE_VIDEO_LINK = "https://www.youtube.com/watch?v=abc123"
 MOCK_EMBED_LINK = "https://mock_embed_link.com/"
 MOCK_THUMBNAIL_LINK = "https://mock_thumbnail_link.com/"
-
-
-def get_site_with_authenticated_member(
-    client, visibility=Visibility.PUBLIC, role=Role.MEMBER
-):
-    site, user = factories.get_site_with_member(visibility, role)
-    client.force_authenticate(user=user)
-    return site, user
-
-
-def get_site_with_authenticated_nonmember(client, visibility=Visibility.PUBLIC):
-    site = factories.SiteFactory.create(visibility=visibility)
-    user = factories.get_non_member_user()
-    client.force_authenticate(user=user)
-    return site, user
-
-
-def get_site_with_anonymous_user(client=None, visibility=Visibility.PUBLIC):
-    # client is intentionally ignored so all these site_with_user functions can have the same signature
-    site = factories.SiteFactory.create(visibility=visibility)
-    user = factories.get_anonymous_user()
-    return site, user
-
-
-def get_site_with_staff_user(client=None, visibility=Visibility.PUBLIC):
-    # client is intentionally ignored so all these site_with_user functions can have the same signature
-    site = factories.SiteFactory.create(visibility=visibility)
-    user = factories.get_app_admin(AppRole.STAFF)
-    client.force_authenticate(user=user)
-    return site, user
 
 
 class FormDataMixin:

--- a/firstvoices/backend/tests/test_apis/base_media_test.py
+++ b/firstvoices/backend/tests/test_apis/base_media_test.py
@@ -4,7 +4,7 @@ import pytest
 from django.test.client import encode_multipart
 from rest_framework.reverse import reverse
 
-from backend.models.constants import Role, Visibility
+from backend.models.constants import AppRole, Role, Visibility
 from backend.tests import factories
 from backend.tests.test_apis import base_api_test
 from backend.tests.utils import get_sample_file
@@ -13,6 +13,36 @@ VIMEO_VIDEO_LINK = "https://vimeo.com/226053498"
 YOUTUBE_VIDEO_LINK = "https://www.youtube.com/watch?v=abc123"
 MOCK_EMBED_LINK = "https://mock_embed_link.com/"
 MOCK_THUMBNAIL_LINK = "https://mock_thumbnail_link.com/"
+
+
+def get_site_with_authenticated_member(
+    client, visibility=Visibility.PUBLIC, role=Role.MEMBER
+):
+    site, user = factories.get_site_with_member(visibility, role)
+    client.force_authenticate(user=user)
+    return site, user
+
+
+def get_site_with_authenticated_nonmember(client, visibility=Visibility.PUBLIC):
+    site = factories.SiteFactory.create(visibility=visibility)
+    user = factories.get_non_member_user()
+    client.force_authenticate(user=user)
+    return site, user
+
+
+def get_site_with_anonymous_user(client=None, visibility=Visibility.PUBLIC):
+    # client is intentionally ignored so all these site_with_user functions can have the same signature
+    site = factories.SiteFactory.create(visibility=visibility)
+    user = factories.get_anonymous_user()
+    return site, user
+
+
+def get_site_with_staff_user(client=None, visibility=Visibility.PUBLIC):
+    # client is intentionally ignored so all these site_with_user functions can have the same signature
+    site = factories.SiteFactory.create(visibility=visibility)
+    user = factories.get_app_admin(AppRole.STAFF)
+    client.force_authenticate(user=user)
+    return site, user
 
 
 class FormDataMixin:
@@ -484,7 +514,7 @@ class BaseMediaApiTest(
         instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
         data = self.get_valid_data(site)
 
-        response_data = self.perform_detail_request(instance, site, data)
+        response_data = self.perform_successful_detail_request(instance, site, data)
 
         self.assert_update_response(data, response_data, instance)
 
@@ -495,7 +525,7 @@ class BaseMediaApiTest(
         data = self.get_valid_data_with_nulls(site)
         expected_data = self.add_expected_defaults(data)
 
-        response_data = self.perform_detail_request(instance, site, data)
+        response_data = self.perform_successful_detail_request(instance, site, data)
 
         self.assert_updated_instance(expected_data, self.get_updated_instance(instance))
         self.assert_update_response(expected_data, response_data, instance)
@@ -532,6 +562,104 @@ class BaseMediaApiTest(
         )
 
         assert response.status_code == 400
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize("role", [Role.ASSISTANT, Role.EDITOR, Role.LANGUAGE_ADMIN])
+    def test_create_permissions_valid(self, role):
+        site, _ = get_site_with_authenticated_member(
+            self.client, Visibility.PUBLIC, role
+        )
+        data = self.get_valid_data(site)
+
+        response = self.client.post(
+            self.get_list_endpoint(site_slug=site.slug),
+            data=self.format_upload_data(data),
+            content_type=self.content_type,
+        )
+
+        assert response.status_code == 201
+
+    @pytest.mark.django_db
+    def test_create_permissions_valid_superadmin(self):
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+        user = factories.get_superadmin()
+        self.client.force_authenticate(user=user)
+        data = self.get_valid_data(site)
+
+        response = self.client.post(
+            self.get_list_endpoint(site_slug=site.slug),
+            data=self.format_upload_data(data),
+            content_type=self.content_type,
+        )
+
+        assert response.status_code == 201
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        "get_site_with_user",
+        [
+            get_site_with_authenticated_member,
+            get_site_with_authenticated_nonmember,
+            get_site_with_anonymous_user,
+            get_site_with_staff_user,
+        ],
+    )
+    def test_create_permissions_denied(self, get_site_with_user):
+        site, _ = get_site_with_user(self.client)
+        data = self.get_valid_data(site)
+
+        response = self.client.post(
+            self.get_list_endpoint(site_slug=site.slug),
+            data=self.format_upload_data(data),
+            content_type=self.content_type,
+        )
+
+        assert response.status_code == 403
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize("role", [Role.ASSISTANT, Role.EDITOR, Role.LANGUAGE_ADMIN])
+    def test_update_permissions_valid(self, role):
+        site, _ = get_site_with_authenticated_member(
+            self.client, Visibility.PUBLIC, role
+        )
+        instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
+        data = self.get_valid_data(site)
+
+        self.perform_successful_detail_request(instance, site, data)
+
+    @pytest.mark.django_db
+    def test_update_permissions_valid_superadmin(self):
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+        user = factories.get_superadmin()
+        self.client.force_authenticate(user=user)
+        instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
+        data = self.get_valid_data(site)
+
+        self.perform_successful_detail_request(instance, site, data)
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        "get_site_with_user",
+        [
+            get_site_with_authenticated_member,
+            get_site_with_authenticated_nonmember,
+            get_site_with_anonymous_user,
+            get_site_with_staff_user,
+        ],
+    )
+    def test_update_permissions_denied(self, get_site_with_user):
+        site, _ = get_site_with_user(self.client, Visibility.PUBLIC)
+        instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
+        data = self.get_valid_data(site)
+
+        response = self.client.put(
+            self.get_detail_endpoint(
+                key=self.get_lookup_key(instance), site_slug=site.slug
+            ),
+            data=self.format_upload_data(data),
+            content_type=self.content_type,
+        )
+        assert response.status_code == 403
 
     def add_related_media_to_objects(self, visibility):
         # Add media file as related media to objects to verify that they show up correctly

--- a/firstvoices/backend/tests/test_permissions/test_predicate_edit.py
+++ b/firstvoices/backend/tests/test_permissions/test_predicate_edit.py
@@ -8,6 +8,7 @@ from backend.tests.factories import (
     UncontrolledSiteContentFactory,
     get_anonymous_user,
     get_app_admin,
+    get_member_of_other_site,
     get_non_member_user,
     get_site_with_member,
 )
@@ -41,11 +42,6 @@ class TestEditRolePredicates:
         user = get_app_admin(AppRole.STAFF)
         obj = SiteFactory.create()
         assert not predicate(user, obj)
-
-
-def get_member_of_other_site():
-    _, user = get_site_with_member(Visibility.PUBLIC, Role.LANGUAGE_ADMIN)
-    return user
 
 
 class TestCanDeleteCoreUncontrolledData:

--- a/firstvoices/backend/tests/test_permissions/test_predicate_edit.py
+++ b/firstvoices/backend/tests/test_permissions/test_predicate_edit.py
@@ -48,7 +48,7 @@ def get_member_of_other_site():
     return user
 
 
-class TestCanEditCoreUncontrolledData:
+class TestCanDeleteCoreUncontrolledData:
     @pytest.mark.parametrize(
         "get_user", [get_anonymous_user, get_non_member_user, get_member_of_other_site]
     )
@@ -57,40 +57,40 @@ class TestCanEditCoreUncontrolledData:
         user = get_user()
         site = SiteFactory.create(visibility=Visibility.PUBLIC)
         obj = UncontrolledSiteContentFactory.create(site=site)
-        assert not edit.can_edit_core_uncontrolled_data(user, obj)
+        assert not edit.can_delete_media(user, obj)
 
     @pytest.mark.django_db
     def test_members_blocked(self):
         site, user = get_site_with_member(Visibility.PUBLIC, Role.MEMBER)
         obj = UncontrolledSiteContentFactory.create(site=site)
-        assert not edit.can_edit_core_uncontrolled_data(user, obj)
+        assert not edit.can_delete_media(user, obj)
 
     @pytest.mark.django_db
     def test_staff_admin_blocked(self):
         user = get_app_admin(AppRole.STAFF)
         site = SiteFactory.create(visibility=Visibility.PUBLIC)
         obj = UncontrolledSiteContentFactory.create(site=site)
-        assert not edit.can_edit_core_uncontrolled_data(user, obj)
+        assert not edit.can_delete_media(user, obj)
 
     @pytest.mark.parametrize("role", [Role.EDITOR, Role.LANGUAGE_ADMIN])
     @pytest.mark.django_db
     def test_editors_and_up_permitted(self, role):
         site, user = get_site_with_member(Visibility.PUBLIC, role)
         obj = UncontrolledSiteContentFactory.create(site=site)
-        assert edit.can_edit_core_uncontrolled_data(user, obj)
+        assert edit.can_delete_media(user, obj)
 
     @pytest.mark.parametrize("visibility", [Visibility.PUBLIC, Visibility.MEMBERS])
     @pytest.mark.django_db
     def test_assistant_blocked_for_non_team_data(self, visibility):
         site, user = get_site_with_member(Visibility.PUBLIC, Role.ASSISTANT)
         obj = UncontrolledSiteContentFactory.create(site=site)
-        assert not edit.can_edit_core_uncontrolled_data(user, obj)
+        assert not edit.can_delete_media(user, obj)
 
     @pytest.mark.django_db
     def test_assistant_permitted_for_team_data(self):
         site, user = get_site_with_member(Visibility.TEAM, Role.ASSISTANT)
         obj = UncontrolledSiteContentFactory.create(site=site)
-        assert edit.can_edit_core_uncontrolled_data(user, obj)
+        assert edit.can_delete_media(user, obj)
 
     @pytest.mark.parametrize("visibility", [Visibility.PUBLIC, Visibility.MEMBERS])
     @pytest.mark.django_db
@@ -98,50 +98,7 @@ class TestCanEditCoreUncontrolledData:
         site, user = get_site_with_member(Visibility.PUBLIC, Role.ASSISTANT)
         obj = UncontrolledSiteContentFactory.create(site=site)
         site.visibility = Visibility.TEAM
-        assert not edit.can_edit_core_uncontrolled_data(user, obj)
-
-
-class TestCanAddCoreUncontrolledData:
-    """
-    These are tested with site objects because the "create" permission is tested with a site object.
-    """
-
-    @pytest.mark.parametrize(
-        "get_user", [get_anonymous_user, get_non_member_user, get_member_of_other_site]
-    )
-    @pytest.mark.django_db
-    def test_non_members_blocked(self, get_user):
-        user = get_user()
-        site = SiteFactory.create(visibility=Visibility.PUBLIC)
-        assert not edit.can_add_core_uncontrolled_data(user, site)
-
-    @pytest.mark.django_db
-    def test_members_blocked(self):
-        site, user = get_site_with_member(Visibility.PUBLIC, Role.MEMBER)
-        assert not edit.can_add_core_uncontrolled_data(user, site)
-
-    @pytest.mark.django_db
-    def test_staff_admin_blocked(self):
-        user = get_app_admin(AppRole.STAFF)
-        site = SiteFactory.create(visibility=Visibility.PUBLIC)
-        assert not edit.can_add_core_uncontrolled_data(user, site)
-
-    @pytest.mark.parametrize("role", [Role.EDITOR, Role.LANGUAGE_ADMIN])
-    @pytest.mark.django_db
-    def test_editors_and_up_permitted(self, role):
-        site, user = get_site_with_member(Visibility.PUBLIC, role)
-        assert edit.can_add_core_uncontrolled_data(user, site)
-
-    @pytest.mark.parametrize("visibility", [Visibility.PUBLIC, Visibility.MEMBERS])
-    @pytest.mark.django_db
-    def test_assistant_blocked_for_non_team_data(self, visibility):
-        site, user = get_site_with_member(Visibility.PUBLIC, Role.ASSISTANT)
-        assert not edit.can_add_core_uncontrolled_data(user, site)
-
-    @pytest.mark.django_db
-    def test_assistant_permitted_for_team_data(self):
-        site, user = get_site_with_member(Visibility.TEAM, Role.ASSISTANT)
-        assert edit.can_add_core_uncontrolled_data(user, site)
+        assert not edit.can_delete_media(user, obj)
 
 
 class TestCanEditControlledData:


### PR DESCRIPTION
### Description of Changes
* update media permissions to allow assistants to add/edit media and galleries (but not persons)
* rename the remaining custom media permission
* add permission tests for media APIs

### Checklist
- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Insomnia workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
