### PR TITLE
FW-5937 Update our log formatter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN pip3 install gunicorn
 COPY requirements.txt /app
 RUN pip3 install -r requirements.txt
 
+# Adding folder for the log file
+RUN mkdir -p /var/log/django
+
 COPY . /app
 WORKDIR /app/firstvoices
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,8 @@ RUN apk add --no-cache git
 RUN pip3 install gunicorn
 
 COPY requirements.txt /app
-RUN pip3 install -r requirements.txt
-
-# Adding folder for the log file
-RUN mkdir -p /var/log/django
+RUN pip3 install -r requirements.txt \
+ && mkdir -p /var/log/django  # Adding folder for the log file
 
 COPY . /app
 WORKDIR /app/firstvoices

--- a/firstvoices/firstvoices/logging_utils.py
+++ b/firstvoices/firstvoices/logging_utils.py
@@ -1,0 +1,7 @@
+import logging
+
+
+class DebugInfoLogLevelFilter(logging.Filter):
+    def filter(self, record):
+        # Only allow DEBUG + INFO logs
+        return record.levelno in [logging.DEBUG, logging.INFO]

--- a/firstvoices/firstvoices/settings.py
+++ b/firstvoices/firstvoices/settings.py
@@ -392,7 +392,7 @@ LOGGING = {
         "file": {
             "level": "WARNING",  # WARNING + ERROR
             "class": "logging.FileHandler",
-            "filename": "./app.log",
+            "filename": "/var/log/django/app.log",
             "formatter": "detailed",
         },
     },

--- a/firstvoices/firstvoices/settings.py
+++ b/firstvoices/firstvoices/settings.py
@@ -120,6 +120,27 @@ REST_FRAMEWORK = {
 # LOGGERS
 ELASTICSEARCH_LOGGER = "elasticsearch"
 
+# Based on the default settings
+# ref: https://docs.djangoproject.com/en/5.1/ref/logging/#default-logging-configuration
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "standard": {
+            "format": "{levelname} {asctime}: {pathname}:{module} - {message}",
+            "style": "{",
+        },
+    },
+    "handlers": {
+        "console": {
+            "level": "INFO",
+            "class": "logging.StreamHandler",
+            "formatter": "standard",
+        }
+    },
+}
+
+
 # local only
 if DEBUG:
     REST_FRAMEWORK.update(
@@ -150,9 +171,7 @@ if DEBUG:
     # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#internal-ips
     INTERNAL_IPS = ["127.0.0.1", "10.0.2.2"]
     LOGGING = {
-        "version": 1,
-        "disable_existing_loggers": False,
-        "handlers": {"console": {"class": "logging.StreamHandler"}},
+        **LOGGING,
         "root": {"handlers": ["console"], "level": "WARNING"},
         "loggers": {
             ELASTICSEARCH_LOGGER: {

--- a/firstvoices/firstvoices/settings.py
+++ b/firstvoices/firstvoices/settings.py
@@ -125,18 +125,46 @@ ELASTICSEARCH_LOGGER = "elasticsearch"
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
+    "filters": {
+        "debug_info_log_level_filter": {
+            "()": "firstvoices.logging_utils.DebugInfoLogLevelFilter"
+        },
+    },
     "formatters": {
         "standard": {
-            "format": "{levelname} {asctime}: {pathname}:{module} - {message}",
+            "format": "{levelname}-{asctime}:{pathname} -- {message}",
+            "style": "{",
+        },
+        "detailed": {
+            "format": "{levelname}-{asctime}:{pathname} {process:d} {thread:d} -- {message}",
             "style": "{",
         },
     },
     "handlers": {
         "console": {
-            "level": "INFO",
+            "level": "DEBUG",  # DEBUG + INFO
+            "filters": ["debug_info_log_level_filter"],
             "class": "logging.StreamHandler",
             "formatter": "standard",
-        }
+        },
+        "file": {
+            "level": "WARNING",  # WARNING + ERROR
+            "class": "logging.FileHandler",
+            "filename": "./app.log",
+            "formatter": "detailed",
+        },
+    },
+    "loggers": {
+        "": {
+            "handlers": ["console", "file"],
+            "level": "INFO",
+            "propagate": True,
+        },
+        ELASTICSEARCH_LOGGER: {
+            "handlers": ["console", "file"],
+            "level": "WARNING",  # Change level to INFO to debug connection requests,
+            "propagate": False,
+        },
     },
 }
 
@@ -170,16 +198,6 @@ if DEBUG:
 
     # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#internal-ips
     INTERNAL_IPS = ["127.0.0.1", "10.0.2.2"]
-    LOGGING = {
-        **LOGGING,
-        "root": {"handlers": ["console"], "level": "WARNING"},
-        "loggers": {
-            ELASTICSEARCH_LOGGER: {
-                "handlers": ["console"],
-                "level": "INFO",  # Change level to INFO to view connection requests
-            },
-        },
-    }
 
 AUTHENTICATION_BACKENDS = [
     "rules.permissions.ObjectPermissionBackend",

--- a/firstvoices/firstvoices/settings.py
+++ b/firstvoices/firstvoices/settings.py
@@ -357,10 +357,12 @@ ELASTICSEARCH_LOGGER = "elasticsearch"
 # Filtering logs to console
 console_filters = []
 log_handlers = ["console"]
+log_file = "./app.log"
 
 if not DEBUG:
     console_filters += ["debug_info_log_level_filter"]
     log_handlers += ["file"]
+    log_file = "/var/log/django/app.log"
 
 # Based on the default settings
 # ref: https://docs.djangoproject.com/en/5.1/ref/logging/#default-logging-configuration
@@ -392,7 +394,7 @@ LOGGING = {
         "file": {
             "level": "WARNING",  # WARNING + ERROR
             "class": "logging.FileHandler",
-            "filename": "/var/log/django/app.log",
+            "filename": log_file,
             "formatter": "detailed",
         },
     },

--- a/firstvoices/firstvoices/settings_test.py
+++ b/firstvoices/firstvoices/settings_test.py
@@ -3,6 +3,7 @@ Settings for automated testing only.
 """
 
 from .settings import *  # noqa
+from .settings import ELASTICSEARCH_LOGGER
 
 # https://docs.djangoproject.com/en/dev/ref/settings/#test-runner
 TEST_RUNNER = "django.test.runner.DiscoverRunner"
@@ -27,3 +28,21 @@ STORAGES = {
     },
 }
 MEDIA_ROOT = BASE_DIR / "backend" / "tests" / "tmp"  # noqa F405
+
+# Logging for tests
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "level": "INFO",
+            "class": "logging.StreamHandler",
+        },
+    },
+    "loggers": {
+        ELASTICSEARCH_LOGGER: {
+            "handlers": ["console"],
+            "level": "WARNING",
+        },
+    },
+}


### PR DESCRIPTION
### Description of Changes
- Added format settings for logs
- on non-local setups,
  `DEBUG` + `INFO` logs will now go to the console, while,
  `WARNING` + `ERROR` logs will now go the app.log file
- on local setups, no change in log levels, but the logs will now be more descriptive in the following format
  `{levelname}-{asctime}:{pathname} -- {message}`

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Insomnia workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
