### PR TITLE
fw-6601, add param to language api 

### DIFF
--- a/firstvoices/backend/tests/test_apis/test_search_apis/test_languages_api.py
+++ b/firstvoices/backend/tests/test_apis/test_search_apis/test_languages_api.py
@@ -4,6 +4,7 @@ import pytest
 
 import backend.tests.factories.access
 from backend.models.constants import Visibility
+from backend.permissions.predicates import can_view_site
 from backend.tests import factories
 from backend.tests.factories.access import (
     get_anonymous_user,
@@ -38,9 +39,45 @@ class TestLanguagesEndpoints(
             self.get_list_endpoint(), mock_search_query_execute, language_search_results
         )
 
+    def get_explore_list_response(
+        self, mock_search_query_execute, language_search_results
+    ):
+        return self.get_response(
+            f"{self.get_list_endpoint()}?explorable=true",
+            mock_search_query_execute,
+            language_search_results,
+        )
+
+    def get_nonexplore_list_response(
+        self, mock_search_query_execute, language_search_results
+    ):
+        return self.get_response(
+            f"{self.get_list_endpoint()}?explorable=false",
+            mock_search_query_execute,
+            language_search_results,
+        )
+
     def get_search_response(self, mock_search_query_execute, language_search_results):
         return self.get_response(
             self.get_search_endpoint(),
+            mock_search_query_execute,
+            language_search_results,
+        )
+
+    def get_explore_search_response(
+        self, mock_search_query_execute, language_search_results
+    ):
+        return self.get_response(
+            f"{self.get_search_endpoint()}&explorable=true",
+            mock_search_query_execute,
+            language_search_results,
+        )
+
+    def get_nonexplore_search_response(
+        self, mock_search_query_execute, language_search_results
+    ):
+        return self.get_response(
+            f"{self.get_search_endpoint()}&explorable=false",
             mock_search_query_execute,
             language_search_results,
         )
@@ -118,13 +155,59 @@ class TestLanguagesEndpoints(
         self.assert_site_response(site, language_response["sites"][0])
 
     @pytest.mark.parametrize(
-        "get_response", ["get_list_response", "get_search_response"]
+        "get_response",
+        [
+            "get_list_response",
+            "get_search_response",
+            "get_nonexplore_list_response",
+            "get_nonexplore_search_response",
+        ],
     )
     @pytest.mark.parametrize(
         "get_user", [get_anonymous_user, get_non_member_user, get_superadmin]
     )
     @pytest.mark.django_db
     def test_language_sites_only_include_visible(
+        self, get_response, get_user, db, mock_search_query_execute, mock_get_page_size
+    ):
+        user = get_user()
+        self.client.force_authenticate(user=user)
+
+        language = backend.tests.factories.access.LanguageFactory.create(
+            title="waffles"
+        )
+        site_public = factories.SiteFactory(
+            language=language, visibility=Visibility.PUBLIC
+        )
+        site_members = factories.SiteFactory(
+            language=language, visibility=Visibility.MEMBERS
+        )
+        site_team = factories.SiteFactory(language=language, visibility=Visibility.TEAM)
+        site_hidden = factories.SiteFactory(
+            language=language, visibility=Visibility.PUBLIC, is_hidden=True
+        )
+
+        response = getattr(self, get_response)(mock_search_query_execute, [language])
+
+        assert response.status_code == 200
+
+        response_data = json.loads(response.content)
+        site_id_list = [site["id"] for site in response_data["results"][0]["sites"]]
+
+        for site in [site_public, site_members, site_team, site_hidden]:
+            if can_view_site(user, site):
+                assert str(site.id) in site_id_list
+            else:
+                assert str(site.id) not in site_id_list
+
+    @pytest.mark.parametrize(
+        "get_response", ["get_explore_list_response", "get_explore_search_response"]
+    )
+    @pytest.mark.parametrize(
+        "get_user", [get_anonymous_user, get_non_member_user, get_superadmin]
+    )
+    @pytest.mark.django_db
+    def test_language_sites_only_include_explorable(
         self, get_response, get_user, db, mock_search_query_execute, mock_get_page_size
     ):
         user = get_user()
@@ -186,11 +269,11 @@ class TestLanguagesEndpoints(
         self.assert_site_response(site_z, site_list[1])
 
     @pytest.mark.parametrize(
-        "get_response", ["get_list_response", "get_search_response"]
+        "get_response", ["get_explore_list_response", "get_explore_search_response"]
     )
     @pytest.mark.parametrize("visibility", [Visibility.PUBLIC, Visibility.MEMBERS])
     @pytest.mark.django_db
-    def test_logo(
+    def test_logo_is_explorable(
         self, get_response, visibility, mock_search_query_execute, mock_get_page_size
     ):
         """
@@ -316,6 +399,38 @@ class TestLanguagesEndpoints(
         )
 
         response = self.get_list_response(mock_search_query_execute, [])
+
+        assert response.status_code == 200
+
+        response_data = json.loads(response.content)
+        site_id_list = [site["id"] for site in response_data["results"][0]["sites"]]
+
+        for site in [site_public, site_members, site_team, site_hidden]:
+            if can_view_site(user, site):
+                assert str(site.id) in site_id_list
+            else:
+                assert str(site.id) not in site_id_list
+
+    @pytest.mark.parametrize(
+        "get_user", [get_anonymous_user, get_non_member_user, get_superadmin]
+    )
+    @pytest.mark.django_db
+    def test_list_more_sites_only_include_explorable(
+        self, get_user, db, mock_search_query_execute, mock_get_page_size
+    ):
+        user = get_user()
+        self.client.force_authenticate(user=user)
+
+        site_public = factories.SiteFactory(language=None, visibility=Visibility.PUBLIC)
+        site_members = factories.SiteFactory(
+            language=None, visibility=Visibility.MEMBERS
+        )
+        site_team = factories.SiteFactory(language=None, visibility=Visibility.TEAM)
+        site_hidden = factories.SiteFactory(
+            language=None, visibility=Visibility.PUBLIC, is_hidden=True
+        )
+
+        response = self.get_explore_list_response(mock_search_query_execute, [])
 
         assert response.status_code == 200
 

--- a/firstvoices/backend/tests/test_apis/test_search_apis/test_languages_api.py
+++ b/firstvoices/backend/tests/test_apis/test_search_apis/test_languages_api.py
@@ -176,15 +176,8 @@ class TestLanguagesEndpoints(
         language = backend.tests.factories.access.LanguageFactory.create(
             title="waffles"
         )
-        site_public = factories.SiteFactory(
-            language=language, visibility=Visibility.PUBLIC
-        )
-        site_members = factories.SiteFactory(
-            language=language, visibility=Visibility.MEMBERS
-        )
-        site_team = factories.SiteFactory(language=language, visibility=Visibility.TEAM)
-        site_hidden = factories.SiteFactory(
-            language=language, visibility=Visibility.PUBLIC, is_hidden=True
+        site_public, site_members, site_team, site_hidden = self.create_mixed_sites(
+            language
         )
 
         response = getattr(self, get_response)(mock_search_query_execute, [language])
@@ -199,6 +192,19 @@ class TestLanguagesEndpoints(
                 assert str(site.id) in site_id_list
             else:
                 assert str(site.id) not in site_id_list
+
+    def create_mixed_sites(self, language):
+        site_public = factories.SiteFactory(
+            language=language, visibility=Visibility.PUBLIC
+        )
+        site_members = factories.SiteFactory(
+            language=language, visibility=Visibility.MEMBERS
+        )
+        site_team = factories.SiteFactory(language=language, visibility=Visibility.TEAM)
+        site_hidden = factories.SiteFactory(
+            language=language, visibility=Visibility.PUBLIC, is_hidden=True
+        )
+        return site_public, site_members, site_team, site_hidden
 
     @pytest.mark.parametrize(
         "get_response", ["get_explore_list_response", "get_explore_search_response"]
@@ -216,15 +222,8 @@ class TestLanguagesEndpoints(
         language = backend.tests.factories.access.LanguageFactory.create(
             title="waffles"
         )
-        site_public = factories.SiteFactory(
-            language=language, visibility=Visibility.PUBLIC
-        )
-        site_members = factories.SiteFactory(
-            language=language, visibility=Visibility.MEMBERS
-        )
-        site_team = factories.SiteFactory(language=language, visibility=Visibility.TEAM)
-        site_hidden = factories.SiteFactory(
-            language=language, visibility=Visibility.PUBLIC, is_hidden=True
+        site_public, site_members, site_team, site_hidden = self.create_mixed_sites(
+            language
         )
 
         response = getattr(self, get_response)(mock_search_query_execute, [language])
@@ -389,13 +388,8 @@ class TestLanguagesEndpoints(
         user = get_user()
         self.client.force_authenticate(user=user)
 
-        site_public = factories.SiteFactory(language=None, visibility=Visibility.PUBLIC)
-        site_members = factories.SiteFactory(
-            language=None, visibility=Visibility.MEMBERS
-        )
-        site_team = factories.SiteFactory(language=None, visibility=Visibility.TEAM)
-        site_hidden = factories.SiteFactory(
-            language=None, visibility=Visibility.PUBLIC, is_hidden=True
+        site_public, site_members, site_team, site_hidden = self.create_mixed_sites(
+            None
         )
 
         response = self.get_list_response(mock_search_query_execute, [])
@@ -421,13 +415,8 @@ class TestLanguagesEndpoints(
         user = get_user()
         self.client.force_authenticate(user=user)
 
-        site_public = factories.SiteFactory(language=None, visibility=Visibility.PUBLIC)
-        site_members = factories.SiteFactory(
-            language=None, visibility=Visibility.MEMBERS
-        )
-        site_team = factories.SiteFactory(language=None, visibility=Visibility.TEAM)
-        site_hidden = factories.SiteFactory(
-            language=None, visibility=Visibility.PUBLIC, is_hidden=True
+        site_public, site_members, site_team, site_hidden = self.create_mixed_sites(
+            None
         )
 
         response = self.get_explore_list_response(mock_search_query_execute, [])

--- a/firstvoices/backend/views/search_languages_views.py
+++ b/firstvoices/backend/views/search_languages_views.py
@@ -22,6 +22,7 @@ from backend.views import doc_strings
 from backend.views.api_doc_variables import inline_site_doc_detail_serializer
 from backend.views.base_views import ThrottlingMixin
 
+from ..search.validators import get_valid_boolean
 from ..serializers.site_serializers import SiteSummarySerializer
 from .base_search_views import BaseSearchViewSet
 
@@ -32,7 +33,7 @@ SECONDARY_BOOST = 3
 @extend_schema_view(
     list=extend_schema(
         description="A list of available language sites, grouped by language. "
-        "Public and member sites are included. If there "
+        "By default sites are filtered by user access. If there "
         "are no accessible sites the list will be empty. Sites with no specified language will be grouped "
         "under 'More FirstVoices Sites'.",
         responses={200: LanguageSerializer},
@@ -50,7 +51,30 @@ SECONDARY_BOOST = 3
                     OpenApiExample("community keyword", value="Example First Nation"),
                     OpenApiExample("site title", value="public demo site"),
                 ],
-            )
+            ),
+            OpenApiParameter(
+                name="explorable",
+                description="Toggles whether the sites are listed based on user access, or by availability for "
+                "browsing and joining.",
+                required=False,
+                default="false",
+                type=str,
+                examples=[
+                    OpenApiExample(
+                        "True",
+                        value="true",
+                        description="Lists all sites that can be browsed and joined. That is, all sites with a "
+                        "visibility of Members or Public, but not Hidden sites. Does not filter based on "
+                        "user access.",
+                    ),
+                    OpenApiExample(
+                        "False",
+                        value="false",
+                        description="Lists sites based on user access. That is, all public sites and any sites the "
+                        "user may have access to through membership.",
+                    ),
+                ],
+            ),
         ],
     ),
     retrieve=extend_schema(
@@ -72,6 +96,16 @@ class LanguageViewSet(ThrottlingMixin, BaseSearchViewSet):
         "Language": LanguageSerializer,
         "Site": LanguagePlaceholderSerializer,
     }
+
+    def get_search_params(self):
+        """
+        Returns validated search parameters based on request inputs.
+        """
+        search_params = super().get_search_params()
+
+        explorable_input = self.request.GET.get("explorable", None)
+
+        return {**search_params, "explorable": get_valid_boolean(explorable_input)}
 
     def build_query(self, q, **kwargs):
         """
@@ -122,7 +156,7 @@ class LanguageViewSet(ThrottlingMixin, BaseSearchViewSet):
 
     def make_queryset_eager(self, model_name, queryset):
         if model_name == "Language":
-            visible_sites = Site.objects.explorable()
+            visible_sites = self.get_visible_sites()
             return LanguageSerializer.make_queryset_eager(
                 queryset, visible_sites=visible_sites
             )
@@ -131,6 +165,13 @@ class LanguageViewSet(ThrottlingMixin, BaseSearchViewSet):
             return LanguagePlaceholderSerializer.make_queryset_eager(queryset)
 
         return super().make_queryset_eager(model_name, queryset)
+
+    def get_visible_sites(self):
+        search_params = self.get_search_params()
+        if search_params["explorable"]:
+            return Site.objects.explorable()
+
+        return Site.objects.visible(self.request.user)
 
     def serialize_search_results(self, search_results, data, **kwargs):
         serialized_data = super().serialize_search_results(
@@ -146,7 +187,7 @@ class LanguageViewSet(ThrottlingMixin, BaseSearchViewSet):
         return serialized_data
 
     def get_other_sites_data(self):
-        other_sites = Site.objects.explorable().filter(language=None)
+        other_sites = self.get_visible_sites().filter(language=None)
 
         if other_sites:
             queryset = LanguagePlaceholderSerializer.make_queryset_eager(other_sites)


### PR DESCRIPTION
### Description of Changes
- param to toggle list of sites from being filtered by user permissions vs "explorable" aka all sites that can be browsed on the explore languages page
- This is a breaking change to the API that would hide some sites on the Explore Languages page, but since we are still pre-1.0 and we are planning to release fv-web at the same time, Guy and I decided this was ok. It makes the default behaviour the same as all the other APIs, which is simpler to remember for the future

### Checklist
- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Insomnia workspace has been updated if applicable
- [ ] Signal and Task inventories have been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
