### PR TITLE
FW-6969 Add handling for multiple alphabets to dictionary cleanup task

### DIFF
--- a/firstvoices/backend/tasks/dictionary_cleanup_tasks.py
+++ b/firstvoices/backend/tasks/dictionary_cleanup_tasks.py
@@ -1,5 +1,6 @@
 from celery import current_task, shared_task
 from celery.utils.log import get_task_logger
+from django.core.exceptions import ValidationError
 
 from backend.models import Alphabet, DictionaryCleanupJob, DictionaryEntry
 from backend.models.jobs import JobStatus
@@ -35,6 +36,20 @@ def cleanup_dictionary(job_instance_id: str):
     job.save()
 
     site = job.site
+
+    alphabets = Alphabet.objects.filter(site=site)
+    if alphabets.count() > 1:
+        cancelled_message = (
+            f"Multiple alphabets found for site {site.slug}. Please ensure sites only have one alphabet. "
+            f"Cancelling dictionary cleanup job."
+        )
+        job.status = JobStatus.CANCELLED
+        job.message = cancelled_message
+        job.save()
+        logger.info(ASYNC_TASK_END_TEMPLATE)
+
+        raise ValidationError(cancelled_message)
+
     alphabet = Alphabet.objects.get_or_create(site=site)[0]
     results = {}
 

--- a/firstvoices/backend/tests/test_tasks/test_dictionary_cleanup_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_dictionary_cleanup_tasks.py
@@ -2,6 +2,7 @@ import uuid
 from unittest.mock import patch
 
 import pytest
+from django.core.exceptions import ValidationError
 
 from backend.models import Alphabet, DictionaryCleanupJob, DictionaryEntry
 from backend.models.jobs import JobStatus
@@ -552,4 +553,27 @@ class TestDictionaryCleanupTasks(IgnoreTaskResultsMixin):
             in caplog.text
         )
 
+        self.assert_async_task_logs(job, caplog)
+
+    @pytest.mark.django_db
+    def test_multiple_alphabets_raises_exception(self, site, caplog):
+        factories.AlphabetFactory.create(site=site)
+        factories.AlphabetFactory.create(site=site)
+
+        job = factories.DictionaryCleanupJobFactory.create(site=site, is_preview=False)
+
+        with pytest.raises(ValidationError) as e:
+            cleanup_dictionary(job.id)
+
+        job.refresh_from_db()
+        assert str(e.value) == (
+            f"['Multiple alphabets found for site {site.slug}. Please ensure sites only have one alphabet. "
+            f"Cancelling dictionary cleanup job.']"
+        )
+
+        assert job.status == JobStatus.CANCELLED
+        assert job.message == (
+            f"Multiple alphabets found for site {site.slug}. Please ensure sites only have one alphabet. "
+            f"Cancelling dictionary cleanup job."
+        )
         self.assert_async_task_logs(job, caplog)


### PR DESCRIPTION
### Description of Changes
- Raises an exception and cancels the dictionary cleanup job if multiple alphabets are present on the site before a dictionary cleanup. This prevents cleanup operations from being stuck in progress and needing to be manually deleted via the shell

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~
- [x] ~~Signal and Task inventories have been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
