### PR TITLE
FW-6205 Add cover image handling to imported galleries

### DIFF
--- a/firstvoices/backend/resources/gallery.py
+++ b/firstvoices/backend/resources/gallery.py
@@ -40,6 +40,13 @@ class GalleryResource(SiteContentResource):
                     )
                     continue
 
+            # Set cover image as the first image in the gallery
+            if gallery.cover_image is None and gallery.galleryitem_set.exists():
+                gallery.cover_image = Image.objects.get(
+                    id=gallery.galleryitem_set.first().image_id
+                )
+                gallery.save(set_modified_date=False)
+
     class Meta:
         model = Gallery
         clean_model_instances = True

--- a/firstvoices/backend/resources/gallery.py
+++ b/firstvoices/backend/resources/gallery.py
@@ -42,8 +42,8 @@ class GalleryResource(SiteContentResource):
 
             # Set cover image as the first image in the gallery
             if gallery.cover_image is None and gallery.galleryitem_set.exists():
-                gallery.cover_image = Image.objects.get(
-                    id=gallery.galleryitem_set.first().image_id
+                gallery.cover_image = (
+                    gallery.galleryitem_set.order_by("ordering").first().image
                 )
                 gallery.save(set_modified_date=False)
 

--- a/firstvoices/backend/tests/test_commands/test_import_gallery_data.py
+++ b/firstvoices/backend/tests/test_commands/test_import_gallery_data.py
@@ -51,6 +51,7 @@ class TestImportGalleryData:
         assert gallery.title == "Test Gallery 1"
         assert gallery.introduction == "Description 1"
         assert GalleryItem.objects.filter(gallery=gallery).count() == 2
+        assert gallery.cover_image == image1
 
         assert "Found 1 gallery CSV files to process." in caplog.text
         assert f"Processing file: {filepath}" in caplog.text
@@ -77,6 +78,7 @@ class TestImportGalleryData:
         assert gallery.title == "Test Gallery 1"
         assert gallery.introduction == "Description 1"
         assert GalleryItem.objects.filter(gallery=gallery).count() == 1
+        assert gallery.cover_image == valid_image
 
         assert (
             f"Image with id {non_existent_image_id} not found. Skipping GalleryItem creation."


### PR DESCRIPTION
### Description of Changes
- Adds logic to make an imported galleries cover image the first valid image in the import csv
- Updates tests to check for cover image handling

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
