### PR TITLE
FW-6598 add further prefetching to site results

### DIFF
--- a/firstvoices/backend/serializers/search_result_serializers.py
+++ b/firstvoices/backend/serializers/search_result_serializers.py
@@ -23,6 +23,38 @@ from backend.serializers.media_serializers import (
 )
 
 
+class SearchResultPrefetchMixin:
+    """
+    Mixin to add prefetching/select related for entry-type search results.
+    """
+
+    @classmethod
+    def make_queryset_eager(cls, queryset, user):
+        return queryset.select_related(
+            "created_by",
+            "last_modified_by",
+        ).prefetch_related(
+            Prefetch(
+                "related_audio",
+                queryset=Audio.objects.visible(user)
+                .select_related("original")
+                .prefetch_related("speakers"),
+            ),
+            Prefetch(
+                "related_images",
+                queryset=Image.objects.visible(user).select_related(
+                    "original", "small"
+                ),
+            ),
+            Prefetch(
+                "related_videos",
+                queryset=Video.objects.visible(user).select_related(
+                    "original", "small"
+                ),
+            ),
+        )
+
+
 class PersonMinimalSerializer(serializers.ModelSerializer):
     class Meta:
         model = Person
@@ -124,7 +156,7 @@ class VideoMinimalSerializer(ImageMinimalSerializer):
 
 
 class DictionaryEntryMinimalSerializer(
-    ReadOnlyVisibilityFieldMixin, serializers.ModelSerializer
+    ReadOnlyVisibilityFieldMixin, SearchResultPrefetchMixin, serializers.ModelSerializer
 ):
     site = LinkedSiteMinimalSerializer(read_only=True)
     translations = TextListField(required=False, allow_empty=True)
@@ -161,36 +193,10 @@ class DictionaryEntryMinimalSerializer(
         )
         read_only_fields = ("id", "title", "type")
 
-    @classmethod
-    def make_queryset_eager(cls, queryset, user):
-        """Add prefetching as required by this serializer"""
-        return queryset.select_related(
-            "site",
-            "created_by",
-            "last_modified_by",
-        ).prefetch_related(
-            Prefetch(
-                "related_audio",
-                queryset=Audio.objects.visible(user)
-                .select_related("original")
-                .prefetch_related("speakers"),
-            ),
-            Prefetch(
-                "related_images",
-                queryset=Image.objects.visible(user).select_related(
-                    "original", "small"
-                ),
-            ),
-            Prefetch(
-                "related_videos",
-                queryset=Video.objects.visible(user).select_related(
-                    "original", "small"
-                ),
-            ),
-        )
 
