### PR TITLE
Fw-6450, merge speakers

### DIFF
--- a/firstvoices/backend/management/commands/merge_duplicate_speakers.py
+++ b/firstvoices/backend/management/commands/merge_duplicate_speakers.py
@@ -9,7 +9,6 @@ class Command(BaseCommand):
     help = "Merge duplicate speakers for all sites."
 
     def handle(self, *args, **options):
-        # Setting logger level to get all logs
         logger = logging.getLogger(__name__)
 
         placeholder_bio = "---"

--- a/firstvoices/backend/management/commands/merge_duplicate_speakers.py
+++ b/firstvoices/backend/management/commands/merge_duplicate_speakers.py
@@ -1,0 +1,64 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from backend.models.media import Person
+
+
+class Command(BaseCommand):
+    help = "Merge duplicate speakers for all sites."
+
+    def handle(self, *args, **options):
+        # Setting logger level to get all logs
+        logger = logging.getLogger(__name__)
+
+        placeholder_bio = "---"
+        people = list(Person.objects.all().order_by("-created"))
+        logger.debug(f"Merging duplicates in {len(people)} people")
+
+        for p in people:
+            oldest_match = (
+                Person.objects.filter(site=p.site, name__iexact=p.name)
+                .exclude(pk=p.pk)
+                .order_by("created")
+                .first()
+            )
+
+            if oldest_match:
+                self.merge_audio_links(oldest_match, p)
+
+                if oldest_match.bio == "":
+                    self.set_bio(oldest_match, placeholder_bio)
+
+                p.delete()
+
+        self.remove_placeholder_bios(placeholder_bio)
+
+        people = Person.objects.all()
+        logger.debug(f"Resulting non-duplicate people: {people.count()}")
+
+    def remove_placeholder_bios(self, placeholder_bio):
+        placeholders = list(Person.objects.filter(bio=placeholder_bio))
+        for p in placeholders:
+            p.bio = ""
+            p.save()
+
+    def set_bio(self, person, placeholder):
+        # find oldest bio
+        oldest_bio = (
+            Person.objects.filter(site=person.site, name__iexact=person.name)
+            .exclude(bio="")
+            .exclude(pk=person.pk)
+            .order_by("created")
+            .first()
+        )
+        if oldest_bio:
+            person.bio = oldest_bio.bio
+        else:
+            person.bio = placeholder
+        person.save()
+
+    def merge_audio_links(self, target, source):
+        audios = source.audio_set.all()
+        for a in audios:
+            target.audio_set.add(a.pk)

