### PR TITLE
FW-5724 Add remove_speaker_links management command

### DIFF
--- a/firstvoices/backend/management/commands/remove_speaker_links.py
+++ b/firstvoices/backend/management/commands/remove_speaker_links.py
@@ -1,0 +1,183 @@
+import csv
+import logging
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from backend.models import Audio, DictionaryEntry, Person
+
+
+class Command(BaseCommand):
+    help = (
+        "Removes the audio links from dictionary entries given a speaker name."
+        "And/or csv file containing the uuids of the entries."
+        "Speaker name is also added as a speaker to all entries that had audio removed."
+    )
+
+    logger = logging.getLogger(__name__)
+    change_log = []
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--site",
+            dest="site_slug",
+            help="Site slug of the site to remove audio links from (required)",
+            required=True,
+        )
+        parser.add_argument(
+            "--speaker",
+            dest="speaker_name",
+            help="Name of the speaker whose links should be removed (optional)",
+            required=True,
+        )
+        parser.add_argument(
+            "--csv",
+            dest="csv_file",
+            help="Path to a CSV file containing the UUIDs of the dictionary entries to process (optional)",
+            default=None,
+        )
+        parser.add_argument(
+            "--typos",
+            dest="typos",
+            help="Provided names will be treated as typos of the speaker name (optional)",
+            default=False,
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            dest="dry_run",
+            help="If set, the command will only log the changes that would be made without actually making them.",
+            default=False,
+        )
+
+    def remove_audio_links_by_uuid(self, uuid_list, site_slug, speaker_name, dry_run):
+        """
+        For each entry in the csv, marks all related audio with the provided speaker name,
+        and removes the audio links from the entry.
+        """
+        for uuid in uuid_list:
+            try:
+                entry = DictionaryEntry.objects.get(uuid=uuid, site__slug=site_slug)
+            except DictionaryEntry.DoesNotExist:
+                self.logger.warning(
+                    f"DictionaryEntry with UUID {uuid} not found in site {site_slug}."
+                )
+                continue
+
+            related_audio = entry.related_audio.all()
+            if related_audio.exists():
+                if dry_run:
+                    audio_uuids = [str(audio.uuid) for audio in related_audio]
+                    self.logger.info(
+                        f"[Dry Run] Would remove links to audio {audio_uuids} from entry {entry.title} "
+                        f"and add speaker '{speaker_name}' to those audio models."
+                    )
+                else:
+                    for audio in related_audio:
+                        self.change_log.append(
+                            {
+                                "entry_id": str(entry.uuid),
+                                "entry_title": entry.title,
+                                "audio_id": str(audio.uuid),
+                                "audio_title": audio.title,
+                                "speaker_name": speaker_name,
+                                "site": site_slug,
+                            }
+                        )
+                        speaker, created = Person.objects.get_or_create(
+                            name=speaker_name,
+                            site=entry.site,
+                            defaults={"bio": "---"},
+                        )
+                        audio.speakers.add(speaker)
+                        audio.save(set_modified_date=False)
+                        entry.related_audio.remove(audio)
+                        entry.save(set_modified_date=False)
+
+    def remove_audio_links_by_speaker(self, speaker_name, site_slug, typos, dry_run):
+        site_audio = Audio.objects.filter(site__slug=site_slug)
+        speakers_to_check = [speaker_name]
+        if typos:
+            speakers_to_check = speakers_to_check + typos.split(",")
+
+        for name in speakers_to_check:
+            name = name.strip()
+            audio_to_unlink = site_audio.filter(speakers__name__iexact=name).distinct()
+            for audio in audio_to_unlink:
+                related_entries = DictionaryEntry.objects.filter(
+                    related_audio=audio, site__slug=site_slug
+                )
+                for entry in related_entries:
+                    if dry_run:
+                        self.logger.info(
+                            f"[Dry Run] Would remove audio link {audio.uuid} from entry {entry.title}."
+                        )
+                    else:
+                        self.change_log.append(
+                            {
+                                "entry_id": str(entry.uuid),
+                                "entry_title": entry.title,
+                                "audio_id": str(audio.uuid),
+                                "audio_title": audio.title,
+                                "speaker_name": speaker_name,
+                                "site": site_slug,
+                            }
+                        )
+                        entry.related_audio.remove(audio)
+                        entry.save(set_modified_date=False)
+
+    def handle(self, *args, **options):
+
+        site_slug = options["site_slug"]
+        speaker_name = options["speaker_name"].strip()
+        csv_file = options["csv_file"]
+        typos = options["typos"]
+        dry_run = options["dry_run"]
+
+        self.logger.info(
+            f"Starting to remove speaker links for speaker '{speaker_name}' in site '{site_slug}'."
+        )
+        if dry_run:
+            self.logger.info("Dry run mode enabled. No changes will be made.")
+
+        if csv_file:
+            self.logger.info(f"Processing entries from CSV file: {csv_file}")
+            try:
+                with open(csv_file) as f:
+                    uuid_list = []
+                    reader = csv.DictReader(f)
+                    for row in reader:
+                        if row:
+                            uuid_list.append(row["id"].strip())
+
+                self.remove_audio_links_by_uuid(
+                    uuid_list, site_slug, speaker_name, dry_run
+                )
+            except FileNotFoundError:
+                self.logger.warning(f"Error: CSV file '{csv_file}' not found.")
+                return
+            except Exception as e:
+                self.logger.warning(f"Error reading CSV file '{csv_file}': {e}")
+                return
+
+        if speaker_name:
+            self.logger.info(f"Processing entries for speaker: {speaker_name}")
+            self.remove_audio_links_by_speaker(speaker_name, site_slug, typos, dry_run)
+        self.logger.info("Finished removing speaker links.")
+
+        if not dry_run and self.change_log:
+            log_file = f"remove_speaker_links_log_{site_slug}_{timezone.now().strftime('%Y%m%d_%H%M%S')}.csv"
+            with open(log_file, "w", newline="") as csvfile:
+                fieldnames = [
+                    "entry_id",
+                    "entry_title",
+                    "audio_id",
+                    "audio_title",
+                    "speaker_name",
+                    "site",
+                ]
+                writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+                writer.writeheader()
+                for change in self.change_log:
+                    writer.writerow(change)
+            self.logger.info(f"Change log written to {log_file}.")

