### PR TITLE
FW-6574 All tasks update system last modified

### DIFF
--- a/firstvoices/backend/resources/base.py
+++ b/firstvoices/backend/resources/base.py
@@ -5,6 +5,7 @@ from import_export import fields, resources, widgets
 from import_export.results import RowResult
 
 from backend.models.constants import Visibility
+from backend.models.import_jobs import ImportJob
 from backend.models.media import Audio, Image, Video
 from backend.models.sites import Site
 from backend.resources.utils.import_export_widgets import (
@@ -37,6 +38,9 @@ class BaseResource(resources.ModelResource):
         self.site = site
         self.run_as_user = run_as_user
         self.import_job = import_job
+        self.created_by = (
+            ImportJob.objects.get(id=import_job).created_by if import_job else ""
+        )
 
     def before_import(self, dataset, **kwargs):
         # Adding required columns, since these will not be present in the headers
@@ -45,7 +49,7 @@ class BaseResource(resources.ModelResource):
         dataset.append_col(lambda x: str(self.run_as_user), header="created_by")
         dataset.append_col(lambda x: str(self.run_as_user), header="last_modified_by")
         dataset.append_col(
-            lambda x: str(self.run_as_user), header="system_last_modified_by"
+            lambda x: str(self.created_by), header="system_last_modified_by"
         )
         dataset.append_col(lambda x: str(self.import_job), header="import_job")
 

--- a/firstvoices/backend/resources/base.py
+++ b/firstvoices/backend/resources/base.py
@@ -26,6 +26,12 @@ class BaseResource(resources.ModelResource):
         widget=UserForeignKeyWidget(),
     )
 
+    system_last_modified_by = fields.Field(
+        column_name="system_last_modified_by",
+        attribute="system_last_modified_by",
+        widget=UserForeignKeyWidget(),
+    )
+
     def __init__(self, site=None, run_as_user=None, import_job=None, **kwargs):
         super().__init__(**kwargs)
         self.site = site
@@ -38,6 +44,9 @@ class BaseResource(resources.ModelResource):
         dataset.append_col(lambda x: str(self.site.id), header="site")
         dataset.append_col(lambda x: str(self.run_as_user), header="created_by")
         dataset.append_col(lambda x: str(self.run_as_user), header="last_modified_by")
+        dataset.append_col(
+            lambda x: str(self.run_as_user), header="system_last_modified_by"
+        )
         dataset.append_col(lambda x: str(self.import_job), header="import_job")
 
     def import_row(self, row, instance_loader, **kwargs):

--- a/firstvoices/backend/tasks/dictionary_cleanup_tasks.py
+++ b/firstvoices/backend/tasks/dictionary_cleanup_tasks.py
@@ -53,6 +53,7 @@ def cleanup_dictionary(job_instance_id: str):
         # If job is not preview, save the entry to recalculate custom order and clean title
         if not job.is_preview:
             try:
+                entry.system_last_modified_by = job.created_by
                 entry.save(set_modified_date=False)
             except Exception as e:
                 job.status = JobStatus.FAILED

--- a/firstvoices/backend/tasks/visibility_tasks.py
+++ b/firstvoices/backend/tasks/visibility_tasks.py
@@ -1,6 +1,7 @@
 from celery import shared_task
 from celery.utils.log import get_task_logger
 from django.db import transaction
+from django.utils import timezone
 
 from backend.models import DictionaryEntry, SitePage, Song, Story, StoryPage
 from backend.models.jobs import BulkVisibilityJob, JobStatus
@@ -54,12 +55,24 @@ def bulk_change_visibility(job_instance_id: str):
 
     try:
         with transaction.atomic():
-            entries.update(visibility=job.to_visibility)
-            songs.update(visibility=job.to_visibility)
-            stories.update(visibility=job.to_visibility)
-            story_pages.update(visibility=job.to_visibility)
-            pages.update(visibility=job.to_visibility)
-            widgets.update(visibility=job.to_visibility)
+            entries.update(
+                system_last_modified=timezone.now(), visibility=job.to_visibility
+            )
+            songs.update(
+                system_last_modified=timezone.now(), visibility=job.to_visibility
+            )
+            stories.update(
+                system_last_modified=timezone.now(), visibility=job.to_visibility
+            )
+            story_pages.update(
+                system_last_modified=timezone.now(), visibility=job.to_visibility
+            )
+            pages.update(
+                system_last_modified=timezone.now(), visibility=job.to_visibility
+            )
+            widgets.update(
+                system_last_modified=timezone.now(), visibility=job.to_visibility
+            )
             # Change Site visibility
             site.visibility = job.to_visibility
             site.save()