--- a/firstvoices/backend/tests/test_commands/test_merge_duplicate_speakers.py
+++ b/firstvoices/backend/tests/test_commands/test_merge_duplicate_speakers.py
@@ -1,0 +1,110 @@
+import pytest
+from django.core.management import call_command
+
+from backend.models.media import Person
+from backend.tests import factories
+
+
+@pytest.mark.django_db
+class TestMergeDuplicateSpeakers:
+    def test_merge_preserves_oldest_instances(self):
+        site = factories.SiteFactory.create()
+        person_a1 = factories.PersonFactory.create(name="person A", site=site)
+        person_a2 = factories.PersonFactory.create(name="person A", site=site)
+        person_b1 = factories.PersonFactory.create(name="person b", site=site)
+        person_b2 = factories.PersonFactory.create(name="person b", site=site)
+
+        call_command("merge_duplicate_speakers")
+        merged_persons = Person.objects.all()
+        assert merged_persons.count() == 2
+
+        assert Person.objects.filter(pk=person_a1.pk).count() == 1
+        assert Person.objects.filter(pk=person_b1.pk).count() == 1
+
+        assert Person.objects.filter(pk=person_a2.pk).count() == 0
+        assert Person.objects.filter(pk=person_b2.pk).count() == 0
+
+    def test_merge_case_insensitive(self):
+        site = factories.SiteFactory.create()
+        factories.PersonFactory.create(name="person A", site=site)
+        factories.PersonFactory.create(name="PERSON A", site=site)
+        factories.PersonFactory.create(name="Person a", site=site)
+
+        call_command("merge_duplicate_speakers")
+        assert Person.objects.all().count() == 1
+
+    def test_no_merging_different_sites(self):
+        factories.PersonFactory.create(name="PERSON A")
+        factories.PersonFactory.create(name="PERSON A")
+        factories.PersonFactory.create(name="PERSON A")
+
+        call_command("merge_duplicate_speakers")
+        assert Person.objects.all().count() == 3
+
+    def test_no_merging_different_names(self):
+        site = factories.SiteFactory.create()
+        factories.PersonFactory.create(name="person A", site=site)
+        factories.PersonFactory.create(name="PERSON b", site=site)
+        factories.PersonFactory.create(name="Person C", site=site)
+
+        call_command("merge_duplicate_speakers")
+        assert Person.objects.all().count() == 3
+
+    def test_merge_preserves_audio_links(self):
+        site = factories.SiteFactory.create()
+        person_a1 = factories.PersonFactory.create(name="person A", site=site)
+        person_a2 = factories.PersonFactory.create(name="PERSON A", site=site)
+        person_a3 = factories.PersonFactory.create(name="Person a", site=site)
+
+        audio_1 = factories.AudioFactory.create(site=site)
+        audio_1.speakers.add(person_a1)
+
+        audio_2 = factories.AudioFactory.create(site=site)
+        audio_2.speakers.add(person_a2)
+
+        audio_3 = factories.AudioFactory.create(site=site)
+        audio_3.speakers.add(person_a3)
+
+        call_command("merge_duplicate_speakers")
+        merged_audio = Person.objects.first().audio_set.values_list("id", flat=True)
+        assert audio_1.pk in merged_audio
+        assert audio_2.pk in merged_audio
+        assert audio_3.pk in merged_audio
+
+    def test_no_duplicate_audio_links(self):
+        site = factories.SiteFactory.create()
+        person_a1 = factories.PersonFactory.create(name="person A", site=site)
+        person_a2 = factories.PersonFactory.create(name="PERSON A", site=site)
+        person_a3 = factories.PersonFactory.create(name="Person a", site=site)
+
+        audio_1 = factories.AudioFactory.create(site=site)
+        audio_1.speakers.add(person_a1)
+        audio_1.speakers.add(person_a2)
+        audio_1.speakers.add(person_a3)
+
+        call_command("merge_duplicate_speakers")
+        merged_audio = Person.objects.first().audio_set.all()
+        assert merged_audio.count() == 1
+
+    def test_keep_oldest_bio(self):
+        site = factories.SiteFactory.create()
+        factories.PersonFactory.create(name="person A", site=site)
+        factories.PersonFactory.create(name="PERSON A", site=site, bio="A great life.")
+        factories.PersonFactory.create(
+            name="Person a", site=site, bio="New updates on a great life."
+        )
+        factories.PersonFactory.create(name="Person a", site=site)
+
+        call_command("merge_duplicate_speakers")
+        merged_person = Person.objects.first()
+        assert merged_person.bio == "A great life."
+
+    def test_all_bios_blank(self):
+        site = factories.SiteFactory.create()
+        factories.PersonFactory.create(name="person A", site=site)
+        factories.PersonFactory.create(name="PERSON A", site=site)
+        factories.PersonFactory.create(name="Person a", site=site)
+
+        call_command("merge_duplicate_speakers")
+        merged_person = Person.objects.first()
+        assert merged_person.bio == ""


### PR DESCRIPTION
### Description of Changes
* Management command to merge duplicate speakers based on case-insensitive exact matches on the name (within the same site)
* Merges all audio links
* Keeps the oldest version of the bio

### Checklist
- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Insomnia workspace has been updated if applicable
- [ ] Signal and Task inventories have been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