--- a/firstvoices/backend/management/commands/remove_speaker_links.py
+++ b/firstvoices/backend/management/commands/remove_speaker_links.py
@@ -1,21 +1,24 @@
 import csv
 import logging
+import os
 
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
-from backend.models import Audio, DictionaryEntry, Person
+from backend.models import Audio, DictionaryEntry, Person, Site
 
 
 class Command(BaseCommand):
     help = (
         "Removes the audio links from dictionary entries given a speaker name."
-        "And/or csv file containing the uuids of the entries."
+        "And/or csv file containing the ids of the entries."
         "Speaker name is also added as a speaker to all entries that had audio removed."
     )
 
-    logger = logging.getLogger(__name__)
-    change_log = []
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.logger = logging.getLogger(__name__)
+        self.change_log = []
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -27,19 +30,25 @@ class Command(BaseCommand):
         parser.add_argument(
             "--speaker",
             dest="speaker_name",
-            help="Name of the speaker whose links should be removed (optional)",
+            help="Name of the speaker whose links should be removed (required)",
             required=True,
+        )
+        parser.add_argument(
+            "--output-dir",
+            dest="output_dir",
+            help="Directory to save the change log CSV file (default is current directory).",
+            default=".",
         )
         parser.add_argument(
             "--csv",
             dest="csv_file",
-            help="Path to a CSV file containing the UUIDs of the dictionary entries to process (optional)",
+            help="Path to a CSV file containing the IDs of the dictionary entries to process (optional)",
             default=None,
         )
         parser.add_argument(
             "--typos",
             dest="typos",
-            help="Provided names will be treated as typos of the speaker name (optional)",
+            help="A list of names that will be treated as typos of the speaker name (optional)",
             default=False,
         )
         parser.add_argument(
@@ -50,41 +59,41 @@ class Command(BaseCommand):
             default=False,
         )
 
-    def remove_audio_links_by_uuid(self, uuid_list, site_slug, speaker_name, dry_run):
+    def remove_audio_links_by_id(self, id_list, site_slug, speaker_name, dry_run):
         """
         For each entry in the csv, marks all related audio with the provided speaker name,
         and removes the audio links from the entry.
         """
-        for uuid in uuid_list:
+        for _id in id_list:
             try:
-                entry = DictionaryEntry.objects.get(uuid=uuid, site__slug=site_slug)
+                entry = DictionaryEntry.objects.get(id=_id, site__slug=site_slug)
             except DictionaryEntry.DoesNotExist:
                 self.logger.warning(
-                    f"DictionaryEntry with UUID {uuid} not found in site {site_slug}."
+                    f"DictionaryEntry with ID {_id} not found in site {site_slug}."
                 )
                 continue
 
             related_audio = entry.related_audio.all()
             if related_audio.exists():
                 if dry_run:
-                    audio_uuids = [str(audio.uuid) for audio in related_audio]
+                    audio_ids = [str(audio.id) for audio in related_audio]
                     self.logger.info(
-                        f"[Dry Run] Would remove links to audio {audio_uuids} from entry {entry.title} "
+                        f"[Dry Run] Would remove links to audio {audio_ids} from entry {entry.title} "
                         f"and add speaker '{speaker_name}' to those audio models."
                     )
                 else:
                     for audio in related_audio:
                         self.change_log.append(
                             {
-                                "entry_id": str(entry.uuid),
+                                "entry_id": str(entry.id),
                                 "entry_title": entry.title,
-                                "audio_id": str(audio.uuid),
+                                "audio_id": str(audio.id),
                                 "audio_title": audio.title,
                                 "speaker_name": speaker_name,
                                 "site": site_slug,
                             }
                         )
