### PR TITLE
fw-6334, unicode_export management command with tests

### DIFF
--- a/firstvoices/backend/management/commands/unicode_export.py
+++ b/firstvoices/backend/management/commands/unicode_export.py
@@ -41,7 +41,6 @@ class Command(BaseCommand):
     def export_language_metadata(self, output_dir):
         languages = Language.objects.all().order_by("title")
 
-        # todo: dynamic year
         filename = os.path.join(output_dir, "bc_language_metadata_2025.csv")
 
         with open(filename, "w") as f:

--- a/firstvoices/backend/management/commands/unicode_export.py
+++ b/firstvoices/backend/management/commands/unicode_export.py
@@ -1,0 +1,142 @@
+import json
+import os
+
+from django.core.management import BaseCommand
+
+from backend.models import Character, CharacterVariant, IgnoredCharacter, Language, Site
+from backend.models.constants import Visibility
+
+
+class Command(BaseCommand):
+    help = "Export unicode information for all sites, suitable for publishing in the unicode-resources repo."
+
+    def handle(self, *args, **options):
+        """
+        Export unicode information for all sites, suitable for publishing in the unicode-resources repo. Files will
+        be output to `./output`.
+
+        Run with:
+        python manage.py unicode_export
+
+        """
+        output_dir = os.path.join(os.getcwd(), "output")
+        os.makedirs(output_dir, exist_ok=True)
+
+        self.export_language_metadata(output_dir)
+
+        sites = self.get_published_bc_language_sites()
+        self.export_sites_metadata(output_dir, sites)
+
+        for s in sites:
+            self.export_site_unicode_folder(output_dir, s)
+
+    def get_published_bc_language_sites(self):
+        return (
+            Site.objects.all()
+            .filter(language__isnull=False)
+            .filter(visibility__in=[Visibility.MEMBERS, Visibility.PUBLIC])
+            .order_by("slug")
+        )
+
+    def export_language_metadata(self, output_dir):
+        languages = Language.objects.all().order_by("title")
+
+        # todo: dynamic year
+        filename = os.path.join(output_dir, "bc_language_metadata_2025.csv")
+
+        with open(filename, "w") as f:
+            f.write(
+                "Language ID,Language Name,Alternate Names,Keywords for Communities Where Language is Spoken,"
+                "BCP 47 Language Code\n"
+            )
+
+            for lang in languages:
+                f.write(
+                    f'"{lang.id}","{lang.title}","{lang.alternate_names}","{lang.community_keywords}",'
+                    f'"{lang.language_code}"\n'
+                )
+
+    def export_sites_metadata(self, output_dir, sites):
+        # Non-BC languages are not associated with a Language
+        # Exclude Team-only sites
+
+        fv_url = "https://firstvoices.com/"
+
+        filename = os.path.join(output_dir, "firstvoices_sites_metadata_2025.csv")
+
+        with open(filename, "w") as f:
+            f.write(
+                "Site ID,Slug,FirstVoices Site Name,URL,Language Name,Language ID\n"
+            )
+
+            for s in sites:
+                f.write(
+                    f'"{s.id}","{s.slug}","{s.title}","{fv_url}{s.slug}","{s.language.title}","{s.language.id}"\n'
+                )
+
+    def export_site_unicode_folder(self, output_dir, site):
+        output_subfolder = self.create_site_subfolder(output_dir, site)
+
+        self.export_alphabet(output_subfolder, site)
+        self.export_character_variants(output_subfolder, site)
+        self.export_ignored_characters(output_subfolder, site)
+        self.export_confusable_characters(output_subfolder, site)
+
+    def create_site_subfolder(self, output_dir, site):
+        subfolder = os.path.join(output_dir, site.slug)
+        os.makedirs(subfolder, exist_ok=True)
+        return subfolder
+
+    def export_alphabet(self, output_dir, site):
+        characters = Character.objects.all().filter(site=site).order_by("sort_order")
+        if characters.count() == 0:
+            return
+
+        filename = os.path.join(output_dir, "alphabet_ordering.csv")
+        with open(filename, "w") as f:
+            f.write("Sort Order,Character,Approximate Latin Form(s)\n")
+
+            for c in characters:
+                f.write(f'"{c.sort_order}","{c.title}","{c.approximate_form}"\n')
+
+    def export_character_variants(self, output_dir, site):
+        variants = (
+            CharacterVariant.objects.all()
+            .filter(site=site)
+            .order_by("base_character__sort_order")
+        )
+        if variants.count() == 0:
+            return
+
+        filename = os.path.join(output_dir, "character_variants.csv")
+        with open(filename, "w") as f:
+            f.write("Base Character,Variant\n")
+
+            for v in variants:
+                f.write(f'"{v.base_character.title}","{v.title}"\n')
+
+    def export_ignored_characters(self, output_dir, site):
+        ignoreds = IgnoredCharacter.objects.all().filter(site=site).order_by("created")
+        if ignoreds.count() == 0:
+            return
+
+        filename = os.path.join(output_dir, "ignored_characters.csv")
+        with open(filename, "w") as f:
+            f.write("Ignored Character\n")
+
+            for i in ignoreds:
+                f.write(f'"{i.title}"\n')
+
+    def export_confusable_characters(self, output_dir, site):
+        alphabet = site.alphabet_set.first()
+        if alphabet is None:
+            return
+
+        confusables = json.loads(alphabet.input_to_canonical_map)
+
+        filename = os.path.join(output_dir, "confusable_characters.csv")
+        with open(filename, "w") as f:
+            f.write("Confusable,Canonical Character\n")
+
+            for c in confusables:
+                f.write(f"\"{c['in']}\",\"{c['out']}\"\n")

