### PR TITLE
FW-5618 Add import-id parameter to search index and as a parameter to the search API

### DIFF
--- a/firstvoices/backend/search/documents/dictionary_entry_document.py
+++ b/firstvoices/backend/search/documents/dictionary_entry_document.py
@@ -24,6 +24,7 @@ class DictionaryEntryDocument(BaseSiteEntryWithMediaDocument):
     type = Keyword()
     custom_order = Keyword()
     categories = Keyword()
+    import_job = Keyword()
     has_translation = Boolean()
     has_unrecognized_chars = Boolean()
 

--- a/firstvoices/backend/search/documents/dictionary_entry_document.py
+++ b/firstvoices/backend/search/documents/dictionary_entry_document.py
@@ -24,7 +24,7 @@ class DictionaryEntryDocument(BaseSiteEntryWithMediaDocument):
     type = Keyword()
     custom_order = Keyword()
     categories = Keyword()
-    import_job = Keyword()
+    import_job_id = Keyword()
     has_translation = Boolean()
     has_unrecognized_chars = Boolean()
 

--- a/firstvoices/backend/search/indexing/dictionary_index.py
+++ b/firstvoices/backend/search/indexing/dictionary_index.py
@@ -28,7 +28,7 @@ class DictionaryEntryDocumentManager(DocumentManager):
             alternate_spelling=instance.alternate_spellings,
             note=instance.notes,
             categories=fields_as_list(instance.categories, "id"),
-            import_job=instance.import_job.id if instance.import_job else None,
+            import_job_id=instance.import_job.id if instance.import_job else None,
             exclude_from_kids=instance.exclude_from_kids,
             exclude_from_games=instance.exclude_from_games,
             custom_order=instance.custom_order,

--- a/firstvoices/backend/search/indexing/dictionary_index.py
+++ b/firstvoices/backend/search/indexing/dictionary_index.py
@@ -28,6 +28,7 @@ class DictionaryEntryDocumentManager(DocumentManager):
             alternate_spelling=instance.alternate_spellings,
             note=instance.notes,
             categories=fields_as_list(instance.categories, "id"),
+            import_job=instance.import_job.id,
             exclude_from_kids=instance.exclude_from_kids,
             exclude_from_games=instance.exclude_from_games,
             custom_order=instance.custom_order,

--- a/firstvoices/backend/search/indexing/dictionary_index.py
+++ b/firstvoices/backend/search/indexing/dictionary_index.py
@@ -28,7 +28,7 @@ class DictionaryEntryDocumentManager(DocumentManager):
             alternate_spelling=instance.alternate_spellings,
             note=instance.notes,
             categories=fields_as_list(instance.categories, "id"),
-            import_job=instance.import_job.id,
+            import_job=instance.import_job.id if instance.import_job else None,
             exclude_from_kids=instance.exclude_from_kids,
             exclude_from_games=instance.exclude_from_games,
             custom_order=instance.custom_order,

