### PR TITLE
FW-6126 default values for empty fields in CSV

### DIFF
--- a/firstvoices/backend/resources/base.py
+++ b/firstvoices/backend/resources/base.py
@@ -41,7 +41,7 @@ class SiteContentResource(BaseResource):
 class ControlledSiteContentResource(SiteContentResource):
     visibility = fields.Field(
         column_name="visibility",
-        widget=ChoicesWidget(Visibility.choices),
+        widget=ChoicesWidget(Visibility.choices, default=Visibility.TEAM),
         attribute="visibility",
     )
 
@@ -82,12 +82,12 @@ class AudienceMixin(resources.ModelResource):
     exclude_from_games = fields.Field(
         column_name="include_in_games",
         attribute="exclude_from_games",
-        widget=InvertedBooleanFieldWidget(column="include_in_games"),
+        widget=InvertedBooleanFieldWidget(column="include_in_games", default=False),
     )
     exclude_from_kids = fields.Field(
         column_name="include_on_kids_site",
         attribute="exclude_from_kids",
-        widget=InvertedBooleanFieldWidget(column="include_on_kids_site"),
+        widget=InvertedBooleanFieldWidget(column="include_on_kids_site", default=False),
     )
 
     class Meta:

--- a/firstvoices/backend/resources/dictionary.py
+++ b/firstvoices/backend/resources/dictionary.py
@@ -22,7 +22,9 @@ class DictionaryEntryResource(
 ):
     type = fields.Field(
         column_name="type",
-        widget=ChoicesWidget(TypeOfDictionaryEntry.choices),
+        widget=ChoicesWidget(
+            TypeOfDictionaryEntry.choices, default=TypeOfDictionaryEntry.WORD
+        ),
         attribute="type",
     )
     part_of_speech = fields.Field(

--- a/firstvoices/backend/resources/utils/import_export_widgets.py
+++ b/firstvoices/backend/resources/utils/import_export_widgets.py
@@ -13,7 +13,7 @@ class ChoicesWidget(Widget):
     Maps display labels to db values for import, and vvsa for export.
     """
 
-    def __init__(self, choices, *args, **kwargs):
+    def __init__(self, choices, default=None, *args, **kwargs):
         """
         Input:
         - choices: iterable of choices containing (dbvalue, label)
@@ -21,11 +21,12 @@ class ChoicesWidget(Widget):
         """
         self.choice_labels = dict(choices)
         self.choice_values = {v: k for k, v in choices}
+        self.default = default
 
     def clean(self, value, row=None, *args, **kwargs):
         """Returns the db value given the display value"""
         value = value.strip().lower().title()
-        return self.choice_values.get(value) if value else None
+        return self.choice_values.get(value) if value else self.default
 
     def render(self, value, obj=None):
         """Returns the display value given the db value"""
@@ -76,12 +77,17 @@ class UserForeignKeyWidget(ForeignKeyWidget):
 class InvertedBooleanFieldWidget(Widget):
     """Import/export widget to return expected boolean value for audience related fields."""
 
-    def __init__(self, column, coerce_to_string=True):
+    def __init__(self, column, coerce_to_string=True, default=None):
         self.column_name = column
+        self.default = default
         super().__init__(coerce_to_string=coerce_to_string)
 
     def clean(self, value, row=None, **kwargs):
         cleaned_input = str(value).strip().lower()
+
+        if not cleaned_input:
+            # emtpy value, resolves to default value
+            return self.default
 
         # Returning negative of input value
         if cleaned_input in ["true", "yes", "y", "1"]:

--- a/firstvoices/backend/tests/factories/resources/import_job/default_values.csv
+++ b/firstvoices/backend/tests/factories/resources/import_job/default_values.csv
@@ -1,0 +1,5 @@
+﻿title,type,visibility,include_in_games,include_on_kids_site
+Empty type ,,  PUBLIC,TRUE,FALSE
+Empty visibility,phrase  ,,FALSE,TRUE
+Empty include in games,WORD,  puBLIc  ,,TRUE
+Empty include on kids site,  PhRasE  ,teaM  ,FALSE,


### PR DESCRIPTION
### Description of Changes
- Added `default` parameter to `ChoicesWidget` and `InvertedBooleanFieldWidget`.
- Added default values to visibility, type, and boolean field widgets for the `DictionaryEntry` resource.

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Insomnia workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