-                        speaker, created = Person.objects.get_or_create(
+                        speaker, _ = Person.objects.get_or_create(
                             name=speaker_name,
                             site=entry.site,
                             defaults={"bio": "---"},
@@ -102,7 +111,9 @@ class Command(BaseCommand):
 
         for name in speakers_to_check:
             name = name.strip()
-            audio_to_unlink = site_audio.filter(speakers__name__iexact=name).distinct()
+            audio_to_unlink = site_audio.filter(
+                speakers__name__icontains=name
+            ).distinct()
             for audio in audio_to_unlink:
                 related_entries = DictionaryEntry.objects.filter(
                     related_audio=audio, site__slug=site_slug
@@ -110,14 +121,14 @@ class Command(BaseCommand):
                 for entry in related_entries:
                     if dry_run:
                         self.logger.info(
-                            f"[Dry Run] Would remove audio link {audio.uuid} from entry {entry.title}."
+                            f"[Dry Run] Would remove audio link {audio.id} from entry {entry.title}."
                         )
                     else:
                         self.change_log.append(
                             {
-                                "entry_id": str(entry.uuid),
+                                "entry_id": str(entry.id),
                                 "entry_title": entry.title,
-                                "audio_id": str(audio.uuid),
+                                "audio_id": str(audio.id),
                                 "audio_title": audio.title,
                                 "speaker_name": speaker_name,
                                 "site": site_slug,
@@ -126,13 +137,62 @@ class Command(BaseCommand):
                         entry.related_audio.remove(audio)
                         entry.save(set_modified_date=False)
 
+    def validate_output_dir(self, output_dir):
+        output_dir = os.path.expandvars(os.path.expanduser(output_dir))
+
+        if os.path.exists(output_dir) and not os.path.isdir(output_dir):
+            self.logger.error(f"Path '{output_dir}' exists but is not a directory.")
+            return None
+
+        if not os.path.exists(output_dir):
+            try:
+                os.makedirs(output_dir, exist_ok=True)
+                self.logger.info(f"Created output directory '{output_dir}'.")
+            except Exception as e:
+                self.logger.error(f"Failed to create directory '{output_dir}': {e}")
+                return None
+
+        if not os.access(output_dir, os.W_OK):
+            self.logger.error(f"Directory '{output_dir}' is not writable.")
+            return None
+
+        return output_dir
+
+    def output_change_log(self, site_slug, output_dir):
+        log_filename = f"remove_speaker_links_log_{site_slug}_{timezone.now().strftime('%Y%m%d_%H%M')}.csv"
+        log_file = os.path.join(output_dir, log_filename)
+
+        with open(log_file, "w", newline="") as csvfile:
+            fieldnames = [
+                "entry_id",
+                "entry_title",
+                "audio_id",
+                "audio_title",
+                "speaker_name",
+                "site",
+            ]
+            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+            writer.writeheader()
+            for change in self.change_log:
+                writer.writerow(change)
+        self.logger.info(f"Change log written to {log_file}.")
+
     def handle(self, *args, **options):
 
         site_slug = options["site_slug"]
         speaker_name = options["speaker_name"].strip()
+        output_dir = options["output_dir"]
         csv_file = options["csv_file"]
         typos = options["typos"]
         dry_run = options["dry_run"]
+
+        output_dir = self.validate_output_dir(output_dir)
+        if output_dir is None:
+            return
+
+        if not Site.objects.filter(slug=site_slug).exists():
+            self.logger.warning(f"Site with slug '{site_slug}' does not exist.")
+            return
 
         self.logger.info(
             f"Starting to remove speaker links for speaker '{speaker_name}' in site '{site_slug}'."
@@ -144,15 +204,13 @@ class Command(BaseCommand):
             self.logger.info(f"Processing entries from CSV file: {csv_file}")
             try:
                 with open(csv_file) as f:
-                    uuid_list = []
+                    id_list = []
                     reader = csv.DictReader(f)
                     for row in reader:
                         if row:
-                            uuid_list.append(row["id"].strip())
+                            id_list.append(row["id"].strip())
 
-                self.remove_audio_links_by_uuid(
-                    uuid_list, site_slug, speaker_name, dry_run
-                )
+                self.remove_audio_links_by_id(id_list, site_slug, speaker_name, dry_run)
             except FileNotFoundError:
                 self.logger.warning(f"Error: CSV file '{csv_file}' not found.")
                 return
@@ -160,24 +218,9 @@ class Command(BaseCommand):
                 self.logger.warning(f"Error reading CSV file '{csv_file}': {e}")
                 return
 
-        if speaker_name:
-            self.logger.info(f"Processing entries for speaker: {speaker_name}")
-            self.remove_audio_links_by_speaker(speaker_name, site_slug, typos, dry_run)
+        self.logger.info(f"Processing entries for speaker: {speaker_name}")
+        self.remove_audio_links_by_speaker(speaker_name, site_slug, typos, dry_run)
         self.logger.info("Finished removing speaker links.")
 
         if not dry_run and self.change_log:
-            log_file = f"remove_speaker_links_log_{site_slug}_{timezone.now().strftime('%Y%m%d_%H%M%S')}.csv"
-            with open(log_file, "w", newline="") as csvfile:
-                fieldnames = [
-                    "entry_id",
-                    "entry_title",
-                    "audio_id",
-                    "audio_title",
-                    "speaker_name",
-                    "site",
-                ]
-                writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-                writer.writeheader()
-                for change in self.change_log:
-                    writer.writerow(change)
-            self.logger.info(f"Change log written to {log_file}.")
+            self.output_change_log(site_slug, output_dir)

--- a/firstvoices/backend/management/commands/remove_speaker_links.py
+++ b/firstvoices/backend/management/commands/remove_speaker_links.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
     help = (
         "Removes the audio links from dictionary entries given a speaker name."
         "And/or csv file containing the ids of the entries."
-        "Speaker name is also added as a speaker to all entries that had audio removed."
+        "The provided speaker name is added as a speaker to all audio files associated with the entries in the csv."
     )
 
     def __init__(self, *args, **kwargs):
@@ -82,7 +82,7 @@ class Command(BaseCommand):
                         audio_ids_str = ", ".join(audio_ids)
                         self.logger.info(
                             f"[Dry Run] Would remove links to audio {audio_ids_str} from entry {entry.title} "
-                            f"and add speaker '{speaker_name}' to those audio models."
+                            f"and add speaker '{speaker_name}' to affected audio instances."
                         )
                     else:
                         for audio in related_audio:

--- a/firstvoices/backend/management/commands/remove_speaker_links.py
+++ b/firstvoices/backend/management/commands/remove_speaker_links.py
@@ -140,20 +140,10 @@ class Command(BaseCommand):
     def validate_output_dir(self, output_dir):
         output_dir = os.path.expandvars(os.path.expanduser(output_dir))
 
-        if os.path.exists(output_dir) and not os.path.isdir(output_dir):
-            self.logger.error(f"Path '{output_dir}' exists but is not a directory.")
-            return None
-
-        if not os.path.exists(output_dir):
-            try:
-                os.makedirs(output_dir, exist_ok=True)
-                self.logger.info(f"Created output directory '{output_dir}'.")
-            except Exception as e:
-                self.logger.error(f"Failed to create directory '{output_dir}': {e}")
-                return None
-
-        if not os.access(output_dir, os.W_OK):
-            self.logger.error(f"Directory '{output_dir}' is not writable.")
+        if not os.path.isdir(output_dir) or not os.access(output_dir, os.W_OK):
+            self.logger.error(
+                f"Output directory '{output_dir}' does not exist or is not writeable."
+            )
             return None
 
         return output_dir

--- a/firstvoices/backend/tests/factories/resources/management_commands/remove_speaker_entries_minimal.csv
+++ b/firstvoices/backend/tests/factories/resources/management_commands/remove_speaker_entries_minimal.csv
@@ -1,3 +1,0 @@
-c36275d4-ba71-4efc-8bbe-c1f91d0bdeff
-4a2e3113-5c7e-44df-9e6a-cc11a10f5fa0
-dfcaae4d-f01f-4fc5-b0ca-7366e7fdf8b9

--- a/firstvoices/backend/tests/factories/resources/management_commands/remove_speaker_entries_minimal.csv
+++ b/firstvoices/backend/tests/factories/resources/management_commands/remove_speaker_entries_minimal.csv
@@ -1,0 +1,3 @@
+c36275d4-ba71-4efc-8bbe-c1f91d0bdeff
+4a2e3113-5c7e-44df-9e6a-cc11a10f5fa0
+dfcaae4d-f01f-4fc5-b0ca-7366e7fdf8b9

--- a/firstvoices/backend/tests/test_commands/test_remove_speaker_links.py
+++ b/firstvoices/backend/tests/test_commands/test_remove_speaker_links.py
@@ -278,7 +278,7 @@ class TestRemoveSpeakerLinks:
         assert f"Change log written to {output_file}." in caplog.text
 
     def test_remove_speaker_links_typo_dry_run(self, caplog):
-        audio_ids, person = self.setup_entries_with_audio("John Doe")
+        audio_ids, _ = self.setup_entries_with_audio("John Doe")
 
         typo_audio = self.setup_typo_audio("Jhon Doe")
 

--- a/firstvoices/backend/tests/test_commands/test_remove_speaker_links.py
+++ b/firstvoices/backend/tests/test_commands/test_remove_speaker_links.py
@@ -1,0 +1,212 @@
+import pytest
+from django.core.management import call_command
+from django.utils import timezone
+
+from backend.models import Audio, DictionaryEntry
+from backend.models.constants import Visibility
+from backend.tests import factories
+
+
+@pytest.mark.django_db
+class TestRemoveSpeakerLinks:
+    TEST_ENTRY_UUID_1 = "c36275d4-ba71-4efc-8bbe-c1f91d0bdeff"
+    TEST_ENTRY_UUID_2 = "4a2e3113-5c7e-44df-9e6a-cc11a10f5fa0"
+    TEST_ENTRY_UUID_3 = "dfcaae4d-f01f-4fc5-b0ca-7366e7fdf8b9"
+
+    def setup_method(self):
+        self.site = factories.SiteFactory(visibility=Visibility.PUBLIC)
+
+    def setup_entries_with_audio(self, speaker_name):
+        person = factories.PersonFactory(name=speaker_name, site=self.site)
+
+        related_audio = factories.AudioFactory.create(site=self.site)
+        related_audio.speakers.set([person])
+        related_audio.save()
+
+        related_audio_no_speaker = factories.AudioFactory.create(site=self.site)
+
+        entry1 = factories.DictionaryEntryFactory.create(
+            id=self.TEST_ENTRY_UUID_1,
+            site=self.site,
+        )
+        entry1.related_audio.set([related_audio])
+        entry1.save()
+
+        entry2 = factories.DictionaryEntryFactory.create(
+            id=self.TEST_ENTRY_UUID_2,
+            site=self.site,
+        )
+        entry2.related_audio.set([related_audio_no_speaker])
+        entry2.save()
+
+        entry3 = factories.DictionaryEntryFactory.create(
+            id=self.TEST_ENTRY_UUID_3,
+            site=self.site,
+        )
+        entry3.related_audio.set([related_audio, related_audio_no_speaker])
+        entry3.save()
+
+        entry_ids = DictionaryEntry.objects.all().values_list("id", flat=True)
+        audio_ids = Audio.objects.filter(site=self.site).values_list("id", flat=True)
+        return entry_ids, audio_ids, person
+
+    def get_entry_csv_content(self):
+        return f"id\n{self.TEST_ENTRY_UUID_1}\n{self.TEST_ENTRY_UUID_2}\n{self.TEST_ENTRY_UUID_3}\n"
+
+    @staticmethod
+    def assert_caplog_text(caplog, speaker_name, site_slug, csv_file):
+        assert (
+            f"Starting to remove speaker links for speaker '{speaker_name}' in site '{site_slug}'."
+            in caplog.text
+        )
+        assert f"Processing entries for speaker: {speaker_name}" in caplog.text
+        assert "Finished removing speaker links." in caplog.text
+        if csv_file:
+            assert f"Processing entries from CSV file: {csv_file}" in caplog.text
+
+    def test_remove_speaker_links_invalid_slug(self, caplog):
+        call_command(
+            "remove_speaker_links", site_slug="invalid-site", speaker_name="John Doe"
+        )
+        assert "Site with slug 'invalid-site' does not exist." in caplog.text
+
+    def test_remove_speaker_links_dry_run_no_csv(self, caplog):
+        entry_ids, audio_ids, _ = self.setup_entries_with_audio("John Doe")
+        call_command(
+            "remove_speaker_links",
+            site_slug=self.site.slug,
+            speaker_name="John Doe",
+            dry_run=True,
+        )
+        assert DictionaryEntry.objects.count() == 3
+        entry1 = DictionaryEntry.objects.get(id=self.TEST_ENTRY_UUID_1)
+        assert entry1.related_audio.count() == 1
+        entry2 = DictionaryEntry.objects.get(id=self.TEST_ENTRY_UUID_2)
+        assert entry2.related_audio.count() == 1
+        entry3 = DictionaryEntry.objects.get(id=self.TEST_ENTRY_UUID_3)
+        assert entry3.related_audio.count() == 2
+
+        self.assert_caplog_text(caplog, "John Doe", self.site.slug, None)
+        assert "Dry run mode enabled. No changes will be made." in caplog.text
+        assert (
+            f"[Dry Run] Would remove audio link {audio_ids[0].id} from entry {entry_ids[0].title}."
+            in caplog.text
+        )
+        assert (
+            f"[Dry Run] Would remove audio link {audio_ids[0].id} from entry {entry_ids[2].title}."
+            in caplog.text
+        )
+
+    def test_remove_speaker_links_dry_run_with_csv(self, tmp_path, caplog):
+        entry_ids, audio_ids, _ = self.setup_entries_with_audio("John Doe")
+        csv_file = tmp_path / "test_speaker_links.csv"
+        with open(csv_file, "w") as f:
+            f.write(self.get_entry_csv_content())
+
+        call_command(
+            "remove_speaker_links",
+            site_slug=self.site.slug,
+            speaker_name="John Doe",
+            csv_file=str(csv_file),
+            dry_run=True,
+        )
+        assert DictionaryEntry.objects.count() == 3
+        entry1 = DictionaryEntry.objects.get(id=self.TEST_ENTRY_UUID_1)
+        assert entry1.related_audio.count() == 1
+        entry2 = DictionaryEntry.objects.get(id=self.TEST_ENTRY_UUID_2)
+        assert entry2.related_audio.count() == 1
+        entry3 = DictionaryEntry.objects.get(id=self.TEST_ENTRY_UUID_3)
+        assert entry3.related_audio.count() == 2
+
+        self.assert_caplog_text(caplog, "John Doe", self.site.slug, str(csv_file))
+        assert "Dry run mode enabled. No changes will be made." in caplog.text
+        assert (
+            f"[Dry Run] Would remove audio link {audio_ids[0].id} from entry {entry_ids[0].title}."
+            in caplog.text
+        )
+        assert (
+            f"[Dry Run] Would remove audio link {audio_ids[0].id} from entry {entry_ids[2].title}."
+            in caplog.text
+        )
+
+    def test_remove_speaker_links_no_csv(self, tmp_path, caplog):
+        entry_ids, audio_ids, person = self.setup_entries_with_audio("John Doe")
+        call_command(
+            "remove_speaker_links",
+            site_slug=self.site.slug,
+            speaker_name="John Doe",
+            output_dir=str(tmp_path),
+            dry_run=False,
+        )
+        assert DictionaryEntry.objects.count() == 3
+        entry1 = DictionaryEntry.objects.get(id=self.TEST_ENTRY_UUID_1)
+        assert entry1.related_audio.count() == 0
+        entry2 = DictionaryEntry.objects.get(id=self.TEST_ENTRY_UUID_2)
+        assert entry2.related_audio.count() == 1
+        entry3 = DictionaryEntry.objects.get(id=self.TEST_ENTRY_UUID_3)
+        assert entry3.related_audio.count() == 1
+        audio = Audio.objects.get(id=audio_ids[0])
+        assert person in audio.speakers.all()
+
+        self.assert_caplog_text(caplog, "John Doe", self.site.slug, None)
+        output_file = (
+            tmp_path
+            / f"remove_speaker_links_log_{self.site.slug}_{timezone.now().strftime('%Y%m%d_%H%M')}.csv"
+        )
+
+        expected_output_csv_content = (
+            "entry_id,entry_title,audio_id,audio_title,speaker_name,site\n"
+            f"{self.TEST_ENTRY_UUID_1},{entry1.title},{audio_ids[0]},{audio.title},John Doe,{self.site.slug}\n"
+            f"{self.TEST_ENTRY_UUID_3},{entry3.title},{audio_ids[0]},{audio.title},John Doe,{self.site.slug}\n"
+        )
+
+        assert output_file.exists()
+        with open(output_file) as f:
+            content = f.read()
+            assert content == expected_output_csv_content
+        assert f"Change log written to {output_file}." in caplog.text
+
+    def test_remove_speaker_links_with_csv(self, tmp_path, caplog):
+        entry_ids, audio_ids, person = self.setup_entries_with_audio("John Doe")
+        csv_file = tmp_path / "test_speaker_links.csv"
+        with open(csv_file, "w") as f:
+            f.write(self.get_entry_csv_content())
+
+        call_command(
+            "remove_speaker_links",
+            site_slug=self.site.slug,
+            speaker_name="John Doe",
+            output_dir=str(tmp_path),
+            csv_file=str(csv_file),
+            dry_run=False,
+        )
+        assert DictionaryEntry.objects.count() == 3
+        entry1 = DictionaryEntry.objects.get(id=self.TEST_ENTRY_UUID_1)
+        assert entry1.related_audio.count() == 0
+        entry2 = DictionaryEntry.objects.get(id=self.TEST_ENTRY_UUID_2)
+        assert entry2.related_audio.count() == 0
+        entry3 = DictionaryEntry.objects.get(id=self.TEST_ENTRY_UUID_3)
+        assert entry3.related_audio.count() == 0
+        audio = Audio.objects.get(id=audio_ids[0])
+        assert person in audio.speakers.all()
+
+        self.assert_caplog_text(caplog, "John Doe", self.site.slug, str(csv_file))
+        output_file = (
+            tmp_path
+            / f"remove_speaker_links_log_{self.site.slug}_{timezone.now().strftime('%Y%m%d_%H%M')}.csv"
+        )
+
+        expected_output_content = (
+            "entry_id,entry_title,audio_id,audio_title,speaker_name,site\n"
+            f"{self.TEST_ENTRY_UUID_1},{entry1.title},{audio_ids[0]},{audio.title},John Doe,{self.site.slug}\n"
+            f"{self.TEST_ENTRY_UUID_2},{entry2.title},{audio_ids[1]},{Audio.objects.get(id=audio_ids[1]).title},"
+            f"John Doe,{self.site.slug}\n"
+            f"{self.TEST_ENTRY_UUID_3},{entry3.title},{audio_ids[0]},{audio.title},John Doe,{self.site.slug}\n"
+            f"{self.TEST_ENTRY_UUID_3},{entry3.title},{audio_ids[1]},{Audio.objects.get(id=audio_ids[1]).title},"
+            f"John Doe,{self.site.slug}\n"
+        )
+        assert output_file.exists()
+        with open(output_file) as f:
+            content = f.read()
+            assert content == expected_output_content
+        assert f"Change log written to {output_file}." in caplog.text

--- a/firstvoices/backend/tests/test_commands/test_remove_speaker_links.py
+++ b/firstvoices/backend/tests/test_commands/test_remove_speaker_links.py
@@ -180,11 +180,11 @@ class TestRemoveSpeakerLinks:
         self.assert_caplog_text(caplog, "John Doe", self.site.slug, str(csv_file))
         assert "Dry run mode enabled. No changes will be made." in caplog.text
         assert (
-            f"[Dry Run] Would remove audio link {audio_ids[0].id} from entry {entry_ids[0].title}."
+            f"[Dry Run] Would remove audio link {audio_ids[0]} from entry {entry1.title}."
             in caplog.text
         )
         assert (
-            f"[Dry Run] Would remove audio link {audio_ids[0].id} from entry {entry_ids[2].title}."
+            f"[Dry Run] Would remove audio link {audio_ids[0]} from entry {entry3.title}."
             in caplog.text
         )
 

--- a/firstvoices/backend/tests/test_commands/test_remove_speaker_links.py
+++ b/firstvoices/backend/tests/test_commands/test_remove_speaker_links.py
@@ -64,11 +64,70 @@ class TestRemoveSpeakerLinks:
         if csv_file:
             assert f"Processing entries from CSV file: {csv_file}" in caplog.text
 
+    def test_remove_speaker_links_invalid_output_dir(self, caplog):
+        call_command(
+            "remove_speaker_links",
+            site_slug=self.site.slug,
+            speaker_name="John Doe",
+            output_dir="/invalid/dir",
+        )
+        assert (
+            "Output directory '/invalid/dir' does not exist or is not writeable."
+            in caplog.text
+        )
+
     def test_remove_speaker_links_invalid_slug(self, caplog):
         call_command(
             "remove_speaker_links", site_slug="invalid-site", speaker_name="John Doe"
         )
         assert "Site with slug 'invalid-site' does not exist." in caplog.text
+
+    def test_remove_speaker_links_invalid_csv(self, tmp_path, caplog):
+        csv_file = tmp_path / "non_existent_file.csv"
+        call_command(
+            "remove_speaker_links",
+            site_slug=self.site.slug,
+            speaker_name="John Doe",
+            csv_file=str(csv_file),
+        )
+        assert f"Error: CSV file '{csv_file}' not found." in caplog.text
+
+    def test_remove_speaker_links_csv_read_error(self, tmp_path, caplog):
+        csv_file = tmp_path / "invalid_format.csv"
+        with open(csv_file, "w") as f:
+            f.write("invalid_column\n123\n456\n")
+        call_command(
+            "remove_speaker_links",
+            site_slug=self.site.slug,
+            speaker_name="John Doe",
+            csv_file=str(csv_file),
+        )
+        assert f"Error reading CSV file '{csv_file}':" in caplog.text
+
+    def test_remove_speaker_links_missing_entries_in_csv(self, tmp_path, caplog):
+        csv_file = tmp_path / "test_speaker_links.csv"
+        with open(csv_file, "w") as f:
+            f.write(self.get_entry_csv_content())
+
+        call_command(
+            "remove_speaker_links",
+            site_slug=self.site.slug,
+            speaker_name="John Doe",
+            csv_file=str(csv_file),
+        )
+        assert DictionaryEntry.objects.count() == 0
+        assert (
+            f"DictionaryEntry with ID {self.TEST_ENTRY_UUID_1} not found in site {self.site.slug}."
+            in caplog.text
+        )
+        assert (
+            f"DictionaryEntry with ID {self.TEST_ENTRY_UUID_2} not found in site {self.site.slug}."
+            in caplog.text
+        )
+        assert (
+            f"DictionaryEntry with ID {self.TEST_ENTRY_UUID_3} not found in site {self.site.slug}."
+            in caplog.text
+        )
 
     def test_remove_speaker_links_dry_run_no_csv(self, caplog):
         entry_ids, audio_ids, _ = self.setup_entries_with_audio("John Doe")
@@ -89,11 +148,11 @@ class TestRemoveSpeakerLinks:
         self.assert_caplog_text(caplog, "John Doe", self.site.slug, None)
         assert "Dry run mode enabled. No changes will be made." in caplog.text
         assert (
-            f"[Dry Run] Would remove audio link {audio_ids[0].id} from entry {entry_ids[0].title}."
+            f"[Dry Run] Would remove audio link {audio_ids[0]} from entry {entry1.title}."
             in caplog.text
         )
         assert (
-            f"[Dry Run] Would remove audio link {audio_ids[0].id} from entry {entry_ids[2].title}."
+            f"[Dry Run] Would remove audio link {audio_ids[0]} from entry {entry3.title}."
             in caplog.text
         )
 
@@ -187,8 +246,11 @@ class TestRemoveSpeakerLinks:
         assert entry2.related_audio.count() == 0
         entry3 = DictionaryEntry.objects.get(id=self.TEST_ENTRY_UUID_3)
         assert entry3.related_audio.count() == 0
+
         audio = Audio.objects.get(id=audio_ids[0])
+        audio2 = Audio.objects.get(id=audio_ids[1])
         assert person in audio.speakers.all()
+        assert person in audio2.speakers.all()
 
         self.assert_caplog_text(caplog, "John Doe", self.site.slug, str(csv_file))
         output_file = (
@@ -204,6 +266,97 @@ class TestRemoveSpeakerLinks:
             f"{self.TEST_ENTRY_UUID_3},{entry3.title},{audio_ids[0]},{audio.title},John Doe,{self.site.slug}\n"
             f"{self.TEST_ENTRY_UUID_3},{entry3.title},{audio_ids[1]},{Audio.objects.get(id=audio_ids[1]).title},"
             f"John Doe,{self.site.slug}\n"
+        )
+        assert output_file.exists()
+        with open(output_file) as f:
+            content = f.read()
+            assert content == expected_output_content
+        assert f"Change log written to {output_file}." in caplog.text
+
+    def test_remove_speaker_links_typo_dry_run(self, caplog):
+        entry_ids, audio_ids, person = self.setup_entries_with_audio("John Doe")
+
+        typo_person = factories.PersonFactory(name="Jhon Doe", site=self.site)
+        typo_audio = factories.AudioFactory.create(site=self.site)
+        typo_audio.speakers.set([typo_person])
+        typo_audio.save()
+
+        entry1 = DictionaryEntry.objects.get(id=self.TEST_ENTRY_UUID_1)
+        entry1.related_audio.add(typo_audio)
+        entry1.save()
+
+        call_command(
+            "remove_speaker_links",
+            site_slug=self.site.slug,
+            speaker_name="John Doe",
+            typos="Jhon Doe, Jon Doe",
+            dry_run=True,
+        )
+
+        assert DictionaryEntry.objects.count() == 3
+        assert entry1.related_audio.count() == 2
+        entry2 = DictionaryEntry.objects.get(id=self.TEST_ENTRY_UUID_2)
+        assert entry2.related_audio.count() == 1
+        entry3 = DictionaryEntry.objects.get(id=self.TEST_ENTRY_UUID_3)
+        assert entry3.related_audio.count() == 2
+
+        self.assert_caplog_text(caplog, "John Doe", self.site.slug, None)
+        assert "Dry run mode enabled. No changes will be made." in caplog.text
+        assert (
+            f"[Dry Run] Would remove audio link {audio_ids[0]} from entry {entry1.title}."
+            in caplog.text
+        )
+        assert (
+            f"[Dry Run] Would remove audio link {audio_ids[0]} from entry {entry3.title}."
+            in caplog.text
+        )
+        assert (
+            f"[Dry Run] Would remove audio link {typo_audio.id} from entry {entry1.title}."
+            in caplog.text
+        )
+
+    def test_remove_speaker_links_typo(self, tmp_path, caplog):
+        entry_ids, audio_ids, person = self.setup_entries_with_audio("John Doe")
+
+        typo_person = factories.PersonFactory(name="Jhon Doe", site=self.site)
+        typo_audio = factories.AudioFactory.create(site=self.site)
+        typo_audio.speakers.set([typo_person])
+        typo_audio.save()
+
+        entry1 = DictionaryEntry.objects.get(id=self.TEST_ENTRY_UUID_1)
+        entry1.related_audio.add(typo_audio)
+        entry1.save()
+
+        call_command(
+            "remove_speaker_links",
+            site_slug=self.site.slug,
+            speaker_name="John Doe",
+            typos="Jhon Doe, Jon Doe",
+            output_dir=str(tmp_path),
+            dry_run=False,
+        )
+
+        assert DictionaryEntry.objects.count() == 3
+        assert entry1.related_audio.count() == 0
+        entry2 = DictionaryEntry.objects.get(id=self.TEST_ENTRY_UUID_2)
+        assert entry2.related_audio.count() == 1
+        entry3 = DictionaryEntry.objects.get(id=self.TEST_ENTRY_UUID_3)
+        assert entry3.related_audio.count() == 1
+
+        audio = Audio.objects.get(id=audio_ids[0])
+        assert person in audio.speakers.all()
+
+        self.assert_caplog_text(caplog, "John Doe", self.site.slug, None)
+        output_file = (
+            tmp_path
+            / f"remove_speaker_links_log_{self.site.slug}_{timezone.now().strftime('%Y%m%d_%H%M')}.csv"
+        )
+
+        expected_output_content = (
+            "entry_id,entry_title,audio_id,audio_title,speaker_name,site\n"
+            f"{self.TEST_ENTRY_UUID_1},{entry1.title},{audio_ids[0]},{audio.title},John Doe,{self.site.slug}\n"
+            f"{self.TEST_ENTRY_UUID_3},{entry3.title},{audio_ids[0]},{audio.title},John Doe,{self.site.slug}\n"
+            f"{self.TEST_ENTRY_UUID_1},{entry1.title},{typo_audio.id},{typo_audio.title},John Doe,{self.site.slug}\n"
         )
         assert output_file.exists()
         with open(output_file) as f:


### PR DESCRIPTION
### Description of Changes
- Adds a management command to remove audio links from entries when specific spekers are present
- Takes a speaker name, site slug, optional entries csv and an output location for the results csv
- Command can also be run as a dry run to see what audio would be unlinked

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~
- [x] ~~Signal and Task inventories have been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [x] Pull the branch and test locally

### Additional Notes
N/A