--- a/firstvoices/backend/tasks/visibility_tasks.py
+++ b/firstvoices/backend/tasks/visibility_tasks.py
@@ -56,22 +56,34 @@ def bulk_change_visibility(job_instance_id: str):
     try:
         with transaction.atomic():
             entries.update(
-                system_last_modified=timezone.now(), visibility=job.to_visibility
+                system_last_modified=timezone.now(),
+                system_last_modified_by=job.created_by,
+                visibility=job.to_visibility,
             )
             songs.update(
-                system_last_modified=timezone.now(), visibility=job.to_visibility
+                system_last_modified=timezone.now(),
+                system_last_modified_by=job.created_by,
+                visibility=job.to_visibility,
             )
             stories.update(
-                system_last_modified=timezone.now(), visibility=job.to_visibility
+                system_last_modified=timezone.now(),
+                system_last_modified_by=job.created_by,
+                visibility=job.to_visibility,
             )
             story_pages.update(
-                system_last_modified=timezone.now(), visibility=job.to_visibility
+                system_last_modified=timezone.now(),
+                system_last_modified_by=job.created_by,
+                visibility=job.to_visibility,
             )
             pages.update(
-                system_last_modified=timezone.now(), visibility=job.to_visibility
+                system_last_modified=timezone.now(),
+                system_last_modified_by=job.created_by,
+                visibility=job.to_visibility,
             )
             widgets.update(
-                system_last_modified=timezone.now(), visibility=job.to_visibility
+                system_last_modified=timezone.now(),
+                system_last_modified_by=job.created_by,
+                visibility=job.to_visibility,
             )
             # Change Site visibility
             site.visibility = job.to_visibility

--- a/firstvoices/backend/tests/test_tasks/test_bulk_visibility.py
+++ b/firstvoices/backend/tests/test_tasks/test_bulk_visibility.py
@@ -294,13 +294,19 @@ class TestBulkVisibilityTasks(IgnoreTaskResultsMixin):
 
         assert entry.last_modified == entry_last_modified
         assert entry.system_last_modified > entry_last_modified
+        assert entry.system_last_modified_by == job.created_by
         assert song.last_modified == song_last_modified
         assert song.system_last_modified > song_last_modified
+        assert song.system_last_modified_by == job.created_by
         assert story.last_modified == story_last_modified
         assert story.system_last_modified > story_last_modified
+        assert story.system_last_modified_by == job.created_by
         assert story_page.last_modified == story_page_last_modified
         assert story_page.system_last_modified > story_page_last_modified
+        assert story_page.system_last_modified_by == job.created_by
         assert site_page.last_modified == site_page_last_modified
         assert site_page.system_last_modified > site_page_last_modified
+        assert site_page.system_last_modified_by == job.created_by
         assert widget.last_modified == widget_last_modified
         assert widget.system_last_modified > widget_last_modified
+        assert widget.system_last_modified_by == job.created_by

--- a/firstvoices/backend/tests/test_tasks/test_dictionary_cleanup_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_dictionary_cleanup_tasks.py
@@ -477,6 +477,7 @@ class TestDictionaryCleanupTasks(IgnoreTaskResultsMixin):
         entry = DictionaryEntry.objects.get(site=site, title="abc")
         assert entry.last_modified == entry_last_modified
         assert entry.system_last_modified > original_system_last_modified
+        assert entry.system_last_modified_by == job.created_by
 
         self.assert_async_task_logs(job, caplog)
 

--- a/firstvoices/backend/tests/test_tasks/test_dictionary_cleanup_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_dictionary_cleanup_tasks.py
@@ -477,6 +477,39 @@ class TestDictionaryCleanupTasks(IgnoreTaskResultsMixin):
         self.assert_async_task_logs(job, caplog)
 
     @pytest.mark.django_db
