### PR TITLE
fw-6429, block uploading more media after an import runs

### DIFF
--- a/firstvoices/backend/views/import_job_media_views.py
+++ b/firstvoices/backend/views/import_job_media_views.py
@@ -70,7 +70,12 @@ class ImportJobMediaViewSet(
     def create(self, *args, **kwargs):
         user = self.request.user
         site = self.get_validated_site()
+
         import_job = self.get_validated_import_job()
+        if import_job.status is not None:
+            raise ValidationError(
+                f"Can't add media after an import job has started. This job already has status: {import_job.status}."
+            )
 
         for file in self.request.FILES.getlist("file"):
             filetype = self.get_filetype(file)


### PR DESCRIPTION
### Description of Changes
- checks the import job status before allowing more media to be uploaded for that batch import

### Checklist
- [ ] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Insomnia workspace has been updated if applicable
- [ ] Signal and Task inventories have been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
