### PR TITLE
FW-6438 Add related video links to batch import

### DIFF
--- a/firstvoices/backend/importing/importers.py
+++ b/firstvoices/backend/importing/importers.py
@@ -382,6 +382,7 @@ class DictionaryEntryImporter(BaseImporter):
         "include_in_games",
         "external_system",
         "external_system_entry_id",
+        "video_embed_links",
     ]
     supported_columns_multiple = [
         "translation",

--- a/firstvoices/backend/resources/base.py
+++ b/firstvoices/backend/resources/base.py
@@ -135,7 +135,7 @@ class RelatedMediaResourceMixin(resources.ModelResource):
         widget=widgets.ManyToManyWidget(Video, separator=",", field="id"),
     )
     related_video_links = fields.Field(
-        column_name="related_video_links",
+        column_name="video_embed_links",
         attribute="related_video_links",
         widget=ArrayOfStringsWidget(),
     )

--- a/firstvoices/backend/serializers/export_serializers.py
+++ b/firstvoices/backend/serializers/export_serializers.py
@@ -21,7 +21,12 @@ class DictionaryEntryExportResultSerializer(
     audio_ids = CommaSeparatedIDsField(source="related_audio", read_only=True)
     video_ids = CommaSeparatedIDsField(source="related_videos", read_only=True)
     image_ids = CommaSeparatedIDsField(source="related_images", read_only=True)
+    video_embed_links = serializers.SerializerMethodField()
     external_system = serializers.SlugRelatedField(slug_field="title", read_only=True)
+
+    @staticmethod
+    def get_video_embed_links(instance):
+        return instance.related_video_links
 
     class Meta:
         model = DictionaryEntry
@@ -40,7 +45,7 @@ class DictionaryEntryExportResultSerializer(
             "video_ids",
             "image_ids",
             "part_of_speech",
-            "related_video_links",
+            "video_embed_links",
             "related_dictionary_entries",
             "include_in_games",
             "include_on_kids_site",

--- a/firstvoices/backend/tests/factories/resources/import_job/invalid_video_embed_links.csv
+++ b/firstvoices/backend/tests/factories/resources/import_job/invalid_video_embed_links.csv
@@ -1,0 +1,4 @@
+TITLE,TYPE,VIDEO_EMBED_LINKS
+Invalid,word,"not,valid,links"
+Duplicate,phrase,"https://www.youtube.com/watch?v=N_Iyb0LkDUc,https://www.youtube.com/watch?v=N_Iyb0LkDUc"
+Both,word,"invalid,https://www.youtube.com/watch?v=N_Iyb0LkDUc,https://www.youtube.com/watch?v=N_Iyb0LkDUc"

--- a/firstvoices/backend/tests/factories/resources/import_job/video_embed_links.csv
+++ b/firstvoices/backend/tests/factories/resources/import_job/video_embed_links.csv
@@ -1,0 +1,4 @@
+TITLE,TYPE,VIDEO_EMBED_LINKS
+YouTube,word,https://www.youtube.com/watch?v=N_Iyb0LkDUc
+Vimeo,phrase,https://vimeo.com/226053498
+Both,word,"https://www.youtube.com/watch?v=N_Iyb0LkDUc,https://vimeo.com/226053498"

--- a/firstvoices/backend/tests/test_apis/base/base_media_test.py
+++ b/firstvoices/backend/tests/test_apis/base/base_media_test.py
@@ -18,7 +18,7 @@ from backend.tests.test_apis.base.base_uncontrolled_site_api import (
 from backend.tests.utils import get_sample_file
 
 VIMEO_VIDEO_LINK = "https://vimeo.com/226053498"
-YOUTUBE_VIDEO_LINK = "https://www.youtube.com/watch?v=abc123"
+YOUTUBE_VIDEO_LINK = "https://www.youtube.com/watch?v=N_Iyb0LkDUc"
 MOCK_EMBED_LINK = "https://mock_embed_link.com/"
 MOCK_THUMBNAIL_LINK = "https://mock_thumbnail_link.com/"
 

--- a/firstvoices/backend/tests/test_apis/test_export_api.py
+++ b/firstvoices/backend/tests/test_apis/test_export_api.py
@@ -166,10 +166,8 @@ class TestDictionaryExportAPI(
         csv_rows = self.get_csv_rows(response)
 
         first_row = csv_rows[0]
-        assert first_row["video_embed_link"] == dictionary_entry.related_video_links[0]
-        assert (
-            first_row["video_embed_link_2"] == dictionary_entry.related_video_links[1]
-        )
+        assert dictionary_entry.related_video_links[0] in first_row["video_embed_links"]
+        assert dictionary_entry.related_video_links[1] in first_row["video_embed_links"]
 
         assert str(audio_1.id) in first_row["audio_ids"]
         assert str(audio_2.id) in first_row["audio_ids"]

--- a/firstvoices/backend/views/dictionary_export_views.py
+++ b/firstvoices/backend/views/dictionary_export_views.py
@@ -62,7 +62,6 @@ class DictionaryEntryExportViewSet(SearchSiteEntriesViewSet):
         "acknowledgements": "acknowledgement",
         "alternate_spellings": "alternate_spelling",
         "pronunciations": "pronunciation",
-        "related_video_links": "video_embed_link",
         "related_dictionary_entries": "related_entry_id",
     }
 


### PR DESCRIPTION
### Description of Changes
- Adds import support for the `video_embed_links` field in batch import, containing a comma separated list of youtube or vimeo links
- Modifies the dictionary export such that related video links are exported to a single field: `video_embed_links`

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~
- [x] ~~Signal and Task inventories have been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
