### PR TITLE
FW-6977 ensure users can only list export jobs they create

### DIFF
--- a/firstvoices/backend/models/jobs.py
+++ b/firstvoices/backend/models/jobs.py
@@ -89,7 +89,7 @@ class ExportJob(BaseJob):
         verbose_name = _("Export Job")
         verbose_name_plural = _("Export Jobs")
         rules_permissions = {
-            "view": predicates.is_at_least_assistant_or_super,
+            "view": predicates.can_view_self,
             "add": predicates.is_at_least_assistant_or_super,
             "change": predicates.is_at_least_assistant_or_super,
             "delete": predicates.is_at_least_assistant_or_super,

--- a/firstvoices/backend/permissions/filters/base.py
+++ b/firstvoices/backend/permissions/filters/base.py
@@ -43,6 +43,10 @@ def is_own_obj(user):
     return Q(user=user)
 
 
+def is_own_creator(created_by):
+    return Q(created_by=created_by)
+
+
 #
 # visibility-based filters
 #

--- a/firstvoices/backend/permissions/filters/view_models.py
+++ b/firstvoices/backend/permissions/filters/view_models.py
@@ -24,6 +24,13 @@ def can_view_membership_model(user):
     )
 
 
+# Export job model is visible to only the user who created the export job, and staff
+def can_view_self(user):
+    return base.is_at_least_staff_admin(user) | (
+        base.is_own_creator(user) & view.has_visible_site(user)
+    )
+
+
 # user can view an immersion label, if the user can view the related dictionary entry
 def can_view_immersion_label(user):
     return (

--- a/firstvoices/backend/permissions/predicates/base.py
+++ b/firstvoices/backend/permissions/predicates/base.py
@@ -63,6 +63,14 @@ def is_own_obj(user, obj):
     return user.id == obj.user.id
 
 
+@predicate
+def is_own_creator(created_by, obj):
+    """
+    Used for models that can only be seen by the user that created them.
+    """
+    return created_by.id == obj.created_by.id
+
+
 #
 # role-based predicates
 #

--- a/firstvoices/backend/permissions/predicates/view_models.py
+++ b/firstvoices/backend/permissions/predicates/view_models.py
@@ -25,6 +25,12 @@ can_view_user_info = Predicate(
     name="can_view_membership_model",
 )
 
+# Export job model is visible to only the user who created the export job, and staff
+can_view_self = Predicate(
+    (base.is_at_least_staff_admin | (base.is_own_creator & view.has_visible_site)),
+    name="can_view_self",
+)
+
 
 # user can view an immersion label, if the user can view the related dictionary entry
 @predicate

--- a/firstvoices/backend/tests/test_apis/test_export_job_api.py
+++ b/firstvoices/backend/tests/test_apis/test_export_job_api.py
@@ -68,6 +68,22 @@ class TestExportJobAPI(
         assert actual_response["message"] == expected_response["message"]
         assert actual_response["exportCsv"] == expected_response["exportCsv"]
 
+    @staticmethod
+    def setup_multiple_jobs_for_staff(site):
+        user1 = factories.UserFactory.create()
+        factories.MembershipFactory.create(
+            site=site, user=user1, role=Role.LANGUAGE_ADMIN
+        )
+        user2 = factories.UserFactory.create()
+        factories.MembershipFactory.create(
+            site=site, user=user2, role=Role.LANGUAGE_ADMIN
+        )
+
+        created_job1 = factories.ExportJobFactory.create(site=site, created_by=user1)
+        created_job2 = factories.ExportJobFactory.create(site=site, created_by=user2)
+
+        return created_job1, created_job2
+
     @pytest.mark.skip(reason="Export jobs have no eligible nulls.")
     def test_create_with_nulls_success_201(self):
         # Export jobs have no eligible nulls.
@@ -239,18 +255,7 @@ class TestExportJobAPI(
     @pytest.mark.parametrize("approle", [AppRole.STAFF, AppRole.SUPERADMIN])
     def test_staff_can_view_all_export_jobs(self, approle):
         site = factories.SiteFactory.create()
-
-        user1 = factories.UserFactory.create()
-        factories.MembershipFactory.create(
-            site=site, user=user1, role=Role.LANGUAGE_ADMIN
-        )
-        user2 = factories.UserFactory.create()
-        factories.MembershipFactory.create(
-            site=site, user=user2, role=Role.LANGUAGE_ADMIN
-        )
-
-        created_job1 = factories.ExportJobFactory.create(site=site, created_by=user1)
-        created_job2 = factories.ExportJobFactory.create(site=site, created_by=user2)
+        created_job1, created_job2 = self.setup_multiple_jobs_for_staff(site)
 
         staff_user = factories.get_app_admin(approle)
         self.client.force_authenticate(user=staff_user)
@@ -268,18 +273,7 @@ class TestExportJobAPI(
     @pytest.mark.parametrize("approle", [AppRole.STAFF, AppRole.SUPERADMIN])
     def test_staff_can_view_all_export_jobs_detail(self, approle):
         site = factories.SiteFactory.create()
-
-        user1 = factories.UserFactory.create()
-        factories.MembershipFactory.create(
-            site=site, user=user1, role=Role.LANGUAGE_ADMIN
-        )
-        user2 = factories.UserFactory.create()
-        factories.MembershipFactory.create(
-            site=site, user=user2, role=Role.LANGUAGE_ADMIN
-        )
-
-        created_job1 = factories.ExportJobFactory.create(site=site, created_by=user1)
-        created_job2 = factories.ExportJobFactory.create(site=site, created_by=user2)
+        created_job1, created_job2 = self.setup_multiple_jobs_for_staff(site)
 
         staff_user = factories.get_app_admin(approle)
         self.client.force_authenticate(user=staff_user)

--- a/firstvoices/backend/tests/test_apis/test_export_job_api.py
+++ b/firstvoices/backend/tests/test_apis/test_export_job_api.py
@@ -207,6 +207,35 @@ class TestExportJobAPI(
         assert response_data["results"][0]["id"] == str(created_job.id)
 
     @pytest.mark.django_db
+    @pytest.mark.parametrize("role", [Role.ASSISTANT, Role.EDITOR, Role.LANGUAGE_ADMIN])
+    def test_only_creating_user_can_view_export_job_detail(self, role):
+        site, user1 = factories.get_site_with_authenticated_member(
+            self.client, Visibility.PUBLIC, role
+        )
+        user2 = factories.UserFactory.create()
+        factories.MembershipFactory.create(site=site, user=user2, role=role)
+
+        created_job = factories.ExportJobFactory.create(site=site, created_by=user1)
+        created_job_2 = factories.ExportJobFactory.create(site=site, created_by=user2)
+
+        response = self.client.get(
+            self.get_detail_endpoint(
+                key=self.get_lookup_key(created_job), site_slug=site.slug
+            )
+        )
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+        assert response_data["id"] == str(created_job.id)
+
+        response = self.client.get(
+            self.get_detail_endpoint(
+                key=self.get_lookup_key(created_job_2), site_slug=site.slug
+            )
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.django_db
     @pytest.mark.parametrize("approle", [AppRole.STAFF, AppRole.SUPERADMIN])
     def test_staff_can_view_all_export_jobs(self, approle):
         site = factories.SiteFactory.create()
@@ -234,3 +263,36 @@ class TestExportJobAPI(
         result_id_list = [job["id"] for job in response_data["results"]]
         assert str(created_job1.id) in result_id_list
         assert str(created_job2.id) in result_id_list
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize("approle", [AppRole.STAFF, AppRole.SUPERADMIN])
+    def test_staff_can_view_all_export_jobs_detail(self, approle):
+        site = factories.SiteFactory.create()
+
+        user1 = factories.UserFactory.create()
+        factories.MembershipFactory.create(
+            site=site, user=user1, role=Role.LANGUAGE_ADMIN
+        )
+        user2 = factories.UserFactory.create()
+        factories.MembershipFactory.create(
+            site=site, user=user2, role=Role.LANGUAGE_ADMIN
+        )
+
+        created_job1 = factories.ExportJobFactory.create(site=site, created_by=user1)
+        created_job2 = factories.ExportJobFactory.create(site=site, created_by=user2)
+
+        staff_user = factories.get_app_admin(approle)
+        self.client.force_authenticate(user=staff_user)
+        response = self.client.get(
+            self.get_detail_endpoint(key=created_job1.id, site_slug=site.slug)
+        )
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+        assert response_data["id"] == str(created_job1.id)
+
+        response = self.client.get(
+            self.get_detail_endpoint(key=created_job2.id, site_slug=site.slug)
+        )
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+        assert response_data["id"] == str(created_job2.id)

--- a/firstvoices/backend/tests/test_apis/test_export_job_api.py
+++ b/firstvoices/backend/tests/test_apis/test_export_job_api.py
@@ -187,3 +187,50 @@ class TestExportJobAPI(
             == "pageSize: The maximum number of items per page is 7500. "
             "Please contact staff if you require more than 7500 items."
         )
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize("role", [Role.ASSISTANT, Role.EDITOR, Role.LANGUAGE_ADMIN])
+    def test_only_creating_user_can_view_export_job(self, role):
+        site, user1 = factories.get_site_with_authenticated_member(
+            self.client, Visibility.PUBLIC, role
+        )
+        user2 = factories.UserFactory.create()
+        factories.MembershipFactory.create(site=site, user=user2, role=role)
+
+        created_job = factories.ExportJobFactory.create(site=site, created_by=user1)
+        factories.ExportJobFactory.create(site=site, created_by=user2)
+        response = self.client.get(self.get_list_endpoint(site_slug=site.slug))
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+        assert response_data["count"] == 1
+        assert response_data["results"][0]["id"] == str(created_job.id)
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize("approle", [AppRole.STAFF, AppRole.SUPERADMIN])
+    def test_staff_can_view_all_export_jobs(self, approle):
+        site = factories.SiteFactory.create()
+
+        user1 = factories.UserFactory.create()
+        factories.MembershipFactory.create(
+            site=site, user=user1, role=Role.LANGUAGE_ADMIN
+        )
+        user2 = factories.UserFactory.create()
+        factories.MembershipFactory.create(
+            site=site, user=user2, role=Role.LANGUAGE_ADMIN
+        )
+
+        created_job1 = factories.ExportJobFactory.create(site=site, created_by=user1)
+        created_job2 = factories.ExportJobFactory.create(site=site, created_by=user2)
+
+        staff_user = factories.get_app_admin(approle)
+        self.client.force_authenticate(user=staff_user)
+
+        response = self.client.get(self.get_list_endpoint(site_slug=site.slug))
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+        assert response_data["count"] == 2
+
+        result_id_list = [job["id"] for job in response_data["results"]]
+        assert str(created_job1.id) in result_id_list
+        assert str(created_job2.id) in result_id_list


### PR DESCRIPTION
### Description of Changes
- Adds predicates and filters such that only the user who created the object and staff can view a specific model
- Applies the new predicate to ExportJob instances
- Adds tests for list view and detail view

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [ ] ~~Insomnia workspace has been updated if applicable~~
- [x] ~~Signal and Task inventories have been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
