### PR TITLE
FW-6577 Elasticsearch version upgrade

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - "9001:9001"
     command: "server /export"
   elastic:
-    image: elasticsearch:7.17.9
+    image: elasticsearch:8.18.2
     hostname: "elastic"
     environment:
       "discovery.type": "single-node"

--- a/firstvoices/backend/search/documents/base_document.py
+++ b/firstvoices/backend/search/documents/base_document.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import Boolean, Date, Document, Integer, Keyword, Text
+from elasticsearch.dsl import Boolean, Date, Document, Integer, Keyword, Text
 
 
 class BaseDocument(Document):

--- a/firstvoices/backend/search/documents/dictionary_entry_document.py
+++ b/firstvoices/backend/search/documents/dictionary_entry_document.py
@@ -1,6 +1,6 @@
-from elasticsearch_dsl import Boolean, Keyword, Text
-from elasticsearch_dsl.analysis import analyzer
-from elasticsearch_dsl.field import TokenCount
+from elasticsearch.dsl import Boolean, Keyword, Text
+from elasticsearch.dsl.analysis import analyzer
+from elasticsearch.dsl.field import TokenCount
 
 from backend.search.constants import ELASTICSEARCH_DICTIONARY_ENTRY_INDEX
 from backend.search.documents.base_document import BaseSiteEntryWithMediaDocument

--- a/firstvoices/backend/search/documents/language_document.py
+++ b/firstvoices/backend/search/documents/language_document.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import Keyword, Text
+from elasticsearch.dsl import Keyword, Text
 
 from backend.search.constants import ELASTICSEARCH_LANGUAGE_INDEX
 from backend.search.documents.base_document import BaseDocument

--- a/firstvoices/backend/search/documents/media_document.py
+++ b/firstvoices/backend/search/documents/media_document.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import Keyword, Text
+from elasticsearch.dsl import Keyword, Text
 
 from backend.search.constants import ELASTICSEARCH_MEDIA_INDEX
 from backend.search.documents.base_document import BaseSiteEntryDocument

--- a/firstvoices/backend/search/documents/song_document.py
+++ b/firstvoices/backend/search/documents/song_document.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import Boolean, Keyword, Text
+from elasticsearch.dsl import Boolean, Keyword, Text
 
 from backend.search.constants import ELASTICSEARCH_SONG_INDEX
 from backend.search.documents.base_document import BaseSiteEntryWithMediaDocument

--- a/firstvoices/backend/search/documents/story_document.py
+++ b/firstvoices/backend/search/documents/story_document.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import Boolean, Keyword, Text
+from elasticsearch.dsl import Boolean, Keyword, Text
 
 from backend.search.constants import ELASTICSEARCH_STORY_INDEX
 from backend.search.documents.base_document import BaseSiteEntryWithMediaDocument

--- a/firstvoices/backend/search/indexing/base.py
+++ b/firstvoices/backend/search/indexing/base.py
@@ -72,8 +72,8 @@ class IndexManager:
         new_index = Index(new_index_name)
 
         new_index.settings(
-            number_of_shards=ELASTICSEARCH_DEFAULT_CONFIG["shards"],
-            number_of_replicas=ELASTICSEARCH_DEFAULT_CONFIG["replicas"],
+            number_of_shards=int(ELASTICSEARCH_DEFAULT_CONFIG["shards"]),
+            number_of_replicas=int(ELASTICSEARCH_DEFAULT_CONFIG["replicas"]),
         )
 
         cls._add_document_types(new_index)

--- a/firstvoices/backend/search/indexing/base.py
+++ b/firstvoices/backend/search/indexing/base.py
@@ -1,10 +1,9 @@
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils import timezone
+from elasticsearch.dsl import Search, connections
+from elasticsearch.dsl.index import Index
 from elasticsearch.exceptions import ConnectionError, NotFoundError
 from elasticsearch.helpers import actions
-from elasticsearch_dsl import Search
-from elasticsearch_dsl.connections import connections
-from elasticsearch_dsl.index import Index
 
 from backend.search import es_logging
 from firstvoices.settings import ELASTICSEARCH_DEFAULT_CONFIG