--- a/firstvoices/backend/tests/test_commands/test_unicode_export.py
+++ b/firstvoices/backend/tests/test_commands/test_unicode_export.py
@@ -1,0 +1,214 @@
+import os
+import shutil
+
+import pytest
+from django.core.management import call_command
+
+from backend.models import Language
+from backend.models.constants import Visibility
+from backend.tests import factories
+
+
+@pytest.fixture
+def get_tmp_output_dir(request) -> str:
+    output_dir = os.path.join(os.getcwd(), "output")
+
+    # Function to clear the resources
+    def remove_output():
+        shutil.rmtree(output_dir, ignore_errors=True)
+
+    request.addfinalizer(remove_output)
+
+    return output_dir
+
+
+@pytest.mark.django_db
+class TestUnicodeExport:
+    def test_subfolders_for_all_sites(self, get_tmp_output_dir):
+        language = Language.objects.first()
+        site1 = factories.SiteFactory.create(
+            slug="site1", language=language, visibility=Visibility.TEAM
+        )
+        site2 = factories.SiteFactory.create(slug="site2")
+        site3 = factories.SiteFactory.create(
+            slug="site3", language=language, visibility=Visibility.MEMBERS
+        )
+        site4 = factories.SiteFactory.create(
+            slug="site4", language=language, visibility=Visibility.PUBLIC
+        )
+
+        call_command("unicode_export")
+        assert not os.path.exists(os.path.join(get_tmp_output_dir, site1.slug))
+        assert not os.path.exists(os.path.join(get_tmp_output_dir, site2.slug))
+        assert os.path.exists(os.path.join(get_tmp_output_dir, site3.slug))
+        assert os.path.exists(os.path.join(get_tmp_output_dir, site4.slug))
+
+    def test_language_metadata(self, get_tmp_output_dir):
+        call_command("unicode_export")
+
+        filename = os.path.join(get_tmp_output_dir, "bc_language_metadata_2025.csv")
+        assert os.path.exists(filename)
+
+        language = Language.objects.get(title="Anishinaabemowin")
+
+        with open(filename) as f:
+            header = f.readline()
+            assert (
+                header
+                == "Language ID,Language Name,Alternate Names,Keywords for Communities Where Language is Spoken,"
+                "BCP 47 Language Code\n"
+            )
+            firstline = f.readline()
+            assert (
+                firstline
+                == f'"{language.id}","Anishinaabemowin","Saulteau, Saulteaux, Ojibwe, Ojibway, Ojibwa, Plains '
+                f'Ojibway","","oji"\n'
+            )
+
+    def test_site_metadata(self, get_tmp_output_dir):
+        language = Language.objects.first()
+        factories.SiteFactory.create(
+            slug="site1", language=language, visibility=Visibility.TEAM
+        )
+        factories.SiteFactory.create(slug="site2")
+        site3 = factories.SiteFactory.create(
+            slug="site3",
+            title="Site 3",
+            language=language,
+            visibility=Visibility.MEMBERS,
+        )
+
+        call_command("unicode_export")
+        filename = os.path.join(
+            get_tmp_output_dir, "firstvoices_sites_metadata_2025.csv"
+        )
+        assert os.path.exists(filename)
+
+        with open(filename) as f:
+            header = f.readline()
+            assert (
+                header
+                == "Site ID,Slug,FirstVoices Site Name,URL,Language Name,Language ID\n"
+            )
+
+            firstline = f.readline()
+            assert (
+                firstline
+                == f'"{site3.id}","site3","Site 3","https://firstvoices.com/site3","{site3.language.title}",'
+                f'"{site3.language.id}"\n'
+            )
+
+    def test_alphabet_ordering(self, get_tmp_output_dir):
+        language = Language.objects.first()
+        site = factories.SiteFactory.create(
+            slug="sluggo", language=language, visibility=Visibility.MEMBERS
+        )
+        char3 = factories.CharacterFactory.create(site=site, sort_order=3, title="C")
+        char1 = factories.CharacterFactory.create(
+            site=site, sort_order=1, title="A", approximate_form="a"
+        )
+
+        call_command("unicode_export")
+
+        filename = os.path.join(get_tmp_output_dir, site.slug, "alphabet_ordering.csv")
+        assert os.path.exists(filename)
+
+        with open(filename) as f:
+            header = f.readline()
+            assert header == "Sort Order,Character,Approximate Latin Form(s)\n"
+
+            line = f.readline()
+            assert (
+                line
+                == f'"{char1.sort_order}","{char1.title}","{char1.approximate_form}"\n'
+            )
+            line = f.readline()
+            assert line == f'"{char3.sort_order}","{char3.title}",""\n'
+
+    def test_character_variants(self, get_tmp_output_dir):
+        language = Language.objects.first()
+        site = factories.SiteFactory.create(
+            language=language, visibility=Visibility.MEMBERS
+        )
+        char3 = factories.CharacterFactory.create(site=site, sort_order=3, title="C")
+        var3 = factories.CharacterVariantFactory.create(
+            site=site, base_character=char3, title="Cc"
+        )
+        char1 = factories.CharacterFactory.create(
+            site=site, sort_order=1, title="A", approximate_form="a"
+        )
+        var1 = factories.CharacterVariantFactory.create(
+            site=site, base_character=char1, title="Aa"
+        )
+
+        call_command("unicode_export")
+
+        filename = os.path.join(get_tmp_output_dir, site.slug, "character_variants.csv")
+        assert os.path.exists(filename)
+
+        with open(filename) as f:
+            header = f.readline()
+            assert header == "Base Character,Variant\n"
+
+            line = f.readline()
+            assert line == f'"{char1.title}","{var1.title}"\n'
+            line = f.readline()
+            assert line == f'"{char3.title}","{var3.title}"\n'
+
+    def test_ignored_characters(self, get_tmp_output_dir):
+        language = Language.objects.first()
+        site = factories.SiteFactory.create(
+            language=language, visibility=Visibility.MEMBERS
+        )
+        ignored1 = factories.IgnoredCharacterFactory.create(site=site, title="-")
+        ignored2 = factories.IgnoredCharacterFactory.create(site=site, title="/")
+
+        call_command("unicode_export")
+
+        filename = os.path.join(get_tmp_output_dir, site.slug, "ignored_characters.csv")
+        assert os.path.exists(filename)
+
+        with open(filename) as f:
+            header = f.readline()
+            assert header == "Ignored Character\n"
+
+            line = f.readline()
+            assert line == f'"{ignored1.title}"\n'
+            line = f.readline()
+            assert line == f'"{ignored2.title}"\n'
+
+    def test_confusable_characters(self, get_tmp_output_dir):
+        language = Language.objects.first()
+        site = factories.SiteFactory.create(
+            language=language, visibility=Visibility.MEMBERS
+        )
+        confusables_map = '[{"in": "k̒ʷ", "out": "k̓ʷ"}, {"in": "k̍ʷ", "out": "k̓ʷ"}]'
+        factories.AlphabetFactory.create(
+            site=site, input_to_canonical_map=confusables_map
+        )
+
+        call_command("unicode_export")
+
+        filename = os.path.join(
+            get_tmp_output_dir, site.slug, "confusable_characters.csv"
+        )
+        assert os.path.exists(filename)
+
+        with open(filename) as f:
+            header = f.readline()
+            assert header == "Confusable,Canonical Character\n"
+
+            line = f.readline()
+            assert line == '"k̒ʷ","k̓ʷ"\n'
+
+    def test_empty_site_has_no_files(self, get_tmp_output_dir):
+        language = Language.objects.first()
+        site = factories.SiteFactory.create(
+            language=language, visibility=Visibility.MEMBERS
+        )
+
+        subfolder = os.path.join(get_tmp_output_dir, site.slug)
+        assert not os.path.exists(os.path.join(subfolder, "alphabet_ordering.csv"))
+        assert not os.path.exists(os.path.join(subfolder, "character_variants.csv"))
+        assert not os.path.exists(os.path.join(subfolder, "ignored_characters.csv"))
+        assert not os.path.exists(os.path.join(subfolder, "confusable_characters.csv"))


### PR DESCRIPTION
### Description of Changes
* Adds a management command to generate the csv files for the [orthography-resources folder for the unicode-resources repository](https://github.com/First-Peoples-Cultural-Council/unicode-resources/tree/main/orthography-resources)

### Checklist
- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Insomnia workspace has been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
