### PR TITLE
FW-6132 Add prefetching order to story views

### DIFF
--- a/firstvoices/backend/views/storypage_views.py
+++ b/firstvoices/backend/views/storypage_views.py
@@ -1,5 +1,4 @@
 from django.core.exceptions import ValidationError
-from django.db.models import Prefetch
 from django.http import Http404
 from django.utils.translation import gettext as _
 from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
@@ -9,11 +8,10 @@ from rest_framework.viewsets import ModelViewSet
 from backend.models import Story, StoryPage
 from backend.views.base_views import FVPermissionViewSetMixin, SiteContentViewSetMixin
 
-from ..models.media import Audio, Image, Video
 from ..serializers.story_serializers import StoryPageDetailSerializer
 from . import doc_strings
 from .api_doc_variables import id_parameter, site_slug_parameter
-from .utils import get_select_related_media_fields
+from .utils import get_created_ordered_media_prefetch_list
 
 
 @extend_schema_view(
@@ -114,25 +112,7 @@ class StoryPageViewSet(SiteContentViewSetMixin, FVPermissionViewSetMixin, ModelV
             .order_by("ordering")
             .all()
             .prefetch_related(
-                Prefetch(
-                    "related_audio",
-                    queryset=Audio.objects.visible(user)
-                    .order_by("created")
-                    .select_related("original", "site")
-                    .prefetch_related("speakers"),
-                ),
-                Prefetch(
-                    "related_images",
-                    queryset=Image.objects.visible(user)
-                    .order_by("created")
-                    .select_related(*get_select_related_media_fields(None)),
-                ),
-                Prefetch(
-                    "related_videos",
-                    queryset=Video.objects.visible(user)
-                    .order_by("created")
-                    .select_related(*get_select_related_media_fields(None)),
-                ),
+                *get_created_ordered_media_prefetch_list(user),
             )
         )
 

--- a/firstvoices/backend/views/utils.py
+++ b/firstvoices/backend/views/utils.py
@@ -1,6 +1,6 @@
-from django.core.cache import caches
 import logging
 
+from django.core.cache import caches
 from django.db.models import Prefetch
 from rest_framework.throttling import UserRateThrottle
 
@@ -45,6 +45,30 @@ def get_media_prefetch_list(user):
             queryset=Video.objects.visible(user).select_related(
                 *get_select_related_media_fields(None)
             ),
+        ),
+    ]
+
+
+def get_created_ordered_media_prefetch_list(user):
+    return [
+        Prefetch(
+            "related_audio",
+            queryset=Audio.objects.visible(user)
+            .order_by("created")
+            .select_related("original", "site")
+            .prefetch_related("speakers"),
+        ),
+        Prefetch(
+            "related_images",
+            queryset=Image.objects.visible(user)
+            .order_by("created")
+            .select_related(*get_select_related_media_fields(None)),
+        ),
+        Prefetch(
+            "related_videos",
+            queryset=Video.objects.visible(user)
+            .order_by("created")
+            .select_related(*get_select_related_media_fields(None)),
         ),
     ]
 


### PR DESCRIPTION
### Description of Changes
- Adds an ordered related media prefetch to story detail and list views, as they display the ordered related media on story pages
- Moves ordered prefetching to `get_created_ordered_media_prefetch_list` function for reuse
- Adds a story view test to verify behaviour

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
