### PR TITLE
FW-56, FW-5220 Dictionary export API

### DIFF
--- a/firstvoices/backend/serializers/export_serializers.py
+++ b/firstvoices/backend/serializers/export_serializers.py
@@ -1,0 +1,49 @@
+from rest_framework import serializers
+
+from backend.models import DictionaryEntry
+from backend.serializers.base_serializers import ReadOnlyVisibilityFieldMixin
+from backend.serializers.search_result_serializers import (
+    SearchResultPrefetchMixin,
+    SearchResultSerializer,
+)
+
+
+class DictionaryEntryExportResultSerializer(
+    ReadOnlyVisibilityFieldMixin, SearchResultPrefetchMixin, serializers.ModelSerializer
+):
+    part_of_speech = serializers.StringRelatedField()
+    categories = serializers.StringRelatedField(many=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    class Meta:
+        model = DictionaryEntry
+        fields = (
+            "id",
+            "visibility",
+            "title",
+            "type",
+            "categories",
+            "translations",
+            "notes",
+            "acknowledgements",
+            "alternate_spellings",
+            "pronunciations",
+            "related_audio",
+            "related_images",
+            "related_videos",
+            "part_of_speech",
+            "related_video_links",
+            "related_dictionary_entries",
+            "exclude_from_games",
+            "exclude_from_kids",
+        )
+
+
+class DictionaryEntryExportSerializer(SearchResultSerializer):
+    entry_serializer = DictionaryEntryExportResultSerializer
+
+    @staticmethod
+    def get_type(obj):
+        return obj["entry"].type

--- a/firstvoices/backend/serializers/export_serializers.py
+++ b/firstvoices/backend/serializers/export_serializers.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 
 from backend.models import DictionaryEntry
 from backend.serializers.base_serializers import ReadOnlyVisibilityFieldMixin
+from backend.serializers.fields import CommaSeparatedIDsField, InvertedBooleanField
 from backend.serializers.search_result_serializers import (
     SearchResultPrefetchMixin,
     SearchResultSerializer,
@@ -13,9 +14,13 @@ class DictionaryEntryExportResultSerializer(
 ):
     part_of_speech = serializers.StringRelatedField()
     categories = serializers.StringRelatedField(many=True)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    include_in_games = InvertedBooleanField(source="exclude_from_games", read_only=True)
+    include_on_kids_site = InvertedBooleanField(
+        source="exclude_from_kids", read_only=True
+    )
+    audio_ids = CommaSeparatedIDsField(source="related_audio", read_only=True)
+    video_ids = CommaSeparatedIDsField(source="related_videos", read_only=True)
+    image_ids = CommaSeparatedIDsField(source="related_images", read_only=True)
 
     class Meta:
         model = DictionaryEntry
@@ -30,14 +35,14 @@ class DictionaryEntryExportResultSerializer(
             "acknowledgements",
             "alternate_spellings",
             "pronunciations",
-            "related_audio",
-            "related_images",
-            "related_videos",
+            "audio_ids",
+            "video_ids",
+            "image_ids",
             "part_of_speech",
             "related_video_links",
             "related_dictionary_entries",
-            "exclude_from_games",
-            "exclude_from_kids",
+            "include_in_games",
+            "include_on_kids_site",
         )
 
 

--- a/firstvoices/backend/serializers/fields.py
+++ b/firstvoices/backend/serializers/fields.py
@@ -164,3 +164,19 @@ class TextListField(serializers.ListField):
                     "Expected the objects in the list to contain key 'text'."
                 )
         return response
+
+
+class InvertedBooleanField(serializers.BooleanField):
+    # Read-only field to be used in export serializers
+    def to_representation(self, value):
+        value = super().to_representation(value)
+        return None if value is None else (not bool(value))
+
+
+class CommaSeparatedIDsField(serializers.Field):
+    # Read-only field to be used in export serializers
+    def to_representation(self, value):
+        ids = value.all().values_list("id", flat=True)
+        ids = [str(id) for id in ids]
+
+        return ",".join(ids)

--- a/firstvoices/backend/tests/test_apis/test_export_api.py
+++ b/firstvoices/backend/tests/test_apis/test_export_api.py
@@ -1,0 +1,225 @@
+import csv
+import io
+import re
+
+import pytest
+
+from backend.models.constants import Role, Visibility
+from backend.models.dictionary import TypeOfDictionaryEntry
+from backend.tests import factories
+from backend.tests.test_apis.base.base_uncontrolled_site_api import (
+    BaseSiteContentApiTest,
+    SiteContentListEndpointMixin,
+)
+from backend.tests.test_apis.test_search_apis.base_search_test import SearchMocksMixin
+
+
+@pytest.mark.django_db
+class TestDictionaryExportAPI(
+    SearchMocksMixin, SiteContentListEndpointMixin, BaseSiteContentApiTest
+):
+    API_LIST_VIEW = "api:dictionary-export-list"
+
+    def setup_method(self):
+        super().setup_method()
+        # Should get an empty csv with a valid filename
+        self.site, self.user = factories.get_site_with_member(
+            site_visibility=Visibility.PUBLIC, user_role=Role.LANGUAGE_ADMIN
+        )
+        self.client.force_authenticate(user=self.user)
+
+    def test_filename(self):
+        response = self.client.get(self.get_list_endpoint(site_slug=self.site.slug))
+
+        assert response.status_code == 200
+        assert "text/csv" in response["content-type"]
+
+        file_header = response["content-disposition"]
+        filename_pattern = r"dictionary_export_\d{4}_\d{2}_\d{2}_\d{2}_\d{2}_\d{2}"
+
+        assert re.search(
+            filename_pattern, file_header
+        ), "Filename does match the expected format."
+
+    def test_base_fields(self, mock_search_query_execute):
+        dictionary_entry = factories.DictionaryEntryFactory.create(
+            site=self.site,
+            title="Title",
+            visibility=Visibility.PUBLIC,
+            type=TypeOfDictionaryEntry.WORD,
+            exclude_from_games=True,
+            exclude_from_kids=True,
+        )
+
+        mock_es_results = {
+            "hits": {
+                "hits": [
+                    {
+                        "_index": "dictionary_entries_2023_06_23_06_11_22",
+                        "_id": str(dictionary_entry.id),
+                        "_score": 1.0,
+                        "_source": {
+                            "document_id": dictionary_entry.id,
+                            "document_type": "DictionaryEntry",
+                            "site_id": self.site.id,
+                        },
+                    },
+                ],
+                "total": {"value": 1, "relation": "eq"},
+            }
+        }
+        mock_search_query_execute.return_value = mock_es_results
+
+        response = self.client.get(
+            self.get_list_endpoint(site_slug=self.site.slug), format="csv"
+        )
+
+        assert response.status_code == 200
+        assert "text/csv" in response["content-type"]
+
+        content = response.content.decode("utf-8")
+        reader = csv.reader(io.StringIO(content))
+
+        rows = list(reader)
+        assert len(rows) > 0
+
+        headers = rows[0]
+        data = [dict(zip(headers, row)) for row in rows[1:]]
+
+        first_row = data[0]
+        assert first_row["id"] == str(dictionary_entry.id)
+        assert first_row["title"] == dictionary_entry.title
+        assert first_row["type"] == dictionary_entry.type
+        assert first_row["visibility"] == str(dictionary_entry.visibility.label).lower()
+        assert first_row["type"] == str(dictionary_entry.type.label).lower()
+        assert first_row["include_in_games"] == str(
+            not dictionary_entry.exclude_from_games
+        )
+        assert first_row["include_on_kids_site"] == str(
+            not dictionary_entry.exclude_from_kids
+        )
+
+    def test_array_fields(self, mock_search_query_execute):
+        dictionary_entry = factories.DictionaryEntryFactory.create(
+            site=self.site,
+            translations=["translation_1", "translation_2"],
+            notes=["note_1", "note_2"],
+            pronunciations=["pronunciation_1", "pronunciation_2"],
+            acknowledgements=["acknowledgement_1", "acknowledgement_2"],
+            alternate_spellings=["alternate_spelling_1", "alternate_spelling_2"],
+        )
+
+        mock_es_results = {
+            "hits": {
+                "hits": [
+                    {
+                        "_index": "dictionary_entries_2023_06_23_06_11_22",
+                        "_id": str(dictionary_entry.id),
+                        "_score": 1.0,
+                        "_source": {
+                            "document_id": dictionary_entry.id,
+                            "document_type": "DictionaryEntry",
+                            "site_id": self.site.id,
+                        },
+                    },
+                ],
+                "total": {"value": 1, "relation": "eq"},
+            }
+        }
+        mock_search_query_execute.return_value = mock_es_results
+
+        response = self.client.get(
+            self.get_list_endpoint(site_slug=self.site.slug), format="csv"
+        )
+
+        content = response.content.decode("utf-8")
+        reader = csv.reader(io.StringIO(content))
+
+        rows = list(reader)
+        assert len(rows) > 0
+
+        headers = rows[0]
+        data = [dict(zip(headers, row)) for row in rows[1:]]
+
+        first_row = data[0]
+        assert first_row["translation"] == dictionary_entry.translations[0]
+        assert first_row["translation_2"] == dictionary_entry.translations[1]
+        assert first_row["note"] == dictionary_entry.notes[0]
+        assert first_row["note_2"] == dictionary_entry.notes[1]
+        assert first_row["pronunciation"] == dictionary_entry.pronunciations[0]
+        assert first_row["pronunciation_2"] == dictionary_entry.pronunciations[1]
+        assert first_row["acknowledgement"] == dictionary_entry.acknowledgements[0]
+        assert first_row["acknowledgement_2"] == dictionary_entry.acknowledgements[1]
+        assert (
+            first_row["alternate_spelling"] == dictionary_entry.alternate_spellings[0]
+        )
+        assert (
+            first_row["alternate_spelling_2"] == dictionary_entry.alternate_spellings[1]
+        )
+
+    def test_media_fields(self, mock_search_query_execute):
+        audio_1 = factories.AudioFactory.create(site=self.site)
+        audio_2 = factories.AudioFactory.create(site=self.site)
+        image_1 = factories.ImageFactory.create(site=self.site)
+        image_2 = factories.ImageFactory.create(site=self.site)
+        video_1 = factories.VideoFactory.create(site=self.site)
+        video_2 = factories.VideoFactory.create(site=self.site)
+        document_1 = factories.DocumentFactory.create(site=self.site)
+        document_2 = factories.DocumentFactory.create(site=self.site)
+
+        dictionary_entry = factories.DictionaryEntryFactory.create(
+            site=self.site,
+            related_audio=[audio_1, audio_2],
+            related_images=[image_1, image_2],
+            related_videos=[video_1, video_2],
+            related_documents=[document_1, document_2],
+            related_video_links=[
+                "https://www.youtube.com/watch?v=abc123",
+                "https://www.youtube.com/watch?v=xyz456",
+            ],
+        )
+
+        mock_es_results = {
+            "hits": {
+                "hits": [
+                    {
+                        "_index": "dictionary_entries_2023_06_23_06_11_22",
+                        "_id": str(dictionary_entry.id),
+                        "_score": 1.0,
+                        "_source": {
+                            "document_id": dictionary_entry.id,
+                            "document_type": "DictionaryEntry",
+                            "site_id": self.site.id,
+                        },
+                    },
+                ],
+                "total": {"value": 1, "relation": "eq"},
+            }
+        }
+        mock_search_query_execute.return_value = mock_es_results
+
+        response = self.client.get(
+            self.get_list_endpoint(site_slug=self.site.slug), format="csv"
+        )
+
+        content = response.content.decode("utf-8")
+        reader = csv.reader(io.StringIO(content))
+
+        rows = list(reader)
+        assert len(rows) > 0
+
+        headers = rows[0]
+        data = [dict(zip(headers, row)) for row in rows[1:]]
+
+        first_row = data[0]
+        assert first_row["video_embed_link"] == dictionary_entry.related_video_links[0]
+        assert (
+            first_row["video_embed_link_2"] == dictionary_entry.related_video_links[1]
+        )
+
+        assert str(audio_1.id) in first_row["audio_ids"]
+        assert str(audio_2.id) in first_row["audio_ids"]
+        assert str(image_1.id) in first_row["image_ids"]
+        assert str(image_2.id) in first_row["image_ids"]
+        assert str(video_1.id) in first_row["video_ids"]
+        assert str(video_2.id) in first_row["video_ids"]

--- a/firstvoices/backend/tests/test_apis/test_export_api.py
+++ b/firstvoices/backend/tests/test_apis/test_export_api.py
@@ -28,7 +28,29 @@ class TestDictionaryExportAPI(
         )
         self.client.force_authenticate(user=self.user)
 
-    def test_filename(self):
+    def test_filename(self, mock_search_query_execute):
+        dictionary_entry = factories.DictionaryEntryFactory.create(
+            site=self.site,
+        )
+        mock_es_results = {
+            "hits": {
+                "hits": [
+                    {
+                        "_index": "dictionary_entries_2023_06_23_06_11_22",
+                        "_id": str(dictionary_entry.id),
+                        "_score": 1.0,
+                        "_source": {
+                            "document_id": dictionary_entry.id,
+                            "document_type": "DictionaryEntry",
+                            "site_id": self.site.id,
+                        },
+                    },
+                ],
+                "total": {"value": 1, "relation": "eq"},
+            }
+        }
+        mock_search_query_execute.return_value = mock_es_results
+
         response = self.client.get(self.get_list_endpoint(site_slug=self.site.slug))
 
         assert response.status_code == 200

--- a/firstvoices/backend/urls.py
+++ b/firstvoices/backend/urls.py
@@ -10,6 +10,7 @@ from backend.views.dictionary_cleanup_views import (
     DictionaryCleanupJobViewSet,
     DictionaryCleanupPreviewViewSet,
 )
+from backend.views.dictionary_export_views import DictionaryEntryExportViewSet
 from backend.views.dictionary_views import DictionaryViewSet
 from backend.views.document_views import DocumentViewSet
 from backend.views.gallery_views import GalleryViewSet
@@ -66,6 +67,9 @@ sites_router.register(
     r"dictionary-cleanup",
     DictionaryCleanupJobViewSet,
     basename="dictionary-cleanup",
+)
+sites_router.register(
+    r"dictionary-export", DictionaryEntryExportViewSet, basename="dictionary-export"
 )
 sites_router.register(r"documents", DocumentViewSet, basename="document")
 sites_router.register(r"features", SiteFeatureViewSet, basename="sitefeature")

--- a/firstvoices/backend/utils/CustomCsvRenderer.py
+++ b/firstvoices/backend/utils/CustomCsvRenderer.py
@@ -1,0 +1,86 @@
+import csv
+import io
+
+from rest_framework.renderers import BaseRenderer
+
+
+class CustomCsvRenderer(BaseRenderer):
+    media_type = "text/csv"
+    format = "csv"
+    charset = "utf-8"
+
+    flatten_fields = {}
+
+    def get_max_lengths(self, rows, fields):
+        # Find max number of columns to add for flattened keys
+        max_lengths = {field: 0 for field in fields}
+        for r in rows:
+            for f in fields:
+                value = r.get(f)
+                if isinstance(value, (list, tuple)):
+                    max_lengths[f] = max(max_lengths[f], len(value))
+                else:
+                    max_lengths[f] = max(max_lengths[f], 1)
+
+        return max_lengths
+
+    def get_first_seen_keys(self, rows):
+        # To preserve order of headers in CSV
+        seen = []
+        for r in rows:
+            for k in r.keys():
+                if k not in seen:
+                    seen.append(k)
+        return seen
+
+    def expand_row(self, row, headers, flatten_fields, max_lengths):
+        output = {}
+
+        for key, val in row.items():
+            if key in flatten_fields:
+                base = flatten_fields[key]
+                n = max(1, max_lengths.get(key, 0))
+                values = val if isinstance(val, (list, tuple)) else [val]
+                for i in range(n):
+                    col = base if i == 0 else f"{base}_{i+1}"
+                    output[col] = values[i] if i < len(values) else ""
+            else:
+                output[key] = val
+
+        return {header: output.get(header, "") for header in headers}
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        if data is None:
+            return ""
+
+        # Get flatten fields from the view if present
+        view = (renderer_context or {}).get("view")
+        self.flatten_fields = getattr(view, "flatten_fields", self.flatten_fields)
+
+        # Compute max_lengths for flatten fields
+        max_lengths = self.get_max_lengths(data, self.flatten_fields.keys())
+
+        # Build headers
+        base_order = self.get_first_seen_keys(data)  # to maintain order
+        headers = []
+        for key in base_order:
+            if key in self.flatten_fields.keys():
+                base = self.flatten_fields[key]
+                n = max(1, max_lengths.get(key, 0))
+                for i in range(n):
+                    headers.append(base if i == 0 else f"{base}_{i+1}")
+            else:
+                headers.append(key)
+
+        # Build CSV
+        buffer = io.StringIO()
+        writer = csv.DictWriter(buffer, fieldnames=headers)
+        writer.writeheader()
+        for row in data:
+            writer.writerow(
+                self.expand_row(row, headers, self.flatten_fields, max_lengths)
+            )
+
+        output = buffer.getvalue()
+        buffer.close()
+        return output

--- a/firstvoices/backend/views/base_search_entries_views.py
+++ b/firstvoices/backend/views/base_search_entries_views.py
@@ -35,6 +35,398 @@ from backend.serializers.search_result_serializers import (
 from backend.views import doc_strings
 from backend.views.base_search_views import BaseSearchViewSet
 
+BASE_SEARCH_PARAMS = [
+    OpenApiParameter(
+        name="q",
+        description="search term",
+        required=False,
+        default="",
+        type=str,
+        examples=[
+            OpenApiExample("ball", value="ball"),
+            OpenApiExample("quick brown fox", value="quick brown fox"),
+        ],
+    ),
+    OpenApiParameter(
+        name="types",
+        description="Filter by type of content. Options are word, phrase, song, story.",
+        required=False,
+        default="",
+        type=str,
+        examples=[
+            OpenApiExample(
+                "",
+                value="",
+                description="Retrieves all types of results.",
+            ),
+            OpenApiExample(
+                "word, phrase",
+                value="word,phrase",
+                description="Searches for word and phrase results.",
+            ),
+            OpenApiExample(
+                "song",
+                value="song",
+                description="Searches for song results only.",
+            ),
+        ],
+    ),
+    OpenApiParameter(
+        name="domain",
+        description="search domain",
+        required=False,
+        default="both",
+        type=str,
+        examples=[
+            OpenApiExample(
+                "",
+                value="",
+                description="Defaults to both.",
+            ),
+            OpenApiExample(
+                "both",
+                value="both",
+                description="Searches in both the Language and English domains.",
+            ),
+            OpenApiExample(
+                "translation",
+                value="translation",
+                description="Performs a search focused on translations.",
+            ),
+            OpenApiExample(
+                "language",
+                value="language",
+                description="Performs a search focused on titles and language.",
+            ),
+            OpenApiExample(
+                "invalid_domain",
+                value="None",
+                description="If invalid domain is passed, the API returns an empty set of results.",
+            ),
+        ],
+    ),
+    OpenApiParameter(
+        name="kids",
+        description="Return kids-friendly entries if true, not kids-friendly entries if false, "
+        "and all entries if left empty or provided an invalid value.",
+        required=False,
+        default=None,
+        type=bool,
+        examples=[
+            OpenApiExample(
+                "True",
+                value=True,
+                description="Return kids-friendly entries only.",
+            ),
+            OpenApiExample(
+                "False",
+                value=False,
+                description="Return only entries that are not kid-friendly.",
+            ),
+            OpenApiExample(
+                "Apples",
+                value=None,
+                description="Invalid input, defaults to all entries.",
+            ),
+        ],
+    ),
+    OpenApiParameter(
+        name="games",
+        description="Return entries which are not excluded from games if true, entries which are excluded from "
+        "games if false, and all entries if left empty or provided with an invalid value.",
+        required=False,
+        default=None,
+        type=bool,
+        examples=[
+            OpenApiExample(
+                "True",
+                value=True,
+                description="Return entries which are not excluded from games.",
+            ),
+            OpenApiExample(
+                "False",
+                value=False,
+                description="Return entries which are excluded from games.",
+            ),
+            OpenApiExample(
+                "Oranges",
+                value=False,
+                description="Invalid input, defaults to all entries.",
+            ),
+        ],
+    ),
+    OpenApiParameter(
+        name="visibility",
+        description="Filter by visibility. Options are team, members, public",
+        required=False,
+        default="",
+        type=str,
+        examples=[
+            OpenApiExample(
+                "",
+                value="",
+                description="Returns results with any visibility.",
+            ),
+            OpenApiExample(
+                "Team",
+                value="team",
+                description="Returns results with team-only visibility.",
+            ),
+            OpenApiExample(
+                "Public, Members",
+                value="public,members",
+                description="Returns results that have been published with Public or Members-only visibility.",
+            ),
+        ],
+    ),
+    OpenApiParameter(
+        name="hasAudio",
+        description="Filter results that have related audio.",
+        required=False,
+        default=None,
+        type=bool,
+        examples=[
+            OpenApiExample(
+                "True",
+                value=True,
+                description="Returns results that have related audio.",
+            ),
+            OpenApiExample(
+                "False",
+                value=False,
+                description="Returns results that do not have related audio.",
+            ),
+        ],
+    ),
+    OpenApiParameter(
+        name="hasDocument",
+        description="Filter results that have related documents.",
+        required=False,
+        default=None,
+        type=bool,
+        examples=[
+            OpenApiExample(
+                "True",
+                value=True,
+                description="Returns results that have related documents.",
+            ),
+            OpenApiExample(
+                "False",
+                value=False,
+                description="Returns results that do not have related documents.",
+            ),
+        ],
+    ),
+    OpenApiParameter(
+        name="hasImage",
+        description="Filter results that have related images.",
+        required=False,
+        default=None,
+        type=bool,
+        examples=[
+            OpenApiExample(
+                "True",
+                value=True,
+                description="Returns results that have related images.",
+            ),
+            OpenApiExample(
+                "False",
+                value=False,
+                description="Returns results that do not have related images.",
+            ),
+        ],
+    ),
+    OpenApiParameter(
+        name="hasVideo",
+        description="Filter results that have related videos.",
+        required=False,
+        default=False,
+        type=bool,
+        examples=[
+            OpenApiExample(
+                "True",
+                value=True,
+                description="Returns results that have related videos.",
+            ),
+            OpenApiExample(
+                "False",
+                value=False,
+                description="Returns results that do not have related videos.",
+            ),
+        ],
+    ),
+    OpenApiParameter(
+        name="hasTranslation",
+        description="Filter results that have a translation or title translation.",
+        required=False,
+        default=None,
+        type=bool,
+        examples=[
+            OpenApiExample(
+                "True",
+                value=True,
+                description="Returns results that have a translation or title translation.",
+            ),
+            OpenApiExample(
+                "False",
+                value=False,
+                description="Returns results that do not have a translation or title translation.",
+            ),
+        ],
+    ),
+    OpenApiParameter(
+        name="hasUnrecognizedChars",
+        description="Filter dictionary entries that contain at least one character in their title that is not "
+        "present in the alphabet configuration.",
+        required=False,
+        default=None,
+        type=bool,
+        examples=[
+            OpenApiExample(
+                "True",
+                value=True,
+                description="Returns dictionary entries that have unrecognized characters.",
+            ),
+            OpenApiExample(
+                "False",
+                value=False,
+                description="Returns dictionary entries that do not have any unrecognized characters.",
+            ),
+        ],
+    ),
+    OpenApiParameter(
+        name="hasCategories",
+        description="Filter dictionary entries that have categories.",
+        required=False,
+        default=None,
+        type=bool,
+        examples=[
+            OpenApiExample(
+                "True",
+                value=True,
+                description="Returns dictionary entries that have categories.",
+            ),
+            OpenApiExample(
+                "False",
+                value=False,
+                description="Returns dictionary entries that do not have categories.",
+            ),
+        ],
+    ),
+    OpenApiParameter(
+        name="hasRelatedEntries",
+        description="Filter dictionary entries that have related dictionary entries.",
+        required=False,
+        default=None,
+        type=bool,
+        examples=[
+            OpenApiExample(
+                "True",
+                value=True,
+                description="Returns dictionary entries that have related dictionary entries.",
+            ),
+            OpenApiExample(
+                "False",
+                value=False,
+                description="Returns dictionary entries that do not have related dictionary entries.",
+            ),
+        ],
+    ),
+    OpenApiParameter(
+        name="hasSiteFeature",
+        description="Filter results based on site features.",
+        required=False,
+        default="",
+        type=str,
+        examples=[
+            OpenApiExample(
+                "valid site feature key",
+                value="EXAMPLE_KEY",
+                description="Retrieves results from sites with the EXAMPLE_KEY feature enabled.",
+            ),
+            OpenApiExample(
+                "multiple valid site feature keys",
+                value="KEY,another_key",
+                description="Retrieves results from sites with KEY, another_key or both features enabled.",
+            ),
+        ],
+    ),
+    OpenApiParameter(
+        name="minWords",
+        description="Filter dictionary entries on the minimum number of words in their title."
+        " Only non-negative integer values are allowed."
+        " If maxWords is less than minWords, no results will be returned.",
+        required=False,
+        default="",
+        type=int,
+        examples=[
+            OpenApiExample(
+                "2",
+                value="2",
+                description="Returns dictionary entries with at least 2 words in their title.",
+            ),
+        ],
+    ),
+    OpenApiParameter(
+        name="maxWords",
+        description="Filter dictionary entries on the maximum number of words in their title. "
+        "Only non-negative integer values are allowed. "
+        f"The maximum value is {LENGTH_FILTER_MAX}. "
+        "If maxWords is less than minWords, no results will be returned.",
+        required=False,
+        default="",
+        type=int,
+        examples=[
+            OpenApiExample(
+                "5",
+                value="5",
+                description="Returns dictionary entries which have at the most 5 words in their title.",
+            )
+        ],
+    ),
+    OpenApiParameter(
+        name="sort",
+        description="Sort results by something other than relevance. Options are: date created, date last "
+        "modified, title, or random. Results can be returned in descending order by adding '_desc' to the "
+        "parameter. (eg: 'sort=created_desc')",
+        required=False,
+        default="",
+        type=str,
+        examples=[
+            OpenApiExample(
+                "Date Created",
+                value="created",
+                description="Returns results ordered by the created date and time in ascending order.",
+            ),
+            OpenApiExample(
+                "Date Modified",
+                value="modified",
+                description="Returns results ordered by the last modified date and time in ascending order.",
+            ),
+            OpenApiExample(
+                "Title",
+                value="title",
+                description="Returns results ordered by title according to a site's custom alphabet.",
+            ),
+            OpenApiExample(
+                "Date Created Descending",
+                value="created_desc",
+                description="Returns results ordered by the created date and time in descending order.",
+            ),
+            OpenApiExample(
+                "Date Modified Descending",
+                value="modified_desc",
+                description="Returns results ordered by the last modified date and time in descending order.",
+            ),
+            OpenApiExample(
+                "Random",
+                value="random",
+                description="Returns results in random order (e.g., for games).",
+            ),
+        ],
+    ),
+]
+
 
 @extend_schema_view(
     list=extend_schema(
@@ -53,397 +445,7 @@ from backend.views.base_search_views import BaseSearchViewSet
             ),
             403: OpenApiResponse(description=doc_strings.error_403),
         },
-        parameters=[
-            OpenApiParameter(
-                name="q",
-                description="search term",
-                required=False,
-                default="",
-                type=str,
-                examples=[
-                    OpenApiExample("ball", value="ball"),
-                    OpenApiExample("quick brown fox", value="quick brown fox"),
-                ],
-            ),
-            OpenApiParameter(
-                name="types",
-                description="Filter by type of content. Options are word, phrase, song, story.",
-                required=False,
-                default="",
-                type=str,
-                examples=[
-                    OpenApiExample(
-                        "",
-                        value="",
-                        description="Retrieves all types of results.",
-                    ),
-                    OpenApiExample(
-                        "word, phrase",
-                        value="word,phrase",
-                        description="Searches for word and phrase results.",
-                    ),
-                    OpenApiExample(
-                        "song",
-                        value="song",
-                        description="Searches for song results only.",
-                    ),
-                ],
-            ),
-            OpenApiParameter(
-                name="domain",
-                description="search domain",
-                required=False,
-                default="both",
-                type=str,
-                examples=[
-                    OpenApiExample(
-                        "",
-                        value="",
-                        description="Defaults to both.",
-                    ),
-                    OpenApiExample(
-                        "both",
-                        value="both",
-                        description="Searches in both the Language and English domains.",
-                    ),
-                    OpenApiExample(
-                        "translation",
-                        value="translation",
-                        description="Performs a search focused on translations.",
-                    ),
-                    OpenApiExample(
-                        "language",
-                        value="language",
-                        description="Performs a search focused on titles and language.",
-                    ),
-                    OpenApiExample(
-                        "invalid_domain",
-                        value="None",
-                        description="If invalid domain is passed, the API returns an empty set of results.",
-                    ),
-                ],
-            ),
-            OpenApiParameter(
-                name="kids",
-                description="Return kids-friendly entries if true, not kids-friendly entries if false, "
-                "and all entries if left empty or provided an invalid value.",
-                required=False,
-                default=None,
-                type=bool,
-                examples=[
-                    OpenApiExample(
-                        "True",
-                        value=True,
-                        description="Return kids-friendly entries only.",
-                    ),
-                    OpenApiExample(
-                        "False",
-                        value=False,
-                        description="Return only entries that are not kid-friendly.",
-                    ),
-                    OpenApiExample(
-                        "Apples",
-                        value=None,
-                        description="Invalid input, defaults to all entries.",
-                    ),
-                ],
-            ),
-            OpenApiParameter(
-                name="games",
-                description="Return entries which are not excluded from games if true, entries which are excluded from "
-                "games if false, and all entries if left empty or provided with an invalid value.",
-                required=False,
-                default=None,
-                type=bool,
-                examples=[
-                    OpenApiExample(
-                        "True",
-                        value=True,
-                        description="Return entries which are not excluded from games.",
-                    ),
-                    OpenApiExample(
-                        "False",
-                        value=False,
-                        description="Return entries which are excluded from games.",
-                    ),
-                    OpenApiExample(
-                        "Oranges",
-                        value=False,
-                        description="Invalid input, defaults to all entries.",
-                    ),
-                ],
-            ),
-            OpenApiParameter(
-                name="visibility",
-                description="Filter by visibility. Options are team, members, public",
-                required=False,
-                default="",
-                type=str,
-                examples=[
-                    OpenApiExample(
-                        "",
-                        value="",
-                        description="Returns results with any visibility.",
-                    ),
-                    OpenApiExample(
-                        "Team",
-                        value="team",
-                        description="Returns results with team-only visibility.",
-                    ),
-                    OpenApiExample(
-                        "Public, Members",
-                        value="public,members",
-                        description="Returns results that have been published with Public or Members-only visibility.",
-                    ),
-                ],
-            ),
-            OpenApiParameter(
-                name="hasAudio",
-                description="Filter results that have related audio.",
-                required=False,
-                default=None,
-                type=bool,
-                examples=[
-                    OpenApiExample(
-                        "True",
-                        value=True,
-                        description="Returns results that have related audio.",
-                    ),
-                    OpenApiExample(
-                        "False",
-                        value=False,
-                        description="Returns results that do not have related audio.",
-                    ),
-                ],
-            ),
-            OpenApiParameter(
-                name="hasDocument",
-                description="Filter results that have related documents.",
-                required=False,
-                default=None,
-                type=bool,
-                examples=[
-                    OpenApiExample(
-                        "True",
-                        value=True,
-                        description="Returns results that have related documents.",
-                    ),
-                    OpenApiExample(
-                        "False",
-                        value=False,
-                        description="Returns results that do not have related documents.",
-                    ),
-                ],
-            ),
-            OpenApiParameter(
-                name="hasImage",
-                description="Filter results that have related images.",
-                required=False,
-                default=None,
-                type=bool,
-                examples=[
-                    OpenApiExample(
-                        "True",
-                        value=True,
-                        description="Returns results that have related images.",
-                    ),
-                    OpenApiExample(
-                        "False",
-                        value=False,
-                        description="Returns results that do not have related images.",
-                    ),
-                ],
-            ),
-            OpenApiParameter(
-                name="hasVideo",
-                description="Filter results that have related videos.",
-                required=False,
-                default=False,
-                type=bool,
-                examples=[
-                    OpenApiExample(
-                        "True",
-                        value=True,
-                        description="Returns results that have related videos.",
-                    ),
-                    OpenApiExample(
-                        "False",
-                        value=False,
-                        description="Returns results that do not have related videos.",
-                    ),
-                ],
-            ),
-            OpenApiParameter(
-                name="hasTranslation",
-                description="Filter results that have a translation or title translation.",
-                required=False,
-                default=None,
-                type=bool,
-                examples=[
-                    OpenApiExample(
-                        "True",
-                        value=True,
-                        description="Returns results that have a translation or title translation.",
-                    ),
-                    OpenApiExample(
-                        "False",
-                        value=False,
-                        description="Returns results that do not have a translation or title translation.",
-                    ),
-                ],
-            ),
-            OpenApiParameter(
-                name="hasUnrecognizedChars",
-                description="Filter dictionary entries that contain at least one character in their title that is not "
-                "present in the alphabet configuration.",
-                required=False,
-                default=None,
-                type=bool,
-                examples=[
-                    OpenApiExample(
-                        "True",
-                        value=True,
-                        description="Returns dictionary entries that have unrecognized characters.",
-                    ),
-                    OpenApiExample(
-                        "False",
-                        value=False,
-                        description="Returns dictionary entries that do not have any unrecognized characters.",
-                    ),
-                ],
-            ),
-            OpenApiParameter(
-                name="hasCategories",
-                description="Filter dictionary entries that have categories.",
-                required=False,
-                default=None,
-                type=bool,
-                examples=[
-                    OpenApiExample(
-                        "True",
-                        value=True,
-                        description="Returns dictionary entries that have categories.",
-                    ),
-                    OpenApiExample(
-                        "False",
-                        value=False,
-                        description="Returns dictionary entries that do not have categories.",
-                    ),
-                ],
-            ),
-            OpenApiParameter(
-                name="hasRelatedEntries",
-                description="Filter dictionary entries that have related dictionary entries.",
-                required=False,
-                default=None,
-                type=bool,
-                examples=[
-                    OpenApiExample(
-                        "True",
-                        value=True,
-                        description="Returns dictionary entries that have related dictionary entries.",
-                    ),
-                    OpenApiExample(
-                        "False",
-                        value=False,
-                        description="Returns dictionary entries that do not have related dictionary entries.",
-                    ),
-                ],
-            ),
-            OpenApiParameter(
-                name="hasSiteFeature",
-                description="Filter results based on site features.",
-                required=False,
-                default="",
-                type=str,
-                examples=[
-                    OpenApiExample(
-                        "valid site feature key",
-                        value="EXAMPLE_KEY",
-                        description="Retrieves results from sites with the EXAMPLE_KEY feature enabled.",
-                    ),
-                    OpenApiExample(
-                        "multiple valid site feature keys",
-                        value="KEY,another_key",
-                        description="Retrieves results from sites with KEY, another_key or both features enabled.",
-                    ),
-                ],
-            ),
-            OpenApiParameter(
-                name="minWords",
-                description="Filter dictionary entries on the minimum number of words in their title."
-                " Only non-negative integer values are allowed."
-                " If maxWords is less than minWords, no results will be returned.",
-                required=False,
-                default="",
-                type=int,
-                examples=[
-                    OpenApiExample(
-                        "2",
-                        value="2",
-                        description="Returns dictionary entries with at least 2 words in their title.",
-                    ),
-                ],
-            ),
-            OpenApiParameter(
-                name="maxWords",
-                description="Filter dictionary entries on the maximum number of words in their title. "
-                "Only non-negative integer values are allowed. "
-                f"The maximum value is {LENGTH_FILTER_MAX}. "
-                "If maxWords is less than minWords, no results will be returned.",
-                required=False,
-                default="",
-                type=int,
-                examples=[
-                    OpenApiExample(
-                        "5",
-                        value="5",
-                        description="Returns dictionary entries which have at the most 5 words in their title.",
-                    )
-                ],
-            ),
-            OpenApiParameter(
-                name="sort",
-                description="Sort results by something other than relevance. Options are: date created, date last "
-                "modified, title, or random. Results can be returned in descending order by adding '_desc' to the "
-                "parameter. (eg: 'sort=created_desc')",
-                required=False,
-                default="",
-                type=str,
-                examples=[
-                    OpenApiExample(
-                        "Date Created",
-                        value="created",
-                        description="Returns results ordered by the created date and time in ascending order.",
-                    ),
-                    OpenApiExample(
-                        "Date Modified",
-                        value="modified",
-                        description="Returns results ordered by the last modified date and time in ascending order.",
-                    ),
-                    OpenApiExample(
-                        "Title",
-                        value="title",
-                        description="Returns results ordered by title according to a site's custom alphabet.",
-                    ),
-                    OpenApiExample(
-                        "Date Created Descending",
-                        value="created_desc",
-                        description="Returns results ordered by the created date and time in descending order.",
-                    ),
-                    OpenApiExample(
-                        "Date Modified Descending",
-                        value="modified_desc",
-                        description="Returns results ordered by the last modified date and time in descending order.",
-                    ),
-                    OpenApiExample(
-                        "Random",
-                        value="random",
-                        description="Returns results in random order (e.g., for games).",
-                    ),
-                ],
-            ),
-        ],
+        parameters=BASE_SEARCH_PARAMS,
     ),
 )
 class BaseSearchEntriesViewSet(BaseSearchViewSet):

