### PR TITLE
fw-6432, handle duplicate images in gallery import

### DIFF
--- a/firstvoices/backend/resources/gallery.py
+++ b/firstvoices/backend/resources/gallery.py
@@ -1,4 +1,5 @@
 import logging
+from collections import OrderedDict
 
 from import_export import fields
 
@@ -23,10 +24,11 @@ class GalleryResource(SiteContentResource):
             image_ids = [
                 img_id.strip() for img_id in related_images.split(",") if img_id.strip()
             ]
+            unique_image_ids = list(OrderedDict.fromkeys(image_ids))
 
             gallery = Gallery.objects.get(id=row_result.object_id)
 
-            for order, image_id in enumerate(image_ids):
+            for order, image_id in enumerate(unique_image_ids):
                 try:
                     image = Image.objects.get(id=image_id)
                     GalleryItem.objects.create(


### PR DESCRIPTION
### Description of Changes
- remove duplicate images while preserving list order, so the first element can be used as the cover

### Checklist
- [ ] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Insomnia workspace has been updated if applicable
- [ ] Signal and Task inventories have been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