--- a/firstvoices/backend/search/query_builder.py
+++ b/firstvoices/backend/search/query_builder.py
@@ -13,6 +13,7 @@ from backend.search.utils.query_builder_utils import (
     get_has_translation_query,
     get_has_unrecognized_chars_query,
     get_has_video_query,
+    get_import_job_query,
     get_indices,
     get_kids_query,
     get_max_words_query,
@@ -39,6 +40,7 @@ def get_search_query(
     domain="both",
     starts_with_char="",
     category_id="",
+    import_job="",
     kids=None,
     games=None,
     visibility="",
@@ -98,6 +100,9 @@ def get_search_query(
 
     if category_id:
         search_query = search_query.query(get_category_query(category_id))
+
+    if import_job:
+        search_query = search_query.query(get_import_job_query(import_job))
 
     if kids is not None:
         search_query = search_query.query(get_kids_query(kids))

--- a/firstvoices/backend/search/query_builder.py
+++ b/firstvoices/backend/search/query_builder.py
@@ -40,7 +40,7 @@ def get_search_query(
     domain="both",
     starts_with_char="",
     category_id="",
-    import_job="",
+    import_job_id="",
     kids=None,
     games=None,
     visibility="",
@@ -101,8 +101,8 @@ def get_search_query(
     if category_id:
         search_query = search_query.query(get_category_query(category_id))
 
-    if import_job:
-        search_query = search_query.query(get_import_job_query(import_job))
+    if import_job_id:
+        search_query = search_query.query(get_import_job_query(import_job_id))
 
     if kids is not None:
         search_query = search_query.query(get_kids_query(kids))

--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -171,6 +171,10 @@ def get_category_query(category_id):
     return Q("bool", filter=[Q("terms", categories=query_categories)])
 
 
+def get_import_job_query(import_job_id):
+    return Q("bool", filter=[Q("term", import_job=str(import_job_id))])
+
+
 def get_kids_query(kids):
     return Q("bool", filter=[Q("term", exclude_from_kids=not kids)])
 

--- a/firstvoices/backend/search/utils/query_builder_utils.py
+++ b/firstvoices/backend/search/utils/query_builder_utils.py
@@ -172,7 +172,7 @@ def get_category_query(category_id):
 
 
 def get_import_job_query(import_job_id):
-    return Q("bool", filter=[Q("term", import_job=str(import_job_id))])
+    return Q("bool", filter=[Q("term", import_job_id=str(import_job_id))])
 
 
 def get_kids_query(kids):

--- a/firstvoices/backend/search/utils/validators.py
+++ b/firstvoices/backend/search/utils/validators.py
@@ -86,7 +86,7 @@ def get_valid_category_id(site, input_category):
     return None
 
 
-def get_valid_import_job(site, import_job_input_str):
+def get_valid_import_job_id(site, import_job_input_str):
     # If import_job_input_str is empty, filter should not be added
     if import_job_input_str:
         try:

--- a/firstvoices/backend/search/utils/validators.py
+++ b/firstvoices/backend/search/utils/validators.py
@@ -72,32 +72,16 @@ def get_valid_starts_with_char(input_str):
     return valid_str
 
 
-def get_valid_category_id(site, input_category):
-    # If input_category is empty, category filter should not be added
-    if input_category:
-        try:
-            # If category does not belong to the site specified, return empty result set
-            valid_category = site.category_set.filter(id=input_category)
-            if len(valid_category):
-                return valid_category[0].id
-        except exceptions.ValidationError:
-            return None
+def validate_model_instance_id(site, model, instance_id):
+    if not instance_id:
+        return None
 
-    return None
-
-
-def get_valid_import_job_id(site, import_job_input_str):
-    # If import_job_input_str is empty, filter should not be added
-    if import_job_input_str:
-        try:
-            # If import-job does not belong to the site specified, return empty result set
-            valid_import_job = site.importjob_set.filter(id=import_job_input_str)
-            if len(valid_import_job):
-                return valid_import_job[0].id
-        except exceptions.ValidationError:
-            return None
-
-    return None
+    try:
+        valid_instance = model.objects.filter(site=site, id=instance_id)
+        return valid_instance[0].id
+    except (exceptions.ValidationError, IndexError):
+        # invalid uuid or no entry found with provided id
+        return None
 
 
 def get_valid_boolean(input_val):

--- a/firstvoices/backend/search/utils/validators.py
+++ b/firstvoices/backend/search/utils/validators.py
@@ -72,7 +72,7 @@ def get_valid_starts_with_char(input_str):
     return valid_str
 
 
-def validate_model_instance_id(site, model, instance_id):
+def get_valid_instance_id(site, model, instance_id):
     if not instance_id:
         return None
 

--- a/firstvoices/backend/search/utils/validators.py
+++ b/firstvoices/backend/search/utils/validators.py
@@ -86,6 +86,20 @@ def get_valid_category_id(site, input_category):
     return None
 
 
+def get_valid_import_job(site, import_job_input_str):
+    # If import_job_input_str is empty, filter should not be added
+    if import_job_input_str:
+        try:
+            # If import-job does not belong to the site specified, return empty result set
+            valid_import_job = site.importjob_set.filter(id=import_job_input_str)
+            if len(valid_import_job):
+                return valid_import_job[0].id
+        except exceptions.ValidationError:
+            return None
+
+    return None
+
+
 def get_valid_boolean(input_val):
     # Python treats bool("False") as true, thus manual verification
     cleaned_input = str(input_val).strip().lower()

--- a/firstvoices/backend/tests/test_search_indexing/test_dictionary_indexing.py
+++ b/firstvoices/backend/tests/test_search_indexing/test_dictionary_indexing.py
@@ -57,7 +57,7 @@ class TestDictionaryEntryDocumentManager(BaseDocumentManagerTest):
         assert doc.created == instance.created
         assert doc.last_modified == instance.last_modified
 
-        assert not doc.import_job
+        assert not doc.import_job_id
 
     @pytest.mark.django_db
     def test_create_document_no_unknown_characters(self):
@@ -96,4 +96,4 @@ class TestDictionaryEntryDocumentManager(BaseDocumentManagerTest):
         )
         assert_list(instance.alternate_spellings, doc.alternate_spelling)
 
-        assert doc.import_job == instance.import_job.id
+        assert doc.import_job_id == instance.import_job.id

--- a/firstvoices/backend/tests/test_search_indexing/test_dictionary_indexing.py
+++ b/firstvoices/backend/tests/test_search_indexing/test_dictionary_indexing.py
@@ -57,6 +57,8 @@ class TestDictionaryEntryDocumentManager(BaseDocumentManagerTest):
         assert doc.created == instance.created
         assert doc.last_modified == instance.last_modified
 
+        assert not doc.import_job
+
     @pytest.mark.django_db
     def test_create_document_no_unknown_characters(self):
         site = factories.SiteFactory.create()

--- a/firstvoices/backend/tests/test_search_indexing/test_dictionary_indexing.py
+++ b/firstvoices/backend/tests/test_search_indexing/test_dictionary_indexing.py
@@ -7,6 +7,7 @@ from backend.search.indexing.dictionary_index import (
 )
 from backend.search.utils.constants import ELASTICSEARCH_DICTIONARY_ENTRY_INDEX
 from backend.tests import factories
+from backend.tests.factories import ImportJobFactory
 from backend.tests.test_search_indexing.base_indexing_tests import (
     BaseDocumentManagerTest,
     BaseIndexManagerTest,
@@ -70,7 +71,8 @@ class TestDictionaryEntryDocumentManager(BaseDocumentManagerTest):
 
     @pytest.mark.django_db
     def test_create_document_related_models(self):
-        instance = self.factory.create()
+        import_job_instance = ImportJobFactory()
+        instance = self.factory.create(import_job=import_job_instance)
 
         doc = self.manager.create_index_document(instance)
 
@@ -91,3 +93,5 @@ class TestDictionaryEntryDocumentManager(BaseDocumentManagerTest):
             doc.categories,
         )
         assert_list(instance.alternate_spellings, doc.alternate_spelling)
+
+        assert doc.import_job == instance.import_job.id

--- a/firstvoices/backend/tests/test_search_querying/test_query_params.py
+++ b/firstvoices/backend/tests/test_search_querying/test_query_params.py
@@ -543,11 +543,11 @@ class TestImportJob:
 
     def test_valid_import_job(self):
         search_query = get_search_query(
-            import_job=self.import_job, user=AnonymousUser()
+            import_job_id=self.import_job.id, user=AnonymousUser()
         )
         search_query = search_query.to_dict()
 
         filtered_term = search_query["query"]["bool"]["filter"][0]["term"]
-        assert "import_job" in filtered_term
+        assert "import_job_id" in filtered_term
 
-        assert str(self.import_job.id) in filtered_term["import_job"]
+        assert str(self.import_job.id) in filtered_term["import_job_id"]

--- a/firstvoices/backend/tests/test_search_querying/test_query_params.py
+++ b/firstvoices/backend/tests/test_search_querying/test_query_params.py
@@ -527,3 +527,27 @@ class TestStartsWithChar:
 
         expected_starts_with_query = "'prefix': {'title': 'red'}"
         assert expected_starts_with_query in str(search_query)
+
+
+@pytest.mark.django_db
+class TestImportJob:
+    def setup_method(self):
+        self.site = factories.SiteFactory()
+        self.import_job = factories.ImportJobFactory(site=self.site)
+
+    def test_default(self):  # default case
+        search_query = get_search_query(user=AnonymousUser())
+        search_query = search_query.to_dict()
+
+        assert "import_job" not in str(search_query)
+
+    def test_valid_import_job(self):
+        search_query = get_search_query(
+            import_job=self.import_job, user=AnonymousUser()
+        )
+        search_query = search_query.to_dict()
+
+        filtered_term = search_query["query"]["bool"]["filter"][0]["term"]
+        assert "import_job" in filtered_term
+
+        assert str(self.import_job.id) in filtered_term["import_job"]

--- a/firstvoices/backend/tests/test_search_querying/test_validators.py
+++ b/firstvoices/backend/tests/test_search_querying/test_validators.py
@@ -10,10 +10,10 @@ from backend.search.utils.validators import (
     get_valid_count,
     get_valid_document_types,
     get_valid_domain,
+    get_valid_instance_id,
     get_valid_site_feature,
     get_valid_sort,
     get_valid_visibility,
-    validate_model_instance_id,
 )
 from backend.tests import factories
 
@@ -67,11 +67,11 @@ class TestValidCategory:
         self.category = factories.ParentCategoryFactory(site=self.site)
 
     def test_no_input(self):
-        assert validate_model_instance_id(self.site, Category, "") is None
+        assert get_valid_instance_id(self.site, Category, "") is None
 
     def test_valid_input(self):
         expected_category_id = self.category.id
-        actual_category_id = validate_model_instance_id(
+        actual_category_id = get_valid_instance_id(
             self.site, Category, self.category.id
         )
 
@@ -79,7 +79,7 @@ class TestValidCategory:
 
     @pytest.mark.parametrize("input_category_id", ["not_real_category", uuid.uuid4()])
     def test_invalid_input(self, input_category_id):
-        actual_category_id = validate_model_instance_id(
+        actual_category_id = get_valid_instance_id(
             self.site, Category, input_category_id
         )
         assert actual_category_id is None

--- a/firstvoices/backend/views/search_all_entries_views.py
+++ b/firstvoices/backend/views/search_all_entries_views.py
@@ -497,7 +497,7 @@ from backend.views.exceptions import ElasticSearchConnectionError
                 ],
             ),
             OpenApiParameter(
-                name="importJob",
+                name="importJobId",
                 description="Filter results based on the associated import-job.",
                 required=False,
                 default="",
@@ -512,7 +512,7 @@ from backend.views.exceptions import ElasticSearchConnectionError
                         "valid UUID",
                         value="valid UUID",
                         description="Return entries which are associated with "
-                        "the given import-job.",
+                        "the specified import-job.",
                     ),
                     OpenApiExample(
                         "invalid UUID",
@@ -589,7 +589,7 @@ class SearchAllEntriesViewSet(ThrottlingMixin, viewsets.GenericViewSet):
             "site_id": "",  # used in site-search
             "starts_with_char": "",  # used in site-search
             "category_id": "",  # used in site-search
-            "import_job": "",  # used in site-search
+            "import_job_id": "",  # used in site-search
             "visibility": valid_visibility,
             "has_audio": has_audio,
             "has_video": has_video,
@@ -644,7 +644,7 @@ class SearchAllEntriesViewSet(ThrottlingMixin, viewsets.GenericViewSet):
             return Response(data=[])
 
         # If invalid import-job, return empty list as a response
-        if search_params["import_job"] is None:
+        if search_params["import_job_id"] is None:
             return Response(data=[])
 
         # If invalid visibility is passed, return empty list as a response
@@ -672,7 +672,7 @@ class SearchAllEntriesViewSet(ThrottlingMixin, viewsets.GenericViewSet):
             site_id=search_params["site_id"],
             starts_with_char=search_params["starts_with_char"],
             category_id=search_params["category_id"],
-            import_job=search_params["import_job"],
+            import_job_id=search_params["import_job_id"],
             visibility=search_params["visibility"],
             has_audio=search_params["has_audio"],
             has_video=search_params["has_video"],

--- a/firstvoices/backend/views/search_all_entries_views.py
+++ b/firstvoices/backend/views/search_all_entries_views.py
@@ -514,11 +514,6 @@ from backend.views.exceptions import ElasticSearchConnectionError
                         description="Return entries which are associated with "
                         "the specified import-job.",
                     ),
-                    OpenApiExample(
-                        "invalid UUID",
-                        value="invalid UUID",
-                        description="Cannot validate given id, returns empty result set.",
-                    ),
                 ],
             ),
         ],

--- a/firstvoices/backend/views/search_all_entries_views.py
+++ b/firstvoices/backend/views/search_all_entries_views.py
@@ -496,6 +496,31 @@ from backend.views.exceptions import ElasticSearchConnectionError
                     ),
                 ],
             ),
