### PR TITLE
FW-5604 batch import minor bug fixes

### DIFF
--- a/firstvoices/backend/resources/dictionary.py
+++ b/firstvoices/backend/resources/dictionary.py
@@ -108,7 +108,7 @@ class DictionaryEntryResource(
                 import_result.error_messages = [
                     err for err in import_result.validation_error.messages
                 ]
-                import_result.validation_error = []
+                import_result.validation_error = None
 
             import_result.import_type = RowResult.IMPORT_TYPE_SKIP
 

--- a/firstvoices/backend/resources/dictionary.py
+++ b/firstvoices/backend/resources/dictionary.py
@@ -77,15 +77,16 @@ class DictionaryEntryResource(
         ),
     )
 
-    def __init__(self, site=None):
-        if site:
-            self.site = site
+    def __init__(self, site=None, run_as_user=None):
+        self.site = site
+        self.run_as_user = run_as_user
 
     def before_import(self, dataset, **kwargs):
-        if "id" not in dataset.headers:
-            dataset.append_col(lambda x: str(uuid.uuid4()), header="id")
-        if "site" not in dataset.headers:
-            dataset.append_col(lambda x: str(self.site.id), header="site")
+        # Adding required columns, since these will not be present in the headers
+        dataset.append_col(lambda x: str(uuid.uuid4()), header="id")
+        dataset.append_col(lambda x: str(self.site.id), header="site")
+        dataset.append_col(lambda x: str(self.run_as_user), header="created_by")
+        dataset.append_col(lambda x: str(self.run_as_user), header="last_modified_by")
 
     def import_row(self, row, instance_loader, **kwargs):
         # Marking erroneous and invalid rows as skipped, then clearing the errors and validation_errors
