### PR TITLE
FW-6851 Handle FileDoesNotExist in export job deletion

### DIFF
--- a/firstvoices/backend/tasks/export_job_tasks.py
+++ b/firstvoices/backend/tasks/export_job_tasks.py
@@ -258,9 +258,15 @@ def delete_old_exports(self):
             logger.info(
                 f"Deleting {old_exports.count()} old export jobs and their associated csv files."
             )
+
             for export in old_exports:
-                if export.export_csv:
-                    export.export_csv.delete()
+                if export.export_csv_id:
+                    try:
+                        export.export_csv.delete()
+                    except File.DoesNotExist:
+                        logger.warning(
+                            f"Missing export csv file for export job {export.id}. Skipping file deletion."
+                        )
                 export.delete()
         else:
             logger.info("No eligible export jobs found for deletion. No action taken.")

--- a/firstvoices/backend/tests/test_tasks/test_export_job_task.py
+++ b/firstvoices/backend/tests/test_tasks/test_export_job_task.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -61,3 +62,24 @@ class TestDeleteOldExportsTask:
             assert "Error deleting old exports: Mocked exception" in caplog.text
             assert ASYNC_TASK_START_TEMPLATE in caplog.text
             assert ASYNC_TASK_END_TEMPLATE in caplog.text
+
+    def test_delete_old_exports_no_export_csv(self, caplog):
+        export_job = factories.ExportJobFactory.create(
+            export_csv=None, export_csv_id=str(uuid.uuid4())
+        )
+        export_job.created = export_job.created - timedelta(days=8)
+        export_job.save()
+
+        result = delete_old_exports.apply()
+        assert result.state == "SUCCESS"
+        assert ExportJob.objects.count() == 0
+        assert File.objects.count() == 0
+        assert (
+            "Deleting 1 old export jobs and their associated csv files." in caplog.text
+        )
+        assert (
+            f"Missing export csv file for export job {export_job.id}. Skipping file deletion."
+            in caplog.text
+        )
+        assert ASYNC_TASK_START_TEMPLATE in caplog.text
+        assert ASYNC_TASK_END_TEMPLATE in caplog.text


### PR DESCRIPTION
### Description of Changes
Handles the File.DoesNotExist exceptions with a warning to prevent prod errors

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~
- [x] ~~Signal and Task inventories have been updated if applicable~~

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
