### PR TITLE
FW-6220 Make has_app site feature case insensitive

### DIFF
--- a/firstvoices/backend/serializers/site_serializers.py
+++ b/firstvoices/backend/serializers/site_serializers.py
@@ -111,7 +111,7 @@ class SiteDetailSerializer(UpdateSerializerMixin, SiteSummarySerializer):
     @staticmethod
     def get_default_menu(site):
         try:
-            has_app_feature = SiteFeature.objects.get(site=site, key="has_app")
+            has_app_feature = SiteFeature.objects.get(site=site, key__iexact="has_app")
             default_menu_key = (
                 "has_app_site_menu"
                 if has_app_feature.is_enabled

--- a/firstvoices/backend/tests/test_apis/test_sites_api.py
+++ b/firstvoices/backend/tests/test_apis/test_sites_api.py
@@ -271,12 +271,13 @@ class TestSitesEndpoints(MediaTestMixin, BaseApiTest):
         assert response_data["menu"] == menu.json
 
     @pytest.mark.django_db
-    def test_detail_app_site_menu(self):
+    @pytest.mark.parametrize("key", ["has_app", "HAS_APP", "Has_App"])
+    def test_detail_app_site_menu(self, key):
         user = factories.get_non_member_user()
         self.client.force_authenticate(user=user)
 
         site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
-        factories.SiteFeatureFactory.create(site=site, key="has_app", is_enabled=True)
+        factories.SiteFeatureFactory.create(site=site, key=key, is_enabled=True)
         menu = AppJson.objects.get(key="has_app_site_menu")
 
         response = self.client.get(f"{self.get_detail_endpoint(site.slug)}")


### PR DESCRIPTION
### Description of Changes
- Ensures has_app site feature is case insensitive when choosing a default site menu
- Updates tests to check insensitivity

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