--- a/firstvoices/backend/views/dictionary_export_views.py
+++ b/firstvoices/backend/views/dictionary_export_views.py
@@ -1,3 +1,4 @@
+from django.utils import timezone
 from rest_framework.response import Response
 
 from backend.serializers.export_serializers import DictionaryEntryExportSerializer
@@ -57,4 +58,9 @@ class DictionaryEntryExportViewSet(SearchSiteEntriesViewSet):
         serialized_data = [
             dictionary_entry["entry"] for dictionary_entry in serialized_data
         ]
-        return Response(data=serialized_data)
+
+        filename = f"dictionary_export_{timezone.localtime(timezone.now()).strftime("%Y_%m_%d_%H_%M_%S")}"
+        return Response(
+            data=serialized_data,
+            headers={"Content-Disposition": f'attachment; filename= "{filename}"'},
+        )

--- a/firstvoices/backend/views/dictionary_export_views.py
+++ b/firstvoices/backend/views/dictionary_export_views.py
@@ -1,0 +1,60 @@
+from rest_framework.response import Response
+
+from backend.serializers.export_serializers import DictionaryEntryExportSerializer
+from backend.utils.CustomCsvRenderer import CustomCsvRenderer
+from backend.views.exceptions import ElasticSearchConnectionError
+from backend.views.search_site_entries_views import SearchSiteEntriesViewSet
+
+
+class DictionaryEntryExportViewSet(SearchSiteEntriesViewSet):
+    http_method_names = ["get"]
+    serializer_classes = {
+        "DictionaryEntry": DictionaryEntryExportSerializer,
+    }
+    renderer_classes = [CustomCsvRenderer]
+    flatten_fields = {
+        "categories": "category",
+        "translations": "translation",
+        "notes": "note",
+        "acknowledgements": "acknowledgement",
+        "alternate_spellings": "alternate_spelling",
+        "pronunciations": "pronunciation",
+        "related_video_links": "video_embed_link",
+        "related_dictionary_entries": "related_entry_id",
+    }
+
+    # Overriding to return CSV instead of search results
+    def list(self, request, **kwargs):
+        search_params = self.get_search_params()
+
+        # If anything else is present in the search params except for words or phrases,
+        # we pop them out as this API only supports dictionary entries
+        search_params["types"] = [
+            entry_type
+            for entry_type in search_params["types"]
+            if entry_type in ["word", "phrase"]
+        ]
+
+        pagination_params = self.get_pagination_params()
+
+        if self.has_invalid_input(search_params):
+            return self.paginate_search_response(request, [], 0)
+
+        search_query = self.build_query(**search_params)
+        search_query = self.paginate_query(search_query, **pagination_params)
+        search_query = self.sort_query(search_query, **search_params)
+
+        try:
+            response = search_query.execute()
+        except ConnectionError:
+            raise ElasticSearchConnectionError()
+
+        search_results = response["hits"]["hits"]
+        data = self.hydrate(search_results)
+        serialized_data = self.serialize_search_results(
+            search_results, data, **search_params, **pagination_params
+        )
+        serialized_data = [
+            dictionary_entry["entry"] for dictionary_entry in serialized_data
+        ]
+        return Response(data=serialized_data)

