### PR TITLE
FW-6060 fix MTD task return in fail and cancel states

### DIFF
--- a/firstvoices/backend/tasks/mtd_export_tasks.py
+++ b/firstvoices/backend/tasks/mtd_export_tasks.py
@@ -93,7 +93,7 @@ def build_index_and_calculate_scores(site_slug: str, *args, **kwargs):
         export_job.save()
         logger.info(cancelled_message)
         logger.info(ASYNC_TASK_END_TEMPLATE)
-        return export_job
+        return export_job.id
 
     characters_list = site.character_set.all().order_by("sort_order")
     dictionary_entries_queryset = (
@@ -182,7 +182,7 @@ def build_index_and_calculate_scores(site_slug: str, *args, **kwargs):
             export_job.save()
             logger.error(e)
             logger.info(ASYNC_TASK_END_TEMPLATE)
-            return export_job
+            return export_job.id
     result = dictionary.export().model_dump(mode="json")
 
     # Save the new result to the database

--- a/firstvoices/backend/tests/test_tasks/test_build_mtd.py
+++ b/firstvoices/backend/tests/test_tasks/test_build_mtd.py
@@ -227,7 +227,9 @@ class TestMTDIndexAndScoreTask:
     def test_parallel_build_and_score_jobs_not_allowed(self, site, caplog):
         factories.MTDExportJobFactory.create(site=site, status=JobStatus.STARTED)
 
-        export_job = build_index_and_calculate_scores(site.slug)
+        export_job = MTDExportJob.objects.get(
+            id=build_index_and_calculate_scores(site.slug)
+        )
         assert export_job.status == JobStatus.CANCELLED
         assert export_job.message == (
             "Job cancelled as another MTD export job is already in progress for the same site."
@@ -252,7 +254,9 @@ class TestMTDIndexAndScoreTask:
             "mothertongues.dictionary.MTDictionary.build_indices",
             side_effect=Exception("Mocked exception"),
         ):
-            result = build_index_and_calculate_scores(site.slug)
+            result = MTDExportJob.objects.get(
+                id=build_index_and_calculate_scores(site.slug)
+            )
 
         assert result.status == JobStatus.FAILED
         assert result.message == "Mocked exception"


### PR DESCRIPTION
### Description of Changes
- Prevents the mtd build task from returning an object in the case of a failed or cancelled task the same as https://github.com/First-Peoples-Cultural-Council/fv-be/pull/1042
- Updates tests as necessary


### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
