### PR TITLE
FW-7012: Fix exception handling when deleting old export jobs

### DIFF
--- a/firstvoices/backend/tasks/export_job_tasks.py
+++ b/firstvoices/backend/tasks/export_job_tasks.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from celery import current_task, shared_task
 from celery.utils.log import get_task_logger
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.base import ContentFile
 from django.utils import timezone
 
@@ -260,13 +261,16 @@ def delete_old_exports(self):
             )
 
             for export in old_exports:
-                if export.export_csv_id:
-                    try:
-                        export.export_csv.delete()
-                    except File.DoesNotExist:
-                        logger.warning(
-                            f"Missing export csv file for export job {export.id}. Skipping file deletion."
-                        )
+                try:
+                    export_csv = export.export_csv
+                except ObjectDoesNotExist:
+                    logger.warning(
+                        f"Missing export csv file for export job {export.id}. Skipping file deletion."
+                    )
+                    export_csv = None
+
+                if export_csv:
+                    export_csv.delete()
                 export.delete()
         else:
             logger.info("No eligible export jobs found for deletion. No action taken.")

--- a/firstvoices/backend/tests/test_tasks/test_export_job_task.py
+++ b/firstvoices/backend/tests/test_tasks/test_export_job_task.py
@@ -1,8 +1,8 @@
-import uuid
 from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
+from django.db import connection
 
 from backend.models.files import File
 from backend.models.jobs import ExportJob
@@ -63,12 +63,14 @@ class TestDeleteOldExportsTask:
             assert ASYNC_TASK_START_TEMPLATE in caplog.text
             assert ASYNC_TASK_END_TEMPLATE in caplog.text
 
-    def test_delete_old_exports_no_export_csv(self, caplog):
-        export_job = factories.ExportJobFactory.create(
-            export_csv=None, export_csv_id=str(uuid.uuid4())
-        )
+    def test_delete_old_exports_invalid_fk(self, caplog):
+        file = factories.FileFactory.create()
+        export_job = factories.ExportJobFactory.create(export_csv=file)
         export_job.created = export_job.created - timedelta(days=8)
         export_job.save()
+
+        with connection.cursor() as cursor:
+            cursor.execute("DELETE FROM backend_file WHERE id = %s", [file.id])
 
         result = delete_old_exports.apply()
         assert result.state == "SUCCESS"
@@ -81,5 +83,3 @@ class TestDeleteOldExportsTask:
             f"Missing export csv file for export job {export_job.id}. Skipping file deletion."
             in caplog.text
         )
-        assert ASYNC_TASK_START_TEMPLATE in caplog.text
-        assert ASYNC_TASK_END_TEMPLATE in caplog.text


### PR DESCRIPTION
### Description of Changes
- Updated method to check for invalid export_csv files while deleting old export jobs

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Insomnia workspace has been updated if applicable~
- ~Signal and Task inventories have been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
