### PR TITLE
FW-6060 fix build_index_and_calculate_scores accepting and returning models

### DIFF
--- a/firstvoices/backend/tasks/mtd_export_tasks.py
+++ b/firstvoices/backend/tasks/mtd_export_tasks.py
@@ -57,23 +57,21 @@ def parse_queryset_for_mtd(
 
 
 @shared_task
-def build_index_and_calculate_scores(site_or_site_slug: str | Site, *args, **kwargs):
+def build_index_and_calculate_scores(site_slug: str, *args, **kwargs):
     """This task builds the inverted index and calculates the entry rankings
 
     Args:
-        site_or_site_slug (Union[str, Site]): A valid site slug or a backend.models.Site object
+        site_slug (str): A valid site slug
     """
     logger = get_task_logger(__name__)
-    logger.info(ASYNC_TASK_START_TEMPLATE, f"site: {site_or_site_slug}")
+    logger.info(ASYNC_TASK_START_TEMPLATE, f"site: {site_slug}")
 
-    if isinstance(site_or_site_slug, Site):
-        site = site_or_site_slug
-    elif isinstance(site_or_site_slug, str):
-        site = Site.objects.get(slug=site_or_site_slug)
+    if isinstance(site_slug, str):
+        site = Site.objects.get(slug=site_slug)
     else:
         raise TypeError(
             f"""site_or_site_slug must be a backend.models.Site object or a valid site slug.
-                {type(site_or_site_slug)} was received instead."""
+                {type(site_slug)} was received instead."""
         )
 
     # Saving an empty model to depict that the task has started
@@ -197,7 +195,7 @@ def build_index_and_calculate_scores(site_or_site_slug: str | Site, *args, **kwa
 
     logger.info(ASYNC_TASK_END_TEMPLATE)
 
-    return export_job
+    return export_job.id
 
 
 @shared_task(bind=True)

--- a/firstvoices/backend/tests/test_apis/test_mtd_data_api.py
+++ b/firstvoices/backend/tests/test_apis/test_mtd_data_api.py
@@ -3,6 +3,7 @@ from mothertongues.config.models import LanguageConfiguration
 from rest_framework.reverse import reverse
 from rest_framework.test import APIClient
 
+from backend.models import MTDExportJob
 from backend.models.constants import Visibility
 from backend.models.jobs import JobStatus
 from backend.tasks.mtd_export_tasks import build_index_and_calculate_scores
@@ -69,7 +70,7 @@ class TestMTDDataEndpoint:
             10, site=site, visibility=Visibility.PUBLIC, translations=["translation"]
         )
 
-        mtd = build_index_and_calculate_scores(site.slug)
+        mtd = MTDExportJob.objects.get(id=build_index_and_calculate_scores(site.slug))
 
         response = self.client.get(self.get_mtd_endpoint(site_slug=site.slug))
         assert response.status_code == 200
@@ -95,7 +96,7 @@ class TestMTDDataEndpoint:
             10, site=site, visibility=Visibility.PUBLIC, translations=["translation"]
         )
 
-        mtd = build_index_and_calculate_scores(site.slug)
+        mtd = MTDExportJob.objects.get(id=build_index_and_calculate_scores(site.slug))
 
         response = self.client.get(
             self.get_mtd_endpoint(site_slug=site.slug) + "/task/"
@@ -115,7 +116,7 @@ class TestMTDDataEndpoint:
             10, site=site, visibility=Visibility.PUBLIC, translations=["translation"]
         )
 
-        mtd = build_index_and_calculate_scores(site.slug)
+        mtd = MTDExportJob.objects.get(id=build_index_and_calculate_scores(site.slug))
 
         factories.MTDExportJobFactory.create(site=site, status=status)
 

--- a/firstvoices/backend/tests/test_tasks/test_build_mtd.py
+++ b/firstvoices/backend/tests/test_tasks/test_build_mtd.py
@@ -29,7 +29,8 @@ class TestMTDIndexAndScoreTask:
 
     @pytest.mark.django_db
     def test_build_empty(self, site, caplog):
-        result = build_index_and_calculate_scores(site.slug).export_result
+        job = MTDExportJob.objects.get(id=build_index_and_calculate_scores(site.slug))
+        result = job.export_result
         assert result["config"]["L1"] == site.title
         assert len(result["data"]) == 0
         assert len(result["l1_index"]) == 0
@@ -51,7 +52,8 @@ class TestMTDIndexAndScoreTask:
             title=self.sample_entry_title,
             translations=[],
         )
-        result = build_index_and_calculate_scores(site.slug).export_result
+        job = MTDExportJob.objects.get(id=build_index_and_calculate_scores(site.slug))
+        result = job.export_result
 
         assert result["config"]["L1"] == site.title
         assert len(result["data"]) == 0
@@ -79,12 +81,14 @@ class TestMTDIndexAndScoreTask:
             type=TypeOfDictionaryEntry.WORD,
             title=self.sample_entry_title,
         )
-        result = build_index_and_calculate_scores(site.slug).export_result
+        job = MTDExportJob.objects.get(id=build_index_and_calculate_scores(site.slug))
+        result = job.export_result
         assert len(result["data"]) == 1
 
     @pytest.mark.django_db
     def test_export_is_saved(self, site):
-        result = build_index_and_calculate_scores(site.slug).export_result
+        job = MTDExportJob.objects.get(id=build_index_and_calculate_scores(site.slug))
+        result = job.export_result
         # Check that the exported contents were saved
         saved_export_format = MTDExportJob.objects.filter(site=site)
         assert saved_export_format.latest().export_result == result
@@ -132,7 +136,8 @@ class TestMTDIndexAndScoreTask:
             title="the word 'third' appears as the third word in this sentence",
         )
         # Build and index
-        result = build_index_and_calculate_scores(site.slug).export_result
+        job = MTDExportJob.objects.get(id=build_index_and_calculate_scores(site.slug))
+        result = job.export_result
         assert len(result["data"]) == 3
         assert result["data"][1]["word"] == self.sample_entry_title
         # punctuation is removed by default so it is titleone in the index
@@ -196,7 +201,8 @@ class TestMTDIndexAndScoreTask:
         )
 
         # Build and index
-        result = build_index_and_calculate_scores(site.slug).export_result
+        job = MTDExportJob.objects.get(id=build_index_and_calculate_scores(site.slug))
+        result = job.export_result
         assert len(result["data"]) == 1
         assert result["data"][0]["word"] == self.sample_entry_title
         assert result["data"][0]["img"] is None
@@ -209,7 +215,8 @@ class TestMTDIndexAndScoreTask:
     def test_old_results_removed(self, site):
         build_index_and_calculate_scores(site.slug)
         build_index_and_calculate_scores(site.slug)
-        final_result = build_index_and_calculate_scores(site.slug).export_result
+        job = MTDExportJob.objects.get(id=build_index_and_calculate_scores(site.slug))
+        final_result = job.export_result
 
         # Check that only the most recent is in the db
         saved_results = MTDExportJob.objects.filter(site=site)


### PR DESCRIPTION
### Description of Changes
This PR should fix the `Object of type MTDExportJob is not JSON serializable` error in build_index_and_calculate_scores
- Modifies the build_index_and_calculate_scores task to no longer return the MTDExportJob model and just return the id
- Additionally modifies the build_index_and_calculate_scores task to not accept Site models as args passed to tasks should be JSON serializable
- Adjusts tests as necessary

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