+            OpenApiParameter(
+                name="importJob",
+                description="Filter results based on the associated import-job.",
+                required=False,
+                default="",
+                type=str,
+                examples=[
+                    OpenApiExample(
+                        "",
+                        value="",
+                        description="Default case. Do not add import-job filter.",
+                    ),
+                    OpenApiExample(
+                        "valid UUID",
+                        value="valid UUID",
+                        description="Return entries which are associated with "
+                        "the given import-job.",
+                    ),
+                    OpenApiExample(
+                        "invalid UUID",
+                        value="invalid UUID",
+                        description="Cannot validate given id, returns empty result set.",
+                    ),
+                ],
+            ),
         ],
     ),
 )
@@ -564,6 +589,7 @@ class SearchAllEntriesViewSet(ThrottlingMixin, viewsets.GenericViewSet):
             "site_id": "",  # used in site-search
             "starts_with_char": "",  # used in site-search
             "category_id": "",  # used in site-search
+            "import_job": "",  # used in site-search
             "visibility": valid_visibility,
             "has_audio": has_audio,
             "has_video": has_video,
@@ -617,6 +643,10 @@ class SearchAllEntriesViewSet(ThrottlingMixin, viewsets.GenericViewSet):
         if search_params["category_id"] is None:
             return Response(data=[])
 