-
-class SongMinimalSerializer(ReadOnlyVisibilityFieldMixin, serializers.ModelSerializer):
+class SongMinimalSerializer(
+    ReadOnlyVisibilityFieldMixin, SearchResultPrefetchMixin, serializers.ModelSerializer
+):
     site = LinkedSiteMinimalSerializer(read_only=True)
     related_images = RelatedImageMinimalSerializer(
         many=True, required=False, read_only=True
@@ -219,36 +225,10 @@ class SongMinimalSerializer(ReadOnlyVisibilityFieldMixin, serializers.ModelSeria
         )
         read_only_fields = ("id", "title", "title_translation", "hide_overlay")
 
-    @classmethod
-    def make_queryset_eager(cls, queryset, user):
-        """Add prefetching as required by this serializer"""
-        return queryset.select_related(
-            "site",
-            "created_by",
-            "last_modified_by",
-        ).prefetch_related(
-            Prefetch(
-                "related_audio",
-                queryset=Audio.objects.visible(user)
-                .select_related("original")
-                .prefetch_related("speakers"),
-            ),
-            Prefetch(
-                "related_images",
-                queryset=Image.objects.visible(user).select_related(
-                    "original", "small"
-                ),
-            ),
-            Prefetch(
-                "related_videos",
-                queryset=Video.objects.visible(user).select_related(
-                    "original", "small"
-                ),
-            ),
-        )
 
-
-class StoryMinimalSerializer(ReadOnlyVisibilityFieldMixin, serializers.ModelSerializer):
+class StoryMinimalSerializer(
+    ReadOnlyVisibilityFieldMixin, SearchResultPrefetchMixin, serializers.ModelSerializer
+):
     site = LinkedSiteMinimalSerializer(read_only=True)
     related_images = RelatedImageMinimalSerializer(
         many=True, required=False, read_only=True
@@ -275,34 +255,6 @@ class StoryMinimalSerializer(ReadOnlyVisibilityFieldMixin, serializers.ModelSeri
             "site",
             "related_images",
             "related_videos",
-        )
-
-    @classmethod
-    def make_queryset_eager(cls, queryset, user):
-        """Add prefetching as required by this serializer"""
-        return queryset.select_related(
-            "site",
-            "created_by",
-            "last_modified_by",
-        ).prefetch_related(
-            Prefetch(
-                "related_audio",
-                queryset=Audio.objects.visible(user)
-                .select_related("original")
-                .prefetch_related("speakers"),
-            ),
-            Prefetch(
-                "related_images",
-                queryset=Image.objects.visible(user).select_related(
-                    "original", "small"
-                ),
-            ),
-            Prefetch(
-                "related_videos",
-                queryset=Video.objects.visible(user).select_related(
-                    "original", "small"
-                ),
-            ),
         )
 
 

--- a/firstvoices/backend/serializers/search_result_serializers.py
+++ b/firstvoices/backend/serializers/search_result_serializers.py
@@ -31,6 +31,7 @@ class SearchResultPrefetchMixin:
     @classmethod
     def make_queryset_eager(cls, queryset, user):
         return queryset.select_related(
+            "site",
             "created_by",
             "last_modified_by",
         ).prefetch_related(

--- a/firstvoices/backend/serializers/search_result_serializers.py
+++ b/firstvoices/backend/serializers/search_result_serializers.py
@@ -181,6 +181,12 @@ class DictionaryEntryMinimalSerializer(
                     "original", "small"
                 ),
             ),
+            Prefetch(
+                "related_videos",
+                queryset=Video.objects.visible(user).select_related(
+                    "original", "small"
+                ),
+            ),
         )
 
 
@@ -216,7 +222,17 @@ class SongMinimalSerializer(ReadOnlyVisibilityFieldMixin, serializers.ModelSeria
     @classmethod
     def make_queryset_eager(cls, queryset, user):
         """Add prefetching as required by this serializer"""
-        return queryset.select_related("site").prefetch_related(
+        return queryset.select_related(
+            "site",
+            "created_by",
+            "last_modified_by",
+        ).prefetch_related(
+            Prefetch(
+                "related_audio",
+                queryset=Audio.objects.visible(user)
+                .select_related("original")
+                .prefetch_related("speakers"),
+            ),
             Prefetch(
                 "related_images",
                 queryset=Image.objects.visible(user).select_related(
@@ -264,7 +280,17 @@ class StoryMinimalSerializer(ReadOnlyVisibilityFieldMixin, serializers.ModelSeri
     @classmethod
     def make_queryset_eager(cls, queryset, user):
         """Add prefetching as required by this serializer"""
-        return queryset.select_related("site").prefetch_related(
+        return queryset.select_related(
+            "site",
+            "created_by",
+            "last_modified_by",
+        ).prefetch_related(
+            Prefetch(
+                "related_audio",
+                queryset=Audio.objects.visible(user)
+                .select_related("original")
+                .prefetch_related("speakers"),
+            ),
             Prefetch(
                 "related_images",
                 queryset=Image.objects.visible(user).select_related(


### PR DESCRIPTION
### Description of Changes
- Adds site and related media prefetching to all dictionary entry, song and story search result serializers.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] ~~Tests have been updated / created if applicable~~
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~
- [x] ~~Signal and Task inventories have been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
