### PR TITLE
fw-6366, handle null visibility in PATCH permissions

### DIFF
--- a/firstvoices/backend/permissions/predicates/edit.py
+++ b/firstvoices/backend/permissions/predicates/edit.py
@@ -40,7 +40,7 @@ can_delete_media = Predicate(
     name="can_edit_core_uncontrolled_data",
 )
 
-# This predicate must be combined with the CreateControlledSiteContentSerializerMixin in
+# This predicate must be combined with the ValidateAssistantWritePermissionMixin in
 # backend/serializers/base_serializers.py
 can_add_controlled_data = Predicate(
     is_at_least_assistant_or_super,

--- a/firstvoices/backend/serializers/story_serializers.py
+++ b/firstvoices/backend/serializers/story_serializers.py
@@ -7,12 +7,13 @@ from backend.models import Story, StoryPage
 from backend.serializers.base_serializers import (
     ArbitraryIdSerializer,
     BaseControlledSiteContentSerializer,
-    CreateControlledSiteContentSerializerMixin,
+    CreateSiteContentSerializerMixin,
     LinkedSiteMinimalSerializer,
     LinkedSiteSerializer,
     ReadOnlyVisibilityFieldMixin,
     SiteContentLinkedTitleSerializer,
     SiteContentUrlMixin,
+    ValidateAssistantWritePermissionMixin,
     ValidateNonNullableCharFieldsMixin,
     WritableControlledSiteContentSerializer,
     WritableVisibilityField,
@@ -60,8 +61,9 @@ class StoryPageSummarySerializer(
 
 
 class StoryPageDetailSerializer(
-    CreateControlledSiteContentSerializerMixin,
+    ValidateAssistantWritePermissionMixin,
     ValidateNonNullableCharFieldsMixin,
+    CreateSiteContentSerializerMixin,
     StoryPageSummarySerializer,
 ):
     created = serializers.DateTimeField(read_only=True)


### PR DESCRIPTION
### Description of Changes
- The special handling we added to check visibility when assistants are creating objects is also reused in put and patch requests. This change handles the case where the submitted data does not contain a visibility field, for patch requests.

### Checklist
- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Insomnia workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