+        # If invalid import-job, return empty list as a response
+        if search_params["import_job"] is None:
+            return Response(data=[])
+
         # If invalid visibility is passed, return empty list as a response
         if search_params["visibility"] is None:
             return Response(data=[])
@@ -642,6 +672,7 @@ class SearchAllEntriesViewSet(ThrottlingMixin, viewsets.GenericViewSet):
             site_id=search_params["site_id"],
             starts_with_char=search_params["starts_with_char"],
             category_id=search_params["category_id"],
+            import_job=search_params["import_job"],
             visibility=search_params["visibility"],
             has_audio=search_params["has_audio"],
             has_video=search_params["has_video"],

--- a/firstvoices/backend/views/search_site_entries_views.py
+++ b/firstvoices/backend/views/search_site_entries_views.py
@@ -1,9 +1,9 @@
 from drf_spectacular.utils import extend_schema, extend_schema_view
 
+from backend.models import Category, ImportJob
 from backend.search.utils.validators import (
-    get_valid_category_id,
-    get_valid_import_job_id,
     get_valid_starts_with_char,
+    validate_model_instance_id,
 )
 from backend.views.api_doc_variables import site_slug_parameter
 from backend.views.base_views import SiteContentViewSetMixin
@@ -29,15 +29,18 @@ class SearchSiteEntriesViewSet(SiteContentViewSetMixin, SearchAllEntriesViewSet)
 
         category_input_str = self.request.GET.get("category", "")
         if category_input_str:
-            category_id = get_valid_category_id(
+            category_id = validate_model_instance_id(
                 site,
+                Category,
                 category_input_str,
             )
             search_params["category_id"] = category_id
 
         import_job_input_str = self.request.GET.get("importJobId", "")
         if import_job_input_str:
-            import_job_id = get_valid_import_job_id(site, import_job_input_str)
+            import_job_id = validate_model_instance_id(
+                site, ImportJob, import_job_input_str
+            )
             search_params["import_job_id"] = import_job_id
 
         return search_params

--- a/firstvoices/backend/views/search_site_entries_views.py
+++ b/firstvoices/backend/views/search_site_entries_views.py
@@ -35,7 +35,7 @@ class SearchSiteEntriesViewSet(SiteContentViewSetMixin, SearchAllEntriesViewSet)
             )
             search_params["category_id"] = category_id
 
-        import_job_input_str = self.request.GET.get("importJob", "")
+        import_job_input_str = self.request.GET.get("importJobId", "")
         if import_job_input_str:
             import_job_id = get_valid_import_job_id(site, import_job_input_str)
             search_params["import_job_id"] = import_job_id

--- a/firstvoices/backend/views/search_site_entries_views.py
+++ b/firstvoices/backend/views/search_site_entries_views.py
@@ -2,8 +2,8 @@ from drf_spectacular.utils import extend_schema, extend_schema_view
 
 from backend.models import Category, ImportJob
 from backend.search.utils.validators import (
+    get_valid_instance_id,
     get_valid_starts_with_char,
-    validate_model_instance_id,
 )
 from backend.views.api_doc_variables import site_slug_parameter
 from backend.views.base_views import SiteContentViewSetMixin
