### PR TITLE
fw-5518, tests for search API response formatting

### DIFF
--- a/firstvoices/backend/tests/test_apis/test_search_apis/test_search_api.py
+++ b/firstvoices/backend/tests/test_apis/test_search_apis/test_search_api.py
@@ -10,11 +10,14 @@ from backend.tests import factories
 from backend.tests.test_apis.base_api_test import BaseApiTest
 from backend.tests.test_apis.base_media_test import VIMEO_VIDEO_LINK, YOUTUBE_VIDEO_LINK
 from backend.tests.test_apis.test_search_apis.base_search_test import SearchMocksMixin
+from backend.tests.test_apis.test_search_apis.test_search_querying.test_search_entry_results import (
+    SearchEntryResultsTestMixin,
+)
 from backend.views.exceptions import ElasticSearchConnectionError
 
 
 @pytest.mark.django_db
-class TestSearchAPI(SearchMocksMixin, BaseApiTest):
+class TestSearchAPI(SearchEntryResultsTestMixin, SearchMocksMixin, BaseApiTest):
     """Tests for base search views."""
 
     API_LIST_VIEW = "api:search-list"

--- a/firstvoices/backend/tests/test_apis/test_search_apis/test_site_search_api.py
+++ b/firstvoices/backend/tests/test_apis/test_search_apis/test_site_search_api.py
@@ -7,14 +7,23 @@ from elasticsearch_dsl import Search
 from backend.models.constants import Role, Visibility
 from backend.tests import factories
 from backend.tests.test_apis.base_api_test import BaseSiteContentApiTest
+from backend.tests.test_apis.test_search_apis.base_search_test import SearchMocksMixin
+from backend.tests.test_apis.test_search_apis.test_search_querying.test_search_entry_results import (
+    SearchEntryResultsTestMixin,
+)
 
 
 @pytest.mark.django_db
-class TestSiteSearchAPI(BaseSiteContentApiTest):
+class TestSiteSearchAPI(
+    SearchEntryResultsTestMixin, SearchMocksMixin, BaseSiteContentApiTest
+):
     """Remaining tests that cover the site search."""
 
     API_LIST_VIEW = "api:site-search-list"
     API_DETAIL_VIEW = "api:site-search-detail"
+
+    def get_search_endpoint(self, site):
+        return f"{self.get_list_endpoint(site_slug=site.slug)}?q=what"
 
     def test_invalid_category_id(self):
         site, user = factories.get_site_with_member(


### PR DESCRIPTION
### Description of Changes
- convert test_hydrate_objects into a mixin to test serialization of search results in the views
- no functional changes

### Checklist
- [ ] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Insomnia workspace has been updated if applicable
- [ ] Signal and Task inventories have been updated if applicable

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
