### PR TITLE
FW-6007 Ignore celery task results

### DIFF
--- a/firstvoices/backend/tests/test_celery_settings.py
+++ b/firstvoices/backend/tests/test_celery_settings.py
@@ -1,0 +1,9 @@
+import pytest
+
+from firstvoices import settings
+
+
+class TestCelerySettings:
+    @pytest.mark.django_db
+    def test_task_ignore_result(self):
+        assert getattr(settings, "CELERY_TASK_IGNORE_RESULT", False) is True

--- a/firstvoices/backend/tests/test_tasks/base_task_test.py
+++ b/firstvoices/backend/tests/test_tasks/base_task_test.py
@@ -1,0 +1,29 @@
+from unittest import mock
+
+import pytest
+
+
+class IgnoreTaskResultsMixin:
+    """Test mixin for tasks that ignore Celery results."""
+
+    TASK = None
+
+    def get_valid_task_args(self):
+        raise NotImplementedError()
+
+    def test_task_ignore_result_set(self):
+        assert self.TASK.ignore_result is True
+
+    @pytest.mark.django_db
+    @mock.patch("celery.backends.base.BaseBackend.store_result")
+    def test_task_does_not_store_result(self, mock_store_result):
+        task_args = self.get_valid_task_args()
+
+        if task_args is None:
+            self.TASK.apply_async()
+            mock_store_result.assert_not_called()
+        else:
+            self.TASK.apply_async(
+                args=task_args,
+            )
+            mock_store_result.assert_not_called()

--- a/firstvoices/backend/tests/test_tasks/test_build_mtd.py
+++ b/firstvoices/backend/tests/test_tasks/test_build_mtd.py
@@ -12,11 +12,16 @@ from backend.tasks.mtd_export_tasks import (
 )
 from backend.tasks.utils import ASYNC_TASK_END_TEMPLATE
 from backend.tests import factories
+from backend.tests.test_tasks.base_task_test import IgnoreTaskResultsMixin
 from firstvoices.celery import link_error_handler
 
 
-class TestMTDIndexAndScoreTask:
+class TestMTDIndexAndScoreTask(IgnoreTaskResultsMixin):
     sample_entry_title = "title_one word"
+    TASK = build_index_and_calculate_scores
+
+    def get_valid_task_args(self):
+        return ("test",)
 
     @staticmethod
     def assert_async_task_logs(site, caplog):
@@ -265,7 +270,12 @@ class TestMTDIndexAndScoreTask:
         self.assert_async_task_logs(site, caplog)
 
 
