### PR TITLE
FW-5096 convert optional charfields in API to non-nullable

### DIFF
--- a/firstvoices/backend/serializers/base_serializers.py
+++ b/firstvoices/backend/serializers/base_serializers.py
@@ -12,7 +12,7 @@ from backend.serializers.utils.context_utils import get_site_from_context
 from ..models import Membership, Site
 from ..models.constants import Role, Visibility
 from . import fields
-from .fields import WritableVisibilityField
+from .fields import NonNullableCharField, WritableVisibilityField
 
 base_timestamp_fields = ("created", "created_by", "last_modified", "last_modified_by")
 base_id_fields = ("id", "url", "title")
@@ -146,7 +146,7 @@ class LinkedSiteSerializer(
         view_name="api:site-detail", lookup_field="slug"
     )
     language = serializers.StringRelatedField()
-    slug = serializers.CharField(read_only=True)
+    slug = NonNullableCharField(read_only=True)
 
     class Meta:
         model = Site

--- a/firstvoices/backend/serializers/category_serializers.py
+++ b/firstvoices/backend/serializers/category_serializers.py
@@ -20,7 +20,7 @@ class ChildCategoryListSerializer(SiteContentLinkedTitleSerializer):
         validators=[UniqueForSite(queryset=Category.objects.all())],
     )
     description = serializers.CharField(
-        required=False, allow_blank=True, allow_null=True
+        required=False, allow_blank=True, allow_null=True, default=""
     )
 
     class Meta(SiteContentLinkedTitleSerializer.Meta):
@@ -44,7 +44,7 @@ class CategoryDetailSerializer(
     WritableSiteContentSerializer,
 ):
     description = serializers.CharField(
-        required=False, allow_blank=True, allow_null=True
+        required=False, allow_blank=True, allow_null=True, default=""
     )
     children = ChildCategoryListSerializer(many=True, read_only=True)
     parent = LinkedCategorySerializer(read_only=True)

--- a/firstvoices/backend/serializers/category_serializers.py
+++ b/firstvoices/backend/serializers/category_serializers.py
@@ -6,6 +6,7 @@ from backend.serializers.base_serializers import (
     SiteContentLinkedTitleSerializer,
     WritableSiteContentSerializer,
 )
+from backend.serializers.fields import NonNullableCharField
 from backend.serializers.validators import HasNoParent, SameSite, UniqueForSite
 
 
@@ -15,11 +16,11 @@ class LinkedCategorySerializer(SiteContentLinkedTitleSerializer):
 
 
 class ChildCategoryListSerializer(SiteContentLinkedTitleSerializer):
-    title = serializers.CharField(
+    title = NonNullableCharField(
         max_length=CATEGORY_POS_MAX_TITLE_LENGTH,
         validators=[UniqueForSite(queryset=Category.objects.all())],
     )
-    description = serializers.CharField(required=False, allow_blank=True)
+    description = NonNullableCharField(required=False, allow_blank=True)
 
     class Meta(SiteContentLinkedTitleSerializer.Meta):
         model = Category
@@ -41,7 +42,7 @@ class ParentCategoryFlatListSerializer(ChildCategoryListSerializer):
 class CategoryDetailSerializer(
     WritableSiteContentSerializer,
 ):
-    description = serializers.CharField(required=False, allow_blank=True)
+    description = NonNullableCharField(required=False, allow_blank=True)
     children = ChildCategoryListSerializer(many=True, read_only=True)
     parent = LinkedCategorySerializer(read_only=True)
     parent_id = serializers.PrimaryKeyRelatedField(

--- a/firstvoices/backend/serializers/category_serializers.py
+++ b/firstvoices/backend/serializers/category_serializers.py
@@ -6,7 +6,6 @@ from backend.serializers.base_serializers import (
     SiteContentLinkedTitleSerializer,
     WritableSiteContentSerializer,
 )
-from backend.serializers.fields import NonNullableCharField
 from backend.serializers.validators import HasNoParent, SameSite, UniqueForSite
 
 
@@ -16,11 +15,13 @@ class LinkedCategorySerializer(SiteContentLinkedTitleSerializer):
 
 
 class ChildCategoryListSerializer(SiteContentLinkedTitleSerializer):
-    title = NonNullableCharField(
+    title = serializers.CharField(
         max_length=CATEGORY_POS_MAX_TITLE_LENGTH,
         validators=[UniqueForSite(queryset=Category.objects.all())],
     )
-    description = NonNullableCharField(required=False, allow_blank=True)
+    description = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True
+    )
 
     class Meta(SiteContentLinkedTitleSerializer.Meta):
         model = Category
@@ -42,7 +43,9 @@ class ParentCategoryFlatListSerializer(ChildCategoryListSerializer):
 class CategoryDetailSerializer(
     WritableSiteContentSerializer,
 ):
-    description = NonNullableCharField(required=False, allow_blank=True)
+    description = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True
+    )
     children = ChildCategoryListSerializer(many=True, read_only=True)
     parent = LinkedCategorySerializer(read_only=True)
     parent_id = serializers.PrimaryKeyRelatedField(

--- a/firstvoices/backend/serializers/fields.py
+++ b/firstvoices/backend/serializers/fields.py
@@ -135,3 +135,10 @@ class TextListField(serializers.ListField):
                     "Expected the objects in the list to contain key 'text'."
                 )
         return response
+
+
+class NonNullableCharField(serializers.CharField):
+    def to_internal_value(self, data):
+        if data is None:
+            return ""
+        return super().to_internal_value(data)

--- a/firstvoices/backend/serializers/fields.py
+++ b/firstvoices/backend/serializers/fields.py
@@ -135,10 +135,3 @@ class TextListField(serializers.ListField):
                     "Expected the objects in the list to contain key 'text'."
                 )
         return response