+    def test_system_last_modified_updated(self, site, alphabet, caplog):
+        factories.CharacterFactory.create(site=site, title="a")
+        factories.CharacterFactory.create(site=site, title="b")
+        entry = factories.DictionaryEntryFactory.create(site=site, title="abc")
+        entry.save()
+
+        factories.CharacterFactory.create(site=site, title="c")
+        original_system_last_modified = entry.system_last_modified
+
+        job = factories.DictionaryCleanupJobFactory.create(site=site, is_preview=False)
+
+        cleanup_dictionary(job.id)
+        job.refresh_from_db()
+
+        assert job.status == JobStatus.COMPLETE
+        assert job.cleanup_result == {
+            "unknown_character_count": {},
+            "updated_entries": [
+                {
+                    "title": "abc",
+                    "cleaned_title": "",
+                    "is_title_updated": False,
+                    "previous_custom_order": "!#⚑c",
+                    "new_custom_order": "!#$",
+                }
+            ],
+        }
+        entry = DictionaryEntry.objects.get(site=site, id=entry.id)
+        assert entry.system_last_modified > original_system_last_modified
+
+        self.assert_async_task_logs(job, caplog)
+
+    @pytest.mark.django_db
     def test_recalculate_preview_alphabet_missing(self, site, caplog):
         assert Alphabet.objects.count() == 0
         job = factories.DictionaryCleanupJobFactory.create(site=site, is_preview=True)

--- a/firstvoices/backend/tests/test_tasks/test_import_job_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_import_job_tasks.py
@@ -845,12 +845,13 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         assert word.type == TypeOfDictionaryEntry.WORD
         assert word.created_by == self.user
         assert word.last_modified_by == self.user
-
+        assert word.system_last_modified >= word.last_modified
         # phrase
         phrase = DictionaryEntry.objects.filter(title="xyz")[0]
         assert phrase.type == TypeOfDictionaryEntry.PHRASE
         assert phrase.created_by == self.user
         assert phrase.last_modified_by == self.user
+        assert phrase.system_last_modified >= phrase.last_modified
 
     def test_all_columns_dictionary_entries(self):
         file_content = get_sample_file(
@@ -1144,6 +1145,7 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         assert related_audio.acknowledgement == "Test Ack"
         assert related_audio.exclude_from_kids is False
         assert related_audio.exclude_from_games is True
+        assert related_audio.system_last_modified >= related_audio.last_modified
 
         entry_2 = DictionaryEntry.objects.get(title="Word 2")
         related_audio = entry_2.related_audio.all()
@@ -1166,6 +1168,7 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         assert related_image.description == "Testing image upload"
         assert related_image.acknowledgement == "Test Ack"
         assert related_image.exclude_from_kids is False
+        assert related_image.system_last_modified >= related_image.last_modified
 
         entry_2 = DictionaryEntry.objects.get(title="Word 2")
         related_images = entry_2.related_images.all()
@@ -1188,6 +1191,7 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         assert related_video.description == "Testing video upload"
         assert related_video.acknowledgement == "Test Ack"
         assert related_video.exclude_from_kids is False
+        assert related_video.system_last_modified >= related_video.last_modified
 
         entry_2 = DictionaryEntry.objects.get(title="Word 2")
         related_videos = entry_2.related_videos.all()

--- a/firstvoices/backend/tests/test_tasks/test_import_job_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_import_job_tasks.py
@@ -808,6 +808,8 @@ class TestBulkImport(IgnoreTaskResultsMixin):
 
         confirm_import_job(import_job.id)
 
+        return import_job
+
     def test_import_task_logs(self, caplog):
         file_content = get_sample_file("import_job/minimal.csv", self.MIMETYPE)
         file = FileFactory(content=file_content)
@@ -846,12 +848,14 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         assert word.created_by == self.user
         assert word.last_modified_by == self.user
         assert word.system_last_modified >= word.last_modified
+        assert word.system_last_modified_by == import_job.created_by
         # phrase
         phrase = DictionaryEntry.objects.filter(title="xyz")[0]
         assert phrase.type == TypeOfDictionaryEntry.PHRASE
         assert phrase.created_by == self.user
         assert phrase.last_modified_by == self.user
         assert phrase.system_last_modified >= phrase.last_modified
+        assert phrase.system_last_modified_by == import_job.created_by
 
     def test_all_columns_dictionary_entries(self):
         file_content = get_sample_file(
@@ -1132,7 +1136,7 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         )
 
     def test_related_audio(self):
-        self.confirm_upload_with_media_files("related_audio.csv")
+        import_job = self.confirm_upload_with_media_files("related_audio.csv")
 
         entry_with_audio = DictionaryEntry.objects.get(title="Word 1")
         related_audio = entry_with_audio.related_audio.all()
@@ -1146,6 +1150,7 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         assert related_audio.exclude_from_kids is False
         assert related_audio.exclude_from_games is True
         assert related_audio.system_last_modified >= related_audio.last_modified
+        assert related_audio.system_last_modified_by == import_job.created_by
 
         entry_2 = DictionaryEntry.objects.get(title="Word 2")
         related_audio = entry_2.related_audio.all()
@@ -1156,7 +1161,7 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         )
 
     def test_related_images(self):