--- a/firstvoices/backend/views/dictionary_export_views.py
+++ b/firstvoices/backend/views/dictionary_export_views.py
@@ -1,11 +1,22 @@
 from django.utils import timezone
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework.response import Response
 
 from backend.serializers.export_serializers import DictionaryEntryExportSerializer
 from backend.utils.CustomCsvRenderer import CustomCsvRenderer
-from backend.views.search_site_entries_views import SearchSiteEntriesViewSet
+from backend.views.base_search_entries_views import BASE_SEARCH_PARAMS
+from backend.views.search_site_entries_views import (
+    SITE_SEARCH_PARAMS,
+    SearchSiteEntriesViewSet,
+)
 
 
+@extend_schema_view(
+    list=extend_schema(
+        description="Export a CSV of dictionary entries.",
+        parameters=[*SITE_SEARCH_PARAMS, *BASE_SEARCH_PARAMS],
+    )
+)
 class DictionaryEntryExportViewSet(SearchSiteEntriesViewSet):
     http_method_names = ["get"]
     serializer_classes = {
@@ -36,9 +47,6 @@ class DictionaryEntryExportViewSet(SearchSiteEntriesViewSet):
         ]
 
         pagination_params = self.get_pagination_params()
-
-        if self.has_invalid_input(search_params):
-            return self.paginate_search_response(request, [], 0)
 
         response = self.get_search_response(search_params, pagination_params)
         search_results = response["hits"]["hits"]