-class TestCheckSitesForMTDSyncTask:
+class TestCheckSitesForMTDSyncTask(IgnoreTaskResultsMixin):
+    TASK = check_sites_for_mtd_sync
+
+    def get_valid_task_args(self):
+        return None
+
     @pytest.fixture(scope="function", autouse=True)
     def mocked_mtd_build_func(self, mocker):
         self.mocked_func = mocker.patch(

--- a/firstvoices/backend/tests/test_tasks/test_bulk_visibility.py
+++ b/firstvoices/backend/tests/test_tasks/test_bulk_visibility.py
@@ -9,9 +9,15 @@ from backend.models.jobs import BulkVisibilityJob, JobStatus
 from backend.models.widget import SiteWidget
 from backend.tasks.visibility_tasks import bulk_change_visibility
 from backend.tests import factories
+from backend.tests.test_tasks.base_task_test import IgnoreTaskResultsMixin
 
 
-class TestBulkVisibilityTasks:
+class TestBulkVisibilityTasks(IgnoreTaskResultsMixin):
+    TASK = bulk_change_visibility
+
+    def get_valid_task_args(self):
+        return (uuid.uuid4(),)
+
     @pytest.fixture(scope="function", autouse=True)
     def mocked_indexing_async_func(self, mocker):
         self.mocked_func = mocker.patch(

--- a/firstvoices/backend/tests/test_tasks/test_dictionary_cleanup_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_dictionary_cleanup_tasks.py
@@ -8,10 +8,16 @@ from backend.models.jobs import JobStatus
 from backend.tasks.dictionary_cleanup_tasks import cleanup_dictionary
 from backend.tasks.utils import ASYNC_TASK_END_TEMPLATE
 from backend.tests import factories
+from backend.tests.test_tasks.base_task_test import IgnoreTaskResultsMixin
 
 
-class TestDictionaryCleanupTasks:
+class TestDictionaryCleanupTasks(IgnoreTaskResultsMixin):
     CONFUSABLE_PREV_CUSTOM_ORDER = "⚑ᐱ⚑ᐱ⚑ᐱ"
+    TASK = cleanup_dictionary
+    TASK_ADDITIONAL_INFO = "job_instance_id"
+
+    def get_valid_task_args(self):
+        return (uuid.uuid4(),)
 
     @pytest.fixture
     def site(self):

--- a/firstvoices/backend/tests/test_tasks/test_import_job_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_import_job_tasks.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest.mock import patch
 from uuid import UUID
 
@@ -17,6 +18,7 @@ from backend.tests.factories import (
     SongFactory,
     get_superadmin,
 )
+from backend.tests.test_tasks.base_task_test import IgnoreTaskResultsMixin
 from backend.tests.utils import get_sample_file
 
 
@@ -397,8 +399,12 @@ class TestBulkImportDryRun:
 
 
 @pytest.mark.django_db
-class TestBulkImport:
+class TestBulkImport(IgnoreTaskResultsMixin):
     MIMETYPE = "text/csv"
+    TASK = batch_import
+
+    def get_valid_task_args(self):
+        return (uuid.uuid4(),)
 
     def setup_method(self):
         self.user = get_superadmin()

--- a/firstvoices/backend/tests/test_tasks/test_media_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_media_tasks.py
@@ -1,6 +1,7 @@
 import pytest
 
 from backend.models.media import Image, Video
+from backend.tasks.media_tasks import generate_media_thumbnails
 from backend.tests.factories import (
     ImageFactory,
     ImageFileFactory,
@@ -8,9 +9,16 @@ from backend.tests.factories import (
     VideoFactory,
     VideoFileFactory,
 )
+from backend.tests.test_tasks.base_task_test import IgnoreTaskResultsMixin
 
 
-class TestThumbnailGeneration:
+class TestThumbnailGeneration(IgnoreTaskResultsMixin):
+    TASK = generate_media_thumbnails
+
+    def get_valid_task_args(self):
+        image = ImageFactory.create()
+        return image._meta.model_name, image.id
+
     @pytest.mark.django_db
     @pytest.mark.disable_thumbnail_mocks
     @pytest.mark.parametrize(

--- a/firstvoices/backend/tests/test_tasks/test_search_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_search_tasks.py
@@ -1,0 +1,67 @@
+import uuid
+
+from backend.search.tasks.index_manager_tasks import (
+    remove_from_index,
+    sync_in_index,
+    update_in_index,
+)
+from backend.search.tasks.site_content_indexing_tasks import (
+    remove_all_site_content_from_indexes,
+    sync_all_media_site_content_in_indexes,
+    sync_all_site_content_in_indexes,
+)
+from backend.tests.test_tasks.base_task_test import IgnoreTaskResultsMixin
+
+# Tests for search task celery behaviour, not the actual search task functionality
+
+
+class TestSyncInIndex(IgnoreTaskResultsMixin):
+    TASK = sync_in_index
+
+    def get_valid_task_args(self):
+        return ["DocumentManager", uuid.uuid4()]
+
+
+class TestUpdateInIndex(IgnoreTaskResultsMixin):
+    TASK = update_in_index
+
+    def get_valid_task_args(self):
+        return ["DocumentManager", uuid.uuid4()]
+
+
+class TestRemoveFromIndex(IgnoreTaskResultsMixin):
+    TASK = remove_from_index
+
+    def get_valid_task_args(self):
+        return ["DocumentManager", uuid.uuid4()]
+
+
+class TestRemoveAllSiteContentFromIndexes(IgnoreTaskResultsMixin):
+    TASK = remove_all_site_content_from_indexes
+
+    def get_valid_task_args(self):
+        return [
+            "site_title",
+            {
+                "dictionaryentry_set": [],
+                "song_set": [],
+                "story_set": [],
+                "audio_set": [],
+                "image_set": [],
+                "video_set": [],
+            },
+        ]
+
+
+class TestSyncAllSiteContentInIndexes(IgnoreTaskResultsMixin):
+    TASK = sync_all_site_content_in_indexes
+
+    def get_valid_task_args(self):
+        return [uuid.uuid4()]
+
+
+class TestSyncAllMediaSiteContentInIndexes(IgnoreTaskResultsMixin):
+    TASK = sync_all_media_site_content_in_indexes
+
+    def get_valid_task_args(self):
+        return [uuid.uuid4()]

--- a/firstvoices/backend/tests/test_tasks/test_send_email_task.py
+++ b/firstvoices/backend/tests/test_tasks/test_send_email_task.py
@@ -1,0 +1,9 @@
+from backend.tasks.send_email_tasks import send_email_task
+from backend.tests.test_tasks.base_task_test import IgnoreTaskResultsMixin
+
+
+class TestSendEmailTask(IgnoreTaskResultsMixin):
+    TASK = send_email_task
+
+    def get_valid_task_args(self):
+        return ("subject", "message", ["testemail"])

--- a/firstvoices/firstvoices/settings.py
+++ b/firstvoices/firstvoices/settings.py
@@ -287,6 +287,8 @@ else:
 CELERY_RESULT_BACKEND = os.getenv("CELERY_RESULT_BACKEND", "redis://localhost/0")
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
+
+CELERY_TASK_IGNORE_RESULT = True
 # Celery tasks are not picked up by autodiscover_tasks() if they are not globally imported. This adds missing tasks.
 # CELERY_IMPORTS = ("backend.tasks.my_task",)
 


### PR DESCRIPTION
### Description of Changes
- Sets the CELERY_TASK_IGNORE_RESULT global setting to true
- Adds tests such that each async task is checked that ignore_results is set to true, and that no results are stored in the db
- Bonus: Removed unused blank test file

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