@@ -116,3 +117,4 @@ class DictionaryEntryResource(
 
     class Meta:
         model = DictionaryEntry
+        clean_model_instances = True

--- a/firstvoices/backend/serializers/import_job_serializers.py
+++ b/firstvoices/backend/serializers/import_job_serializers.py
@@ -119,6 +119,10 @@ class ImportJobSerializer(CreateSiteContentSerializerMixin, BaseJobSerializer):
             if run_as_user:
                 user = validate_username(run_as_user)
                 validated_data["run_as_user"] = user
+            else:
+                # If no alternative user supplied, treat the user requesting
+                # the import as run_as_user
+                validated_data["run_as_user"] = self.context["request"].user
 
             validated_data["data"] = file
             return super().create(validated_data)

--- a/firstvoices/backend/tasks/import_job_tasks.py
+++ b/firstvoices/backend/tasks/import_job_tasks.py
@@ -272,9 +272,13 @@ def batch_import(import_job_instance_id, dry_run=True):
         return
 
     if dry_run:
-        import_job_instance.validation_task_id = task_id
         import_job_instance.validation_status = JobStatus.STARTED
-        import_job_instance.save()
+        import_job_instance.validation_task_id = task_id
+    else:
+        # we don't need to set the import_job_instance primary task status here
+        # as that is assigned in the @confirm view
+        import_job_instance.task_id = task_id
+    import_job_instance.save()
 
     file = import_job_instance.data.content.open().read().decode("utf-8-sig")
     data = tablib.Dataset().load(file, format="csv")

--- a/firstvoices/backend/tasks/import_job_tasks.py
+++ b/firstvoices/backend/tasks/import_job_tasks.py
@@ -175,14 +175,14 @@ def import_resource(
             error_row_instance.save()
             error_row_numbers.append(row.number)
 
-    error_row_numbers.sort()
-
-    # Attach the csv
-    failed_row_csv_file = get_failed_rows_csv_file(
-        import_job_instance, data, error_row_numbers
-    )
-    import_job_instance.failed_rows_csv = failed_row_csv_file
-    import_job_instance.save()
+    # Sort rows and attach the csv
+    if error_row_numbers:
+        error_row_numbers.sort()
+        failed_row_csv_file = get_failed_rows_csv_file(
+            import_job_instance, data, error_row_numbers
+        )
+        import_job_instance.failed_rows_csv = failed_row_csv_file
+        import_job_instance.save()
 
     return report
 

--- a/firstvoices/backend/tasks/import_job_tasks.py
+++ b/firstvoices/backend/tasks/import_job_tasks.py
@@ -188,7 +188,9 @@ def import_resource(
 
 
 def import_job(data, import_job_instance, logger):
-    resource = DictionaryEntryResource(site=import_job_instance.site)
+    resource = DictionaryEntryResource(
+        site=import_job_instance.site, run_as_user=import_job_instance.run_as_user
+    )
 
     try:
         import_resource(data, resource, import_job_instance, dry_run=False)
@@ -201,7 +203,9 @@ def import_job(data, import_job_instance, logger):
 def import_job_dry_run(data, import_job_instance, logger):
     """Variation of the import_job method above, for dry-run only.
     Updates the validationReport and validationStatus instead of the job status."""
-    resource = DictionaryEntryResource(site=import_job_instance.site)
+    resource = DictionaryEntryResource(
+        site=import_job_instance.site, run_as_user=import_job_instance.run_as_user
+    )
 
     try:
         report = import_resource(data, resource, import_job_instance, dry_run=True)

--- a/firstvoices/backend/tests/factories/resources/import_job/invalid_dictionary_entries.csv
+++ b/firstvoices/backend/tests/factories/resources/import_job/invalid_dictionary_entries.csv
@@ -1,7 +1,7 @@
 ﻿title,type,visibility,acknowledgement,include_in_games,include_on_kids_site,part_of_speech,Ignorable_comments_column
 Phrase 1,phrase,Team,123,FALSE,TRUE,Suffix,Valid entry for control
 Word 1,xyz,Public,123,TRUE,FALSE,Adjective,invalid type entry
-,notAType,Public,123,FALSE,TRUE,Adjective,Missing title
+,word,Public,123,FALSE,TRUE,Adjective,Missing title
 Phrase 3,phrase,notAValidVis,123,FALSE,TRUE,Suffix,invalid visibility
 Phrase 4,phrase,Team,123,notBoolValue,TRUE,Adjective,invalid boolean value
 Word 1,xyz,Public,123,TRUE,FALSE,invalid_part,invalid_part_of_speech

--- a/firstvoices/backend/tests/test_resources/test_dictionary_resources.py
+++ b/firstvoices/backend/tests/test_resources/test_dictionary_resources.py
@@ -10,7 +10,7 @@ from backend.resources.dictionary import DictionaryEntryResource
 from backend.tests import factories
 
 
-# @pytest.mark.skip("Tests are for initial migration only")
+@pytest.mark.skip("Tests are for initial migration only")
 class TestDictionaryEntryImport:
     @staticmethod
     def build_table(data: list[str]):

--- a/firstvoices/backend/tests/test_tasks/test_import_job_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_import_job_tasks.py
@@ -39,7 +39,7 @@ class TestBulkImportDryRun:
 
         return import_job_instance
 
-    def test_import_task_logs(self, caplog):
+    def import_minimal_dictionary_entries(self):
         site = SiteFactory(visibility=Visibility.PUBLIC)
 
         file_content = get_sample_file("import_job/minimal.csv", self.MIMETYPE)
@@ -47,6 +47,14 @@ class TestBulkImportDryRun:
         import_job_instance = ImportJobFactory(site=site, data=file)
 
         batch_import(import_job_instance.id)
+
+        # Updated instance
+        import_job_instance = ImportJob.objects.get(id=import_job_instance.id)
+
+        return import_job_instance
+
+    def test_import_task_logs(self, caplog):
+        import_job_instance = self.import_minimal_dictionary_entries()
 
         assert (
             f"Task started. Additional info: import_job_instance_id: {import_job_instance.id}, dry-run: True."
@@ -372,6 +380,13 @@ class TestBulkImportDryRun:
                 error_rows_numbers[i] - 1
             )  # since we do +1 while generating error row numbers
             assert input_csv_table[input_index] == failed_rows_csv_table[i]
+
+    def test_failed_rows_csv_not_generated_on_valid_rows(self):
+        # To verify no failedRowsCsv is generated if all rows
+        # in the input file are valid.
+
+        import_job_instance = self.import_minimal_dictionary_entries()
+        assert import_job_instance.failed_rows_csv is None
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Description of Changes
- Added `clean_model_instances` flag to `DictionaryEntry` resource to enable `full_clean` on imported entries.
- The above change required addition of `created_by` and `last_modified_by` fields to the CSV before importing. These fields default back to the user requesting the import if the `run_as_user` field is not supplied.
- added `task_id` to confirm endpoint
- Skip failed_rows_csv generation if no erroneous rows

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable~
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Insomnia workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