--- a/firstvoices/backend/views/dictionary_export_views.py
+++ b/firstvoices/backend/views/dictionary_export_views.py
@@ -1,5 +1,10 @@
 from django.utils import timezone
-from drf_spectacular.utils import extend_schema, extend_schema_view
+from drf_spectacular.utils import (
+    OpenApiExample,
+    OpenApiParameter,
+    extend_schema,
+    extend_schema_view,
+)
 from rest_framework.response import Response
 
 from backend.serializers.export_serializers import DictionaryEntryExportSerializer
@@ -14,7 +19,34 @@ from backend.views.search_site_entries_views import (
 @extend_schema_view(
     list=extend_schema(
         description="Export a CSV of dictionary entries.",
-        parameters=[*SITE_SEARCH_PARAMS, *BASE_SEARCH_PARAMS],
+        parameters=[
+            *SITE_SEARCH_PARAMS,
+            *BASE_SEARCH_PARAMS,
+            OpenApiParameter(
+                name="types",
+                description="Filter by type of content. Options are word & phrase.",
+                required=False,
+                default="",
+                type=str,
+                examples=[
+                    OpenApiExample(
+                        "",
+                        value="",
+                        description="Retrieves all types of results.",
+                    ),
+                    OpenApiExample(
+                        "word",
+                        value="word",
+                        description="Retrieves all words.",
+                    ),
+                    OpenApiExample(
+                        "phrase",
+                        value="phrase",
+                        description="Retrieves all phrases.",
+                    ),
+                ],
+            ),
+        ],
     )
 )
 class DictionaryEntryExportViewSet(SearchSiteEntriesViewSet):

--- a/firstvoices/backend/views/dictionary_export_views.py
+++ b/firstvoices/backend/views/dictionary_export_views.py
@@ -40,11 +40,12 @@ class DictionaryEntryExportViewSet(SearchSiteEntriesViewSet):
 
         # If anything else is present in the search params except for words or phrases,
         # we pop them out as this API only supports dictionary entries
-        search_params["types"] = [
+        filtered_types = [
             entry_type
             for entry_type in search_params["types"]
             if entry_type in ["word", "phrase"]
         ]
+        search_params["types"] = filtered_types
 
         pagination_params = self.get_pagination_params()
 

--- a/firstvoices/backend/views/dictionary_export_views.py
+++ b/firstvoices/backend/views/dictionary_export_views.py
@@ -3,7 +3,6 @@ from rest_framework.response import Response
 
 from backend.serializers.export_serializers import DictionaryEntryExportSerializer
 from backend.utils.CustomCsvRenderer import CustomCsvRenderer
-from backend.views.exceptions import ElasticSearchConnectionError
 from backend.views.search_site_entries_views import SearchSiteEntriesViewSet
 
 
@@ -41,16 +40,9 @@ class DictionaryEntryExportViewSet(SearchSiteEntriesViewSet):
         if self.has_invalid_input(search_params):
             return self.paginate_search_response(request, [], 0)
 
-        search_query = self.build_query(**search_params)
-        search_query = self.paginate_query(search_query, **pagination_params)
-        search_query = self.sort_query(search_query, **search_params)
-
-        try:
-            response = search_query.execute()
-        except ConnectionError:
-            raise ElasticSearchConnectionError()
-
+        response = self.get_search_response(search_params, pagination_params)
         search_results = response["hits"]["hits"]
+
         data = self.hydrate(search_results)
         serialized_data = self.serialize_search_results(
             search_results, data, **search_params, **pagination_params

--- a/firstvoices/backend/views/search_all_entries_views.py
+++ b/firstvoices/backend/views/search_all_entries_views.py
@@ -6,13 +6,17 @@ from drf_spectacular.utils import (
 )
 
 from backend.search.validators import get_valid_site_ids_from_slugs
-from backend.views.base_search_entries_views import BaseSearchEntriesViewSet
+from backend.views.base_search_entries_views import (
+    BASE_SEARCH_PARAMS,
+    BaseSearchEntriesViewSet,
+)
 
 
 @extend_schema_view(
     list=extend_schema(
         description="List of search results from all sites satisfying the query.",
         parameters=[
+            *BASE_SEARCH_PARAMS,
             OpenApiParameter(
                 name="sites",
                 description="Filter results based on site. Multiple site slugs can be passed as a comma-separated "

--- a/firstvoices/backend/views/search_site_entries_views.py
+++ b/firstvoices/backend/views/search_site_entries_views.py
@@ -63,13 +63,13 @@ SITE_SEARCH_PARAMS = [
             ),
             OpenApiExample(
                 "valid UUID",
-                value="valid UUID",
+                value="6cdb161a-2ce7-4197-813d-1683448128a2",
                 description="Return entries which are associated with "
                 "the given category or its child categories.",
             ),
             OpenApiExample(
                 "invalid UUID",
-                value="invalid UUID",
+                value="invalid-uuid",
                 description="Cannot validate given id, returns empty result set.",
             ),
         ],

--- a/firstvoices/backend/views/search_site_entries_views.py
+++ b/firstvoices/backend/views/search_site_entries_views.py
@@ -8,74 +8,79 @@ from drf_spectacular.utils import (
 from backend.models import Category, ImportJob
 from backend.search.validators import get_valid_instance_id, get_valid_starts_with_char
 from backend.views.api_doc_variables import site_slug_parameter
-from backend.views.base_search_entries_views import BaseSearchEntriesViewSet
+from backend.views.base_search_entries_views import (
+    BASE_SEARCH_PARAMS,
+    BaseSearchEntriesViewSet,
+)
 from backend.views.base_views import SiteContentViewSetMixin
+
+SITE_SEARCH_PARAMS = [
+    site_slug_parameter,
+    OpenApiParameter(
+        name="startsWithChar",
+        description="Return entries that start with the specified character.",
+        required=False,
+        default="",
+        type=str,
+        examples=[
+            OpenApiExample(
+                "",
+                value="",
+                description="Default case. Do not add startsWithChar filter.",
+            ),
+            OpenApiExample(
+                "a",
+                value="a",
+                description="Return all entries starting with a.",
+            ),
+        ],
+    ),
+    OpenApiParameter(
+        name="importJobId",
+        description="Filter results based on the associated batch import job.",
+        required=False,
+        default="",
+        type=str,
+        examples=[
+            OpenApiExample(
+                "valid UUID",
+                value="6cdb161a-2ce7-4197-813d-1683448128a2",
+                description="Return entries which were imported by the specified job.",
+            ),
+        ],
+    ),
+    OpenApiParameter(
+        name="category",
+        description="Return entries which are associated with the given category or its child categories.",
+        required=False,
+        default="",
+        type=str,
+        examples=[
+            OpenApiExample(
+                "",
+                value="",
+                description="Default case. Do not add categories filter.",
+            ),
+            OpenApiExample(
+                "valid UUID",
+                value="valid UUID",
+                description="Return entries which are associated with "
+                "the given category or its child categories.",
+            ),
+            OpenApiExample(
+                "invalid UUID",
+                value="invalid UUID",
+                description="Cannot validate given id, returns empty result set.",
+            ),
+        ],
+    ),
+]
 
 
 @extend_schema_view(
     list=extend_schema(
         description="List of search results from this site satisfying the query.",
-        parameters=[
-            site_slug_parameter,
-            OpenApiParameter(
-                name="startsWithChar",
-                description="Return entries that start with the specified character.",
-                required=False,
-                default="",
-                type=str,
-                examples=[
-                    OpenApiExample(
-                        "",
-                        value="",
-                        description="Default case. Do not add startsWithChar filter.",
-                    ),
-                    OpenApiExample(
-                        "a",
-                        value="a",
-                        description="Return all entries starting with a.",
-                    ),
-                ],
-            ),
-            OpenApiParameter(
-                name="importJobId",
-                description="Filter results based on the associated batch import job.",
-                required=False,
-                default="",
-                type=str,
-                examples=[
-                    OpenApiExample(
-                        "valid UUID",
-                        value="6cdb161a-2ce7-4197-813d-1683448128a2",
-                        description="Return entries which were imported by the specified job.",
-                    ),
-                ],
-            ),
-            OpenApiParameter(
-                name="category",
-                description="Return entries which are associated with the given category or its child categories.",
-                required=False,
-                default="",
-                type=str,
-                examples=[
-                    OpenApiExample(
-                        "",
-                        value="",
-                        description="Default case. Do not add categories filter.",
-                    ),
-                    OpenApiExample(
-                        "valid UUID",
-                        value="valid UUID",
-                        description="Return entries which are associated with "
-                        "the given category or its child categories.",
-                    ),
-                    OpenApiExample(
-                        "invalid UUID",
-                        value="invalid UUID",
-                        description="Cannot validate given id, returns empty result set.",
-                    ),
-                ],
-            ),
-        ],
+        parameters=[*BASE_SEARCH_PARAMS, *SITE_SEARCH_PARAMS],
     )
 )
 class SearchSiteEntriesViewSet(SiteContentViewSetMixin, BaseSearchEntriesViewSet):


### PR DESCRIPTION
### Description of Changes
- Added Dictionary export api at `/{site_slug}/dictionary-export` with support for all the same parameters as the site-search API. Returns a CSV with the specified filename in the response.
- Added DictionaryExportSerializer that subclasses SearchResultSerializer to build on top of it, added utility read-only fields(`InvertedBooleanField`, `CommaSeparatedIDsField`) to export in the required format.
- Added CustomCSVRenderer that can be used to export any serializer's data output in a CSV format with the option to flatten fields (e.g. notes -> note, note_2, ...).
- Refactored API docs for search views to be reused in dictionary-export API as well.
- Minor refactor base_search_views to pull out a `get_search_response` method to reduce duplicating it in export API.

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- [x] Insomnia workspace has been updated if applicable
- ~Signal and Task inventories have been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [x] Pull the branch and test locally

### Additional Notes
N/A