-        self.confirm_upload_with_media_files("related_images.csv")
+        import_job = self.confirm_upload_with_media_files("related_images.csv")
 
         entry_with_image = DictionaryEntry.objects.filter(title="Word 1")[0]
         related_images = entry_with_image.related_images.all()
@@ -1169,6 +1174,7 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         assert related_image.acknowledgement == "Test Ack"
         assert related_image.exclude_from_kids is False
         assert related_image.system_last_modified >= related_image.last_modified
+        assert related_image.system_last_modified_by == import_job.created_by
 
         entry_2 = DictionaryEntry.objects.get(title="Word 2")
         related_images = entry_2.related_images.all()
@@ -1179,7 +1185,7 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         )
 
     def test_related_videos(self):
-        self.confirm_upload_with_media_files("related_videos.csv")
+        import_job = self.confirm_upload_with_media_files("related_videos.csv")
 
         entry_with_video = DictionaryEntry.objects.filter(title="Word 1")[0]
         related_videos = entry_with_video.related_videos.all()
@@ -1192,6 +1198,7 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         assert related_video.acknowledgement == "Test Ack"
         assert related_video.exclude_from_kids is False
         assert related_video.system_last_modified >= related_video.last_modified
+        assert related_video.system_last_modified_by == import_job.created_by
 
         entry_2 = DictionaryEntry.objects.get(title="Word 2")
         related_videos = entry_2.related_videos.all()

--- a/firstvoices/backend/tests/test_tasks/test_import_job_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_import_job_tasks.py
@@ -807,6 +807,7 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         )
 
         confirm_import_job(import_job.id)
+        return import_job
 
     def test_import_task_logs(self, caplog):
         file_content = get_sample_file("import_job/minimal.csv", self.MIMETYPE)
@@ -846,14 +847,14 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         assert word.created_by == self.user
         assert word.last_modified_by == self.user
         assert word.system_last_modified >= word.last_modified
-        assert word.system_last_modified_by == self.user
+        assert word.system_last_modified_by == import_job.created_by
         # phrase
         phrase = DictionaryEntry.objects.filter(title="xyz")[0]
         assert phrase.type == TypeOfDictionaryEntry.PHRASE
         assert phrase.created_by == self.user
         assert phrase.last_modified_by == self.user
         assert phrase.system_last_modified >= phrase.last_modified
-        assert phrase.system_last_modified_by == self.user
+        assert phrase.system_last_modified_by == import_job.created_by
 
     def test_all_columns_dictionary_entries(self):
         file_content = get_sample_file(
@@ -1134,7 +1135,7 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         )
 
     def test_related_audio(self):
-        self.confirm_upload_with_media_files("related_audio.csv")
+        import_job = self.confirm_upload_with_media_files("related_audio.csv")
 
         entry_with_audio = DictionaryEntry.objects.get(title="Word 1")
         related_audio = entry_with_audio.related_audio.all()
