### PR TITLE
fw-6183, allow media from other sites in banners and galleries

### DIFF
--- a/firstvoices/backend/serializers/gallery_serializers.py
+++ b/firstvoices/backend/serializers/gallery_serializers.py
@@ -11,7 +11,6 @@ from backend.serializers.media_serializers import (
     ImageSerializer,
     WriteableRelatedImageSerializer,
 )
-from backend.serializers.validators import SameSite
 
 
 class GalleryItemSerializer(serializers.ModelSerializer):
@@ -55,7 +54,7 @@ class GallerySummarySerializer(WritableSiteContentSerializer):
         required=False,
         queryset=Image.objects.all(),
         allow_null=True,
-        validators=[SameSite()],
+        validators=[],
     )
 
     def validate(self, attrs):

--- a/firstvoices/backend/serializers/page_serializers.py
+++ b/firstvoices/backend/serializers/page_serializers.py
@@ -62,13 +62,13 @@ class SitePageDetailWriteSerializer(WritableControlledSiteContentSerializer):
     banner_image = serializers.PrimaryKeyRelatedField(
         queryset=Image.objects.all(),
         allow_null=True,
-        validators=[SameSite()],
+        validators=[],
         required=False,
     )
     banner_video = serializers.PrimaryKeyRelatedField(
         queryset=Video.objects.all(),
         allow_null=True,
-        validators=[SameSite()],
+        validators=[],
         required=False,
     )
 

--- a/firstvoices/backend/serializers/site_serializers.py
+++ b/firstvoices/backend/serializers/site_serializers.py
@@ -170,12 +170,12 @@ class SiteDetailWriteSerializer(SiteDetailSerializer):
     banner_image = serializers.PrimaryKeyRelatedField(
         queryset=Image.objects.all(),
         allow_null=True,
-        validators=[SameSite()],
+        validators=[],
     )
     banner_video = serializers.PrimaryKeyRelatedField(
         queryset=Video.objects.all(),
         allow_null=True,
-        validators=[SameSite()],
+        validators=[],
     )
 
     def validate_homepage(self, homepage):


### PR DESCRIPTION
### Description of Changes
Allow media from other sites, to support shared media. Site logos still enforce the SameSite validator.

### Checklist
- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Insomnia workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