@@ -29,7 +29,7 @@ class SearchSiteEntriesViewSet(SiteContentViewSetMixin, SearchAllEntriesViewSet)
 
         category_input_str = self.request.GET.get("category", "")
         if category_input_str:
-            category_id = validate_model_instance_id(
+            category_id = get_valid_instance_id(
                 site,
                 Category,
                 category_input_str,
@@ -38,9 +38,7 @@ class SearchSiteEntriesViewSet(SiteContentViewSetMixin, SearchAllEntriesViewSet)
 
         import_job_input_str = self.request.GET.get("importJobId", "")
         if import_job_input_str:
-            import_job_id = validate_model_instance_id(
-                site, ImportJob, import_job_input_str
-            )
+            import_job_id = get_valid_instance_id(site, ImportJob, import_job_input_str)
             search_params["import_job_id"] = import_job_id
 
         return search_params

--- a/firstvoices/backend/views/search_site_entries_views.py
+++ b/firstvoices/backend/views/search_site_entries_views.py
@@ -2,7 +2,7 @@ from drf_spectacular.utils import extend_schema, extend_schema_view
 
 from backend.search.utils.validators import (
     get_valid_category_id,
-    get_valid_import_job,
+    get_valid_import_job_id,
     get_valid_starts_with_char,
 )
 from backend.views.api_doc_variables import site_slug_parameter
@@ -37,7 +37,7 @@ class SearchSiteEntriesViewSet(SiteContentViewSetMixin, SearchAllEntriesViewSet)
 
         import_job_input_str = self.request.GET.get("importJob", "")
         if import_job_input_str:
-            import_job = get_valid_import_job(site, import_job_input_str)
-            search_params["import_job"] = import_job
+            import_job_id = get_valid_import_job_id(site, import_job_input_str)
+            search_params["import_job_id"] = import_job_id
 
         return search_params

--- a/firstvoices/backend/views/search_site_entries_views.py
+++ b/firstvoices/backend/views/search_site_entries_views.py
@@ -2,6 +2,7 @@ from drf_spectacular.utils import extend_schema, extend_schema_view
 
 from backend.search.utils.validators import (
     get_valid_category_id,
+    get_valid_import_job,
     get_valid_starts_with_char,
 )
 from backend.views.api_doc_variables import site_slug_parameter
@@ -33,5 +34,10 @@ class SearchSiteEntriesViewSet(SiteContentViewSetMixin, SearchAllEntriesViewSet)
                 category_input_str,
             )
             search_params["category_id"] = category_id
+
+        import_job_input_str = self.request.GET.get("importJob", "")
+        if import_job_input_str:
+            import_job = get_valid_import_job(site, import_job_input_str)
+            search_params["import_job"] = import_job
 
         return search_params


### PR DESCRIPTION
### Description of Changes
- Added import-job attribute to the DicitonaryEntry index, and as a parameter to the search API.
- Refactored `get_valid_category` to `validate_model_instance_id` to be reused for import-jobs.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Insomnia workspace has been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