@@ -1148,7 +1149,7 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         assert related_audio.exclude_from_kids is False
         assert related_audio.exclude_from_games is True
         assert related_audio.system_last_modified >= related_audio.last_modified
-        assert related_audio.system_last_modified_by == self.user
+        assert related_audio.system_last_modified_by == import_job.created_by
 
         entry_2 = DictionaryEntry.objects.get(title="Word 2")
         related_audio = entry_2.related_audio.all()
@@ -1159,7 +1160,7 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         )
 
     def test_related_images(self):
-        self.confirm_upload_with_media_files("related_images.csv")
+        import_job = self.confirm_upload_with_media_files("related_images.csv")
 
         entry_with_image = DictionaryEntry.objects.filter(title="Word 1")[0]
         related_images = entry_with_image.related_images.all()
@@ -1172,7 +1173,7 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         assert related_image.acknowledgement == "Test Ack"
         assert related_image.exclude_from_kids is False
         assert related_image.system_last_modified >= related_image.last_modified
-        assert related_image.system_last_modified_by == self.user
+        assert related_image.system_last_modified_by == import_job.created_by
 
         entry_2 = DictionaryEntry.objects.get(title="Word 2")
         related_images = entry_2.related_images.all()
@@ -1183,7 +1184,7 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         )
 
     def test_related_videos(self):
-        self.confirm_upload_with_media_files("related_videos.csv")
+        import_job = self.confirm_upload_with_media_files("related_videos.csv")
 
         entry_with_video = DictionaryEntry.objects.filter(title="Word 1")[0]
         related_videos = entry_with_video.related_videos.all()
@@ -1196,7 +1197,7 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         assert related_video.acknowledgement == "Test Ack"
         assert related_video.exclude_from_kids is False
         assert related_video.system_last_modified >= related_video.last_modified
-        assert related_video.system_last_modified_by == self.user
+        assert related_video.system_last_modified_by == import_job.created_by
 
         entry_2 = DictionaryEntry.objects.get(title="Word 2")
         related_videos = entry_2.related_videos.all()

--- a/firstvoices/backend/tests/test_tasks/test_import_job_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_import_job_tasks.py
@@ -808,8 +808,6 @@ class TestBulkImport(IgnoreTaskResultsMixin):
 
         confirm_import_job(import_job.id)
 
-        return import_job
-
     def test_import_task_logs(self, caplog):
         file_content = get_sample_file("import_job/minimal.csv", self.MIMETYPE)
         file = FileFactory(content=file_content)
@@ -848,14 +846,14 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         assert word.created_by == self.user
         assert word.last_modified_by == self.user
         assert word.system_last_modified >= word.last_modified
-        assert word.system_last_modified_by == import_job.created_by
+        assert word.system_last_modified_by == self.user
         # phrase
         phrase = DictionaryEntry.objects.filter(title="xyz")[0]
         assert phrase.type == TypeOfDictionaryEntry.PHRASE
         assert phrase.created_by == self.user
         assert phrase.last_modified_by == self.user
         assert phrase.system_last_modified >= phrase.last_modified
-        assert phrase.system_last_modified_by == import_job.created_by
+        assert phrase.system_last_modified_by == self.user
 
     def test_all_columns_dictionary_entries(self):
         file_content = get_sample_file(
@@ -1136,7 +1134,7 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         )
 
     def test_related_audio(self):
-        import_job = self.confirm_upload_with_media_files("related_audio.csv")
+        self.confirm_upload_with_media_files("related_audio.csv")
 
         entry_with_audio = DictionaryEntry.objects.get(title="Word 1")
         related_audio = entry_with_audio.related_audio.all()
@@ -1150,7 +1148,7 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         assert related_audio.exclude_from_kids is False
         assert related_audio.exclude_from_games is True
         assert related_audio.system_last_modified >= related_audio.last_modified
-        assert related_audio.system_last_modified_by == import_job.created_by
+        assert related_audio.system_last_modified_by == self.user
 
         entry_2 = DictionaryEntry.objects.get(title="Word 2")
         related_audio = entry_2.related_audio.all()
@@ -1161,7 +1159,7 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         )
 
     def test_related_images(self):