-
-
-class NonNullableCharField(serializers.CharField):
-    def to_internal_value(self, data):
-        if data is None:
-            return ""
-        return super().to_internal_value(data)

--- a/firstvoices/backend/serializers/gallery_serializers.py
+++ b/firstvoices/backend/serializers/gallery_serializers.py
@@ -42,13 +42,13 @@ class GallerySummarySerializer(WritableSiteContentSerializer):
     """
 
     title_translation = serializers.CharField(
-        required=False, allow_blank=True, allow_null=True
+        required=False, allow_blank=True, allow_null=True, default=""
     )
     introduction = serializers.CharField(
-        required=False, allow_blank=True, allow_null=True
+        required=False, allow_blank=True, allow_null=True, default=""
     )
     introduction_translation = serializers.CharField(
-        required=False, allow_blank=True, allow_null=True
+        required=False, allow_blank=True, allow_null=True, default=""
     )
 
     cover_image = WriteableRelatedImageSerializer(

--- a/firstvoices/backend/serializers/gallery_serializers.py
+++ b/firstvoices/backend/serializers/gallery_serializers.py
@@ -41,6 +41,16 @@ class GallerySummarySerializer(WritableSiteContentSerializer):
     List serializer for Gallery model.
     """
 
+    title_translation = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True
+    )
+    introduction = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True
+    )
+    introduction_translation = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True
+    )
+
     cover_image = WriteableRelatedImageSerializer(
         required=False,
         queryset=Image.objects.all(),

--- a/firstvoices/backend/serializers/media_serializers.py
+++ b/firstvoices/backend/serializers/media_serializers.py
@@ -18,6 +18,7 @@ from .base_serializers import (
     ExternalSiteContentUrlMixin,
     SiteContentLinkedTitleSerializer,
     UpdateSerializerMixin,
+    ValidateNonNullableCharFieldsMixin,
     base_id_fields,
 )
 from .validators import SupportedFileType
@@ -26,8 +27,11 @@ from .validators import SupportedFileType
 class PersonSerializer(
     UpdateSerializerMixin,
     CreateSiteContentSerializerMixin,
+    ValidateNonNullableCharFieldsMixin,
     SiteContentLinkedTitleSerializer,
 ):
+    bio = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+
     class Meta:
         model = media.Person
         fields = (

--- a/firstvoices/backend/serializers/media_serializers.py
+++ b/firstvoices/backend/serializers/media_serializers.py
@@ -30,7 +30,9 @@ class PersonSerializer(
     ValidateNonNullableCharFieldsMixin,
     SiteContentLinkedTitleSerializer,
 ):
-    bio = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+    bio = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True, default=""
+    )
 
     class Meta:
         model = media.Person

--- a/firstvoices/backend/serializers/page_serializers.py
+++ b/firstvoices/backend/serializers/page_serializers.py
@@ -23,7 +23,7 @@ class SitePageSerializer(
     )
 
     slug = serializers.CharField(required=False)
-    subtitle = serializers.CharField(required=False)
+    subtitle = serializers.CharField(required=False, allow_blank=True, allow_null=True)
 
     class Meta:
         model = SitePage
@@ -49,7 +49,7 @@ class SitePageDetailSerializer(SitePageSerializer):
 
 class SitePageDetailWriteSerializer(WritableControlledSiteContentSerializer):
     slug = serializers.CharField(required=False)
-    subtitle = serializers.CharField(required=False)
+    subtitle = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     widgets = serializers.PrimaryKeyRelatedField(
         queryset=SiteWidget.objects.all(),
         allow_null=True,

--- a/firstvoices/backend/serializers/page_serializers.py
+++ b/firstvoices/backend/serializers/page_serializers.py
@@ -49,7 +49,9 @@ class SitePageDetailSerializer(SitePageSerializer):
 
 class SitePageDetailWriteSerializer(WritableControlledSiteContentSerializer):
     slug = serializers.CharField(required=False)
-    subtitle = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+    subtitle = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True, default=""
+    )
     widgets = serializers.PrimaryKeyRelatedField(
         queryset=SiteWidget.objects.all(),
         allow_null=True,

--- a/firstvoices/backend/serializers/song_serializers.py
+++ b/firstvoices/backend/serializers/song_serializers.py
@@ -36,11 +36,13 @@ class SongSerializer(
     visibility = WritableVisibilityField(required=True)
 
     title_translation = serializers.CharField(
-        required=False, allow_blank=True, default=""
+        required=False, allow_blank=True, allow_null=True, default=""
     )
-    introduction = serializers.CharField(required=False, allow_blank=True, default="")
+    introduction = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True, default=""
+    )
     introduction_translation = serializers.CharField(
-        required=False, allow_blank=True, default=""
+        required=False, allow_blank=True, allow_null=True, default=""
     )
 
     lyrics = LyricSerializer(many=True)

--- a/firstvoices/backend/serializers/story_serializers.py
+++ b/firstvoices/backend/serializers/story_serializers.py
@@ -13,6 +13,7 @@ from backend.serializers.base_serializers import (
     ReadOnlyVisibilityFieldMixin,
     SiteContentLinkedTitleSerializer,
     SiteContentUrlMixin,
+    ValidateNonNullableCharFieldsMixin,
     WritableControlledSiteContentSerializer,
     WritableVisibilityField,
     audience_fields,
@@ -59,7 +60,9 @@ class StoryPageSummarySerializer(
 
 
 class StoryPageDetailSerializer(
-    CreateControlledSiteContentSerializerMixin, StoryPageSummarySerializer
+    CreateControlledSiteContentSerializerMixin,
+    ValidateNonNullableCharFieldsMixin,
+    StoryPageSummarySerializer,
 ):
     created = serializers.DateTimeField(read_only=True)
     created_by = serializers.StringRelatedField(read_only=True)
@@ -68,7 +71,9 @@ class StoryPageDetailSerializer(
     story = LinkedStorySerializer(read_only=True)
     site = LinkedSiteSerializer(read_only=True)
 
-    translation = serializers.CharField(required=False, allow_blank=True, default="")
+    translation = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True, default=""
+    )
 
     class Meta(StoryPageSummarySerializer.Meta):
         fields = (
@@ -101,15 +106,20 @@ class StorySerializer(
     RelatedMediaSerializerMixin,
     WritableControlledSiteContentSerializer,
 ):
+    author = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True, default=""
+    )
     site = LinkedSiteSerializer(required=False, read_only=True)
     visibility = WritableVisibilityField(required=True)
 
     title_translation = serializers.CharField(
-        required=False, allow_blank=True, default=""
+        required=False, allow_blank=True, allow_null=True, default=""
     )
-    introduction = serializers.CharField(required=False, allow_blank=True, default="")
+    introduction = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True, default=""
+    )
     introduction_translation = serializers.CharField(
-        required=False, allow_blank=True, default=""
+        required=False, allow_blank=True, allow_null=True, default=""
     )
 
     pages = StoryPageSummarySerializer(many=True, read_only=True)

--- a/firstvoices/backend/tests/test_apis/base_media_test.py
+++ b/firstvoices/backend/tests/test_apis/base_media_test.py
@@ -707,6 +707,20 @@ class BaseMediaApiTest(
         assert len(response_data["usage"]["songs"]) == 0
         assert len(response_data["usage"]["stories"]) == 0
 
+    @pytest.mark.skip(
+        reason="Multipart form data not supported for null string values."
+    )
+    def test_create_with_null_optional_charfields_success_201(self):
+        # This test is skipped because the multipart form data encoder does not support null string values.
+        pass
+
+    @pytest.mark.skip(
+        reason="Multipart form data not supported for null string values."
+    )
+    def test_update_with_null_optional_charfields_success_200(self):
+        # This test is skipped because the multipart form data encoder does not support null string values.
+        pass
+
 
 class BaseVisualMediaAPITest(BaseMediaApiTest):
     @pytest.fixture()

--- a/firstvoices/backend/tests/test_apis/test_bulkvisibility_api.py
+++ b/firstvoices/backend/tests/test_apis/test_bulkvisibility_api.py
@@ -87,6 +87,20 @@ class TestBulkVisibilityEndpoints(
         # Bulk visibility jobs have no eligible nulls.
         pass
 
+    @pytest.mark.skip(
+        reason="Bulk visibility jobs have no eligible optional charfields."
+    )
+    def test_create_with_null_optional_charfields_success_201(self):
+        #  Bulk visibility jobs have no eligible optional charfields.
+        pass
+
+    @pytest.mark.skip(
+        reason="Bulk visibility jobs have no eligible optional charfields."
+    )
+    def test_update_with_null_optional_charfields_success_200(self):
+        # Bulk visibility jobs have no eligible optional charfields..
+        pass
+
     @pytest.mark.django_db
     def test_list_minimal(self):
         site = factories.SiteFactory.create()

--- a/firstvoices/backend/tests/test_apis/test_category_api.py
+++ b/firstvoices/backend/tests/test_apis/test_category_api.py
@@ -28,6 +28,7 @@ class TestCategoryEndpoints(BaseUncontrolledSiteContentApiTest):
 
     API_LIST_VIEW = "api:category-list"
     API_DETAIL_VIEW = "api:category-detail"
+    TITLE = "Cool new title"
     model = Category
 
     def setup_method(self):
@@ -52,14 +53,20 @@ class TestCategoryEndpoints(BaseUncontrolledSiteContentApiTest):
         parent = CategoryFactory.create(site=site)
 
         return {
-            "title": "Cool new title",
+            "title": self.TITLE,
             "description": "Cool new description",
             "parent_id": str(parent.id),
         }
 
     def get_valid_data_with_nulls(self, site=None):
         return {
-            "title": "Cool new title",
+            "title": self.TITLE,
+        }
+
+    def get_valid_data_with_null_optional_charfields(self, site=None):
+        return {
+            "title": self.TITLE,
+            "description": None,
         }
 
     def add_expected_defaults(self, data):

--- a/firstvoices/backend/tests/test_apis/test_dictionary_api.py
+++ b/firstvoices/backend/tests/test_apis/test_dictionary_api.py
@@ -358,19 +358,19 @@ class TestDictionaryEndpoint(
             },
         ]
 
-        @pytest.mark.skip(
-            reason="Dictionary entry API does not have eligible optional charfields."
-        )
-        def test_create_with_null_optional_charfields_success_201(self):
-            # Dictionary entry API does not have eligible optional charfields.
-            pass
+    @pytest.mark.skip(
+        reason="Dictionary entry API does not have eligible optional charfields."
+    )
+    def test_create_with_null_optional_charfields_success_201(self):
+        # Dictionary entry API does not have eligible optional charfields.
+        pass
 
-        @pytest.mark.skip(
-            reason="Dictionary entry API does not have eligible optional charfields."
-        )
-        def test_update_with_null_optional_charfields_success_200(self):
-            # Dictionary entry API does not have eligible optional charfields.
-            pass
+    @pytest.mark.skip(
+        reason="Dictionary entry API does not have eligible optional charfields."
+    )
+    def test_update_with_null_optional_charfields_success_200(self):
+        # Dictionary entry API does not have eligible optional charfields.
+        pass
 
     @pytest.mark.django_db
     def test_list_permissions(self):

--- a/firstvoices/backend/tests/test_apis/test_dictionary_api.py
+++ b/firstvoices/backend/tests/test_apis/test_dictionary_api.py
@@ -358,6 +358,20 @@ class TestDictionaryEndpoint(
             },
         ]
 
+        @pytest.mark.skip(
+            reason="Dictionary entry API does not have eligible optional charfields."
+        )
+        def test_create_with_null_optional_charfields_success_201(self):
+            # Dictionary entry API does not have eligible optional charfields.
+            pass
+
+        @pytest.mark.skip(
+            reason="Dictionary entry API does not have eligible optional charfields."
+        )
+        def test_update_with_null_optional_charfields_success_200(self):
+            # Dictionary entry API does not have eligible optional charfields.
+            pass
+
     @pytest.mark.django_db
     def test_list_permissions(self):
         # create some visible words and some invisible words

--- a/firstvoices/backend/tests/test_apis/test_dictionary_cleanup_api.py
+++ b/firstvoices/backend/tests/test_apis/test_dictionary_cleanup_api.py
@@ -87,6 +87,20 @@ class TestDictionaryCleanupAPI(
         # Dictionary cleanup jobs require no data to post.
         pass
 
+    @pytest.mark.skip(
+        reason="Dictionary cleanup jobs have no eligible optional charfields."
+    )
+    def test_create_with_null_optional_charfields_success_201(self):
+        #  Dictionary cleanup jobs have no eligible optional charfields.
+        pass
+
+    @pytest.mark.skip(
+        reason="Dictionary cleanup jobs have no eligible optional charfields."
+    )
+    def test_update_with_null_optional_charfields_success_200(self):
+        # Dictionary cleanup jobs have no eligible optional charfields..
+        pass
+
     @pytest.mark.django_db
     def test_list_minimal(self):
         site = factories.SiteFactory.create()

--- a/firstvoices/backend/tests/test_apis/test_gallery_api.py
+++ b/firstvoices/backend/tests/test_apis/test_gallery_api.py
@@ -156,6 +156,14 @@ class TestGalleryEndpoints(MediaTestMixin, BaseUncontrolledSiteContentApiTest):
             "title": "Test Gallery",
         }
 
+    def get_valid_data_with_null_optional_charfields(self, site=None):
+        return {
+            "title": "Test Gallery",
+            "titleTranslation": None,
+            "introduction": None,
+            "introductionTranslation": None,
+        }
+
     @pytest.mark.django_db
     def test_gallery_cover_image_not_unique(self):
         """Galleries can be created using the same image as their cover image"""

--- a/firstvoices/backend/tests/test_apis/test_immersion_label_api.py
+++ b/firstvoices/backend/tests/test_apis/test_immersion_label_api.py
@@ -132,6 +132,20 @@ class TestImmersionEndpoints(BaseUncontrolledSiteContentApiTest):
         # Immersion label API does not have eligible null fields.
         pass
 
+    @pytest.mark.skip(
+        reason="Immersion label API does not have eligible optional charfields."
+    )
+    def test_create_with_null_optional_charfields_success_201(self):
+        # Immersion label API does not have eligible optional charfields.
+        pass
+
+    @pytest.mark.skip(
+        reason="Immersion label API does not have eligible optional charfields."
+    )
+    def test_update_with_null_optional_charfields_success_200(self):
+        # Immersion label API does not have eligible optional charfields.
+        pass
+
     @pytest.mark.django_db
     def test_dictionary_entry_same_site_validation(self):
         """

--- a/firstvoices/backend/tests/test_apis/test_import_job_api.py
+++ b/firstvoices/backend/tests/test_apis/test_import_job_api.py
@@ -252,6 +252,20 @@ class TestImportEndpoints(
         # Check custom permissions tests below
         pass
 
+    @pytest.mark.skip(
+        reason="Import job API does not have eligible optional charfields."
+    )
+    def test_create_with_null_optional_charfields_success_201(self):
+        # Import job API does not have eligible optional charfields.
+        pass
+
+    @pytest.mark.skip(
+        reason="Import job API does not have eligible optional charfields."
+    )
+    def test_update_with_null_optional_charfields_success_200(self):
+        # Import job API does not have eligible optional charfields.
+        pass
+
     @pytest.mark.parametrize("role", [Role.MEMBER, Role.ASSISTANT])
     @pytest.mark.parametrize("visibility", Visibility)
     def test_detail_403_for_members_and_assistants(self, role, visibility):

--- a/firstvoices/backend/tests/test_apis/test_join_request_api.py
+++ b/firstvoices/backend/tests/test_apis/test_join_request_api.py
@@ -173,6 +173,20 @@ class TestJoinRequestEndpoints(
         # See custom permission tests instead
         pass
 
+    @pytest.mark.skip(
+        reason="Join request API does not have eligible optional charfields."
+    )
+    def test_create_with_null_optional_charfields_success_201(self):
+        # Join request API does not have eligible optional charfields.
+        pass
+
+    @pytest.mark.skip(
+        reason="Join request API does not have eligible optional charfields."
+    )
+    def test_update_with_null_optional_charfields_success_200(self):
+        # Join request API does not have eligible optional charfields.
+        pass
+
     @pytest.mark.parametrize("role", [Role.MEMBER, Role.ASSISTANT, Role.EDITOR])
     @pytest.mark.parametrize("visibility", Visibility)
     @pytest.mark.django_db

--- a/firstvoices/backend/tests/test_apis/test_pages_api.py
+++ b/firstvoices/backend/tests/test_apis/test_pages_api.py
@@ -54,6 +54,17 @@ class TestSitePageEndpoint(BaseControlledLanguageAdminOnlySiteContentAPITest):
             "slug": "test-page-slug",
         }
 
+    def get_valid_data_with_null_optional_charfields(self, site=None):
+        return {
+            "title": "Title",
+            "visibility": "public",
+            "subtitle": None,
+            "slug": "test-page-slug",
+            "widgets": [],
+            "banner_image": None,
+            "banner_video": None,
+        }
+
     def add_expected_defaults(self, data):
         return {
             **data,

--- a/firstvoices/backend/tests/test_apis/test_person_api.py
+++ b/firstvoices/backend/tests/test_apis/test_person_api.py
@@ -35,6 +35,12 @@ class TestPeopleEndpoints(BaseUncontrolledSiteContentApiTest):
             "name": "Cool new name",
         }
 
+    def get_valid_data_with_null_optional_charfields(self, site=None):
+        return {
+            "name": "Cool new name",
+            "bio": None,
+        }
+
     def add_expected_defaults(self, data):
         return {
             **data,

--- a/firstvoices/backend/tests/test_apis/test_site_features_api.py
+++ b/firstvoices/backend/tests/test_apis/test_site_features_api.py
@@ -123,6 +123,20 @@ class TestSiteFeatureEndpoints(BaseUncontrolledSiteContentApiTest):
         # SiteFeature API does not have eligible null fields.
         pass
 
+    @pytest.mark.skip(
+        reason="SiteFeature API does not have eligible optional charfields."
+    )
+    def test_create_with_null_optional_charfields_success_201(self):
+        # SiteFeature API does not have eligible optional charfields.
+        pass
+
+    @pytest.mark.skip(
+        reason="SiteFeature API does not have eligible optional charfields."
+    )
+    def test_update_with_null_optional_charfields_success_200(self):
+        # SiteFeature API does not have eligible optional charfields.
+        pass
+
     @pytest.mark.django_db
     def test_feature_key_read_only(self):
         """

--- a/firstvoices/backend/tests/test_apis/test_song_api.py
+++ b/firstvoices/backend/tests/test_apis/test_song_api.py
@@ -95,6 +95,21 @@ class TestSongEndpoint(
             ],
         }
 
+    def get_valid_data_with_null_optional_charfields(self, site=None):
+        return {
+            "title": "Title",
+            "visibility": "Public",
+            "titleTranslation": None,
+            "introduction": None,
+            "introductionTranslation": None,
+            "lyrics": [
+                {
+                    "text": "First lyrics page",
+                    "translation": "Translated 1st",
+                }
+            ],
+        }
+
     def add_expected_defaults(self, data):
         return {
             **data,

--- a/firstvoices/backend/tests/test_apis/test_story_api.py
+++ b/firstvoices/backend/tests/test_apis/test_story_api.py
@@ -75,6 +75,17 @@ class TestStoryEndpoint(
             "pages": [],
         }
 
+    def get_valid_data_with_null_optional_charfields(self, site=None):
+        return {
+            "title": "Title",
+            "visibility": "Public",
+            "pages": [],
+            "titleTranslation": None,
+            "introduction": None,
+            "introductionTranslation": None,
+            "author": None,
+        }
+
     def get_valid_page_data(self, site, story, page):
         return {
             "id": str(page.id),

--- a/firstvoices/backend/tests/test_apis/test_storypage_api.py
+++ b/firstvoices/backend/tests/test_apis/test_storypage_api.py
@@ -98,6 +98,13 @@ class TestStoryPageEndpoint(RelatedMediaTestMixin, BaseControlledSiteContentApiT
             "ordering": 8,
         }
 
+    def get_valid_data_with_null_optional_charfields(self, site=None):
+        return {
+            "text": "Title",
+            "translation": None,
+            "ordering": 8,
+        }
+
     def add_expected_defaults(self, data):
         return {
             **data,
@@ -377,6 +384,27 @@ class TestStoryPageEndpoint(RelatedMediaTestMixin, BaseControlledSiteContentApiT
         site = self.create_site_with_app_admin(Visibility.PUBLIC)
         story = factories.StoryFactory.create(site=site, visibility=site.visibility)
         data = self.get_valid_data_with_nulls(site)
+
+        response = self.client.post(
+            self.get_list_endpoint(site_slug=site.slug, story_id=str(story.id)),
+            data=self.format_upload_data(data),
+            content_type=self.content_type,
+        )
+
+        assert response.status_code == 201
+
+        response_data = json.loads(response.content)
+        pk = response_data["id"]
+
+        expected_data = self.add_expected_defaults(data)
+        self.assert_created_instance(pk, expected_data)
+        self.assert_created_response(expected_data, response_data)
+
+    @pytest.mark.django_db
+    def test_create_with_null_optional_charfields_success_201(self):
+        site = self.create_site_with_app_admin(Visibility.PUBLIC)
+        story = factories.StoryFactory.create(site=site, visibility=site.visibility)
+        data = self.get_valid_data_with_null_optional_charfields(site)
 
         response = self.client.post(
             self.get_list_endpoint(site_slug=site.slug, story_id=str(story.id)),

--- a/firstvoices/backend/tests/test_apis/test_widgets_api.py
+++ b/firstvoices/backend/tests/test_apis/test_widgets_api.py
@@ -41,10 +41,7 @@ class TestSiteWidgetEndpoint(BaseControlledLanguageAdminOnlySiteContentAPITest):
         }
 
     def add_expected_defaults(self, data):
-        return {
-            **data,
-            "settings": []
-        }
+        return {**data, "settings": []}
 
     def add_related_objects(self, instance):
         factories.WidgetSettingsFactory.create(widget=instance)
@@ -165,6 +162,20 @@ class TestSiteWidgetEndpoint(BaseControlledLanguageAdminOnlySiteContentAPITest):
     )
     def test_list_minimal(self):
         # Skipping test as it is same as the test_list_permissions test above.
+        pass
+
+    @pytest.mark.skip(
+        reason="Site widget API does not have eligible optional charfields."
+    )
+    def test_create_with_null_optional_charfields_success_201(self):
+        # Site widget API does not have eligible optional charfields.
+        pass
+
+    @pytest.mark.skip(
+        reason="Site widget API does not have eligible optional charfields."
+    )
+    def test_update_with_null_optional_charfields_success_200(self):
+        # Site widget API does not have eligible optional charfields.
         pass
 
     @pytest.mark.django_db

--- a/firstvoices/backend/utils/character_utils.py
+++ b/firstvoices/backend/utils/character_utils.py
@@ -142,5 +142,7 @@ def nfc(string: str) -> str:
     return unicodedata.normalize("NFC", unicodedata.normalize("NFD", string))
 
 
-def clean_input(string: str) -> str:
+def clean_input(string: str | None) -> str:
+    if string is None:
+        return ""
     return nfc(string.strip())


### PR DESCRIPTION
### Description of Changes
- Adds a `ValidateNonNullableCharFieldsMixin` to most writable serializers, which checks for charfields on the model and if they are null and the field is provided, sets them to "" via the validate method
- Changes the optional charfields serializers to allow_null=true, as validation will set them to "" (otherwise the API automatically returns a 400 error)
- Adds the `test_create_with_null_optional_charfields_success_201` and `test_update_with_null_optional_charfields_success_200` tests to most writable APIs
- Skips the above tests if the API does not have eligible optional charfields

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
- Unfortunately a `NonNullableCharfield` solution is not viable, as django raises an integrity error if given a null value for a model field that does not allow null values before the `to_internal_value` method of the field can be applied. The `ValidateNonNullableCharFieldsMixin` performs essentially the same function.