--- a/firstvoices/backend/search/queries/query_builder.py
+++ b/firstvoices/backend/search/queries/query_builder.py
@@ -1,6 +1,6 @@
 import random
 
-from elasticsearch_dsl import Search
+from elasticsearch.dsl import Search
 
 from backend.search.constants import ALL_SEARCH_TYPES
 from backend.search.queries.query_builder_utils import (

--- a/firstvoices/backend/search/queries/query_builder_utils.py
+++ b/firstvoices/backend/search/queries/query_builder_utils.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from elasticsearch_dsl import Q
+from elasticsearch.dsl import Q
 
 from backend.models import Membership
 from backend.models.category import Category

--- a/firstvoices/backend/search/queries/search_term_query.py
+++ b/firstvoices/backend/search/queries/search_term_query.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import Q
+from elasticsearch.dsl import Q
 
 from backend.search.constants import FUZZY_SEARCH_CUTOFF
 

--- a/firstvoices/backend/search/queries/text_matching.py
+++ b/firstvoices/backend/search/queries/text_matching.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import Q
+from elasticsearch.dsl import Q
 
 BASE_BOOST = 1.0  # neutral default
 

--- a/firstvoices/backend/tests/test_apis/test_search_apis/base_search_test.py
+++ b/firstvoices/backend/tests/test_apis/test_search_apis/base_search_test.py
@@ -2,7 +2,7 @@ import uuid
 from unittest.mock import MagicMock
 
 import pytest
-from elasticsearch_dsl import Search
+from elasticsearch.dsl import Search
 
 from backend.pagination import SearchPageNumberPagination
 

--- a/firstvoices/backend/tests/test_apis/test_search_apis/test_search_api.py
+++ b/firstvoices/backend/tests/test_apis/test_search_apis/test_search_api.py
@@ -208,7 +208,7 @@ class TestSearchAPI(
         assert response_data["count"] == 0
 
     def test_connection_error(self, mock_search_query_execute):
-        mock_search_query_execute.side_effect = ConnectionError()
+        mock_search_query_execute.side_effect = ConnectionError("Connection Error.")
 
         response = self.client.get(self.get_list_endpoint())
         assert response.status_code == 500

--- a/firstvoices/backend/tests/test_apis/test_search_apis/test_site_search_api.py
+++ b/firstvoices/backend/tests/test_apis/test_search_apis/test_site_search_api.py
@@ -2,7 +2,7 @@ import json
 from unittest.mock import patch
 
 import pytest
-from elasticsearch_dsl import Search
+from elasticsearch.dsl import Search
 
 from backend.models.constants import Role, Visibility
 from backend.tests import factories

--- a/firstvoices/backend/tests/test_commands/test_rebuild_index.py
+++ b/firstvoices/backend/tests/test_commands/test_rebuild_index.py
@@ -27,7 +27,7 @@ class TestRebuildIndex:
     def test_base_case(self, caplog):
         # Testing all indices are rebuild if no args are passed.
         with patch(
-            "elasticsearch_dsl.connections.Connections.get_connection",
+            "elasticsearch.dsl.connections.Connections.get_connection",
             return_value=self.mock_connection,
         ), patch(
             "backend.management.commands.rebuild_index.Command.index_managers",
@@ -45,7 +45,7 @@ class TestRebuildIndex:
     def test_valid_index_name_passed(self, caplog):
         # Testing all indices are rebuild if no args are passed.
         with patch(
-            "elasticsearch_dsl.connections.Connections.get_connection",
+            "elasticsearch.dsl.connections.Connections.get_connection",
             return_value=self.mock_connection,
         ), patch(
             "backend.management.commands.rebuild_index.Command.index_managers",
@@ -60,7 +60,7 @@ class TestRebuildIndex:
 
     def test_invalid_index_provided(self, caplog):
         with patch(
-            "elasticsearch_dsl.connections.Connections.get_connection",
+            "elasticsearch.dsl.connections.Connections.get_connection",
             return_value=self.mock_connection,
         ), patch(
             "backend.management.commands.rebuild_index.Command.index_managers",

--- a/firstvoices/backend/tests/test_search_indexing/base_indexing_tests.py
+++ b/firstvoices/backend/tests/test_search_indexing/base_indexing_tests.py
@@ -98,7 +98,7 @@ class BaseIndexManagerTest:
                 **{self.expected_index_name: {"is_write_index": True}}
             )
             mock_settings.assert_called_once_with(
-                number_of_shards="1", number_of_replicas="0"
+                number_of_shards=1, number_of_replicas=0
             )
             mock_create.assert_called_once()
 

--- a/firstvoices/backend/views/base_search_views.py
+++ b/firstvoices/backend/views/base_search_views.py
@@ -101,7 +101,7 @@ class BaseSearchViewSet(viewsets.GenericViewSet):
     def build_query(self, **kwargs):
         """Subclasses should implement.
 
-        Returns: elasticsearch_dsl.search.Search object specifying the query to execute
+        Returns: elasticsearch.dsl.search.Search object specifying the query to execute
         """
         raise NotImplementedError()
 

--- a/firstvoices/backend/views/search_languages_views.py
+++ b/firstvoices/backend/views/search_languages_views.py
@@ -5,7 +5,7 @@ from drf_spectacular.utils import (
     extend_schema,
     extend_schema_view,
 )
-from elasticsearch_dsl import Q, Search
+from elasticsearch.dsl import Q, Search
 
 from backend.models.sites import Site
 from backend.search.constants import ELASTICSEARCH_LANGUAGE_INDEX
@@ -109,7 +109,7 @@ class LanguageViewSet(ThrottlingMixin, BaseSearchViewSet):
 
     def build_query(self, q, **kwargs):
         """
-        Returns: elasticsearch_dsl.search.Search object specifying the query to execute
+        Returns: elasticsearch.dsl.search.Search object specifying the query to execute
         """
         if q:
             return self.build_search_term_query(q)

--- a/firstvoices/firstvoices/settings.py
+++ b/firstvoices/firstvoices/settings.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import sentry_sdk
 from dotenv import load_dotenv
-from elasticsearch_dsl import connections
+from elasticsearch.dsl import connections
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
@@ -292,7 +292,7 @@ CELERY_TASK_IGNORE_RESULT = True
 # Celery tasks are not picked up by autodiscover_tasks() if they are not globally imported. This adds missing tasks.
 # CELERY_IMPORTS = ("backend.tasks.my_task",)
 
-ELASTICSEARCH_HOST = os.getenv("ELASTICSEARCH_HOST", "localhost")
+ELASTICSEARCH_HOST = os.getenv("ELASTICSEARCH_HOST", "http://localhost:9200")
 ELASTICSEARCH_PRIMARY_INDEX = os.getenv("ELASTICSEARCH_PRIMARY_INDEX", "fv")
 # The following defaults are defaults in context of non-production environments.
 ELASTICSEARCH_DEFAULT_CONFIG = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,8 +32,7 @@ drf-nested-routers==0.94.2  # https://github.com/alanjds/drf-nested-routers/
 drf-spectacular==0.28.0
 editdistance==0.8.1
 elastic-transport==8.17.1
-elasticsearch==7.13.4
-elasticsearch-dsl==7.4.1
+elasticsearch==8.18.0
 et-xmlfile==2.0.0
 eventlet==0.40.1
 factory-boy==3.3.3


### PR DESCRIPTION
### Description of Changes
- Required changes for elasticsearch version upgrade from 7.x to 8.x
- `elasticsearch_dsl` is now packaged with the `elasticsearch` package from 8.x. So that package is removed from dependencies and all imports are changed accordingly.
- Elasticsearch image in docker-compose is updated to [8.18.2](https://hub.docker.com/_/elasticsearch).

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Insomnia workspace has been updated if applicable~
- ~Signal and Task inventories have been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [x] Pull the branch and test locally
Note: When pulling the branch locally, you will have to run a new cluster with the updated version. It can be done using stopping/deleting your current ES cluster, and starting up a new one using docker-compose. A re-index will also be required.

### Additional Notes
- We would have to upgrade the Elasticsearch image on servers simultaneously to keep the downtime to the minimum.