-        import_job = self.confirm_upload_with_media_files("related_images.csv")
+        self.confirm_upload_with_media_files("related_images.csv")
 
         entry_with_image = DictionaryEntry.objects.filter(title="Word 1")[0]
         related_images = entry_with_image.related_images.all()
@@ -1174,7 +1172,7 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         assert related_image.acknowledgement == "Test Ack"
         assert related_image.exclude_from_kids is False
         assert related_image.system_last_modified >= related_image.last_modified
-        assert related_image.system_last_modified_by == import_job.created_by
+        assert related_image.system_last_modified_by == self.user
 
         entry_2 = DictionaryEntry.objects.get(title="Word 2")
         related_images = entry_2.related_images.all()
@@ -1185,7 +1183,7 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         )
 
     def test_related_videos(self):
-        import_job = self.confirm_upload_with_media_files("related_videos.csv")
+        self.confirm_upload_with_media_files("related_videos.csv")
 
         entry_with_video = DictionaryEntry.objects.filter(title="Word 1")[0]
         related_videos = entry_with_video.related_videos.all()
@@ -1198,7 +1196,7 @@ class TestBulkImport(IgnoreTaskResultsMixin):
         assert related_video.acknowledgement == "Test Ack"
         assert related_video.exclude_from_kids is False
         assert related_video.system_last_modified >= related_video.last_modified
-        assert related_video.system_last_modified_by == import_job.created_by
+        assert related_video.system_last_modified_by == self.user
 
         entry_2 = DictionaryEntry.objects.get(title="Word 2")
         related_videos = entry_2.related_videos.all()

--- a/firstvoices/backend/tests/test_tasks/test_media_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_media_tasks.py
@@ -48,7 +48,7 @@ class TestThumbnailGeneration(IgnoreTaskResultsMixin):
             (Video, VideoFactory, VideoFileFactory),
         ],
     )
-    def test_thumbnail_generation_does_not_update_last_modified(
+    def test_thumbnail_generation_last_modified_behaviour(
         self, model, model_factory, model_file_factory
     ):
         site = SiteFactory()
@@ -61,9 +61,8 @@ class TestThumbnailGeneration(IgnoreTaskResultsMixin):
 
         media_item = model.objects.get(id=media_item.id)
 
-        new_last_modified = media_item.last_modified
-
-        assert new_last_modified == original_last_modified
+        assert media_item.last_modified == original_last_modified
+        assert media_item.system_last_modified > media_item.last_modified
 
     @pytest.mark.django_db
     @pytest.mark.disable_thumbnail_mocks
@@ -106,13 +105,11 @@ class TestThumbnailGeneration(IgnoreTaskResultsMixin):
     @pytest.mark.django_db
     @pytest.mark.disable_thumbnail_mocks
     def test_generate_media_thumbnails_model_does_not_exist(self, caplog):
-        test_id = uuid.uuid4()
-        generate_media_thumbnails("Image", str(test_id))
+        test_id = str(uuid.uuid4())
+        generate_media_thumbnails("Image", test_id)
 
-        assert (
-            f"Thumbnail generation failed for Image with id {str(test_id)}: Model not found."
-            in caplog.text
-        )
+        assert f"Thumbnail generation failed for Image with id {test_id}" in caplog.text
+
         assert "Task ended." in caplog.text
 
     @pytest.mark.django_db


### PR DESCRIPTION
### Description of Changes
Ensures that all tasks in the [task inventory](https://firstvoices.atlassian.net/wiki/spaces/FIR/pages/832995337/Task+Inventory) are tested to update system_last_modified when creating/modifying an entry in the db.
- `confirm_import_job`: ensure all created dictionary entries/media have a system_last_modified field >= last_modified
- `build_index_and_calculate_scores`: already handled by https://github.com/First-Peoples-Cultural-Council/fv-be/pull/1326
- `bulk_change_visibility`: updates every entry's system_last_modified value as well as visibility
- `cleanup_dictionary`: tests that the system_last_modified value has been updated
- `generate_media_thumbnails`: tests that the system_last_modified value has been updated

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~
- [x] ~~Signal and Task inventories have been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
