### PR TITLE
fw-6436, copy rather than link to mp3 files

### DIFF
--- a/firstvoices/backend/management/commands/convert_mp3_to_audio.py
+++ b/firstvoices/backend/management/commands/convert_mp3_to_audio.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.core.files.uploadedfile import UploadedFile
 from django.core.management.base import BaseCommand
 from django.db import transaction
 
@@ -47,13 +48,14 @@ class Command(BaseCommand):
         with transaction.atomic():
             # convert ImageFile or VideoFile to File
             original_file = model.original
+
             file = File.objects.create(
                 created_by=original_file.created_by,
                 created=original_file.created,
                 last_modified_by=original_file.last_modified_by,
                 last_modified=original_file.last_modified,
                 site=original_file.site,
-                content=original_file.content,
+                content=UploadedFile(original_file.content.file),
                 mimetype=original_file.mimetype,
                 size=original_file.size,
             )


### PR DESCRIPTION
### Description of Changes
When converting broken media instances to the correct type, ensure we use a copy of the underlying file content, rather than pointing the new File instance to the same old stored file object. When the old broken media is removed, its associated File (and file object) is deleted, so the new media instance was left with a file path that pointed to nothing.

### Checklist
- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Insomnia workspace has been updated if applicable
- [ ] Signal and Task inventories have been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
