### PR TITLE
FW-6988 export more than 10000 entries

### DIFF
--- a/firstvoices/backend/search/utils.py
+++ b/firstvoices/backend/search/utils.py
@@ -263,7 +263,7 @@ def get_search_response(search_query):
 
 
 def get_export_search_response(search_query, page_size):
-    # Modified get_serach_response using search_after for over 10000 results in dictionary exports
+    # Modified get_search_response using search_after for over 10000 results in dictionary exports
     try:
         all_hits = []
         search_after_point = None

--- a/firstvoices/backend/search/utils.py
+++ b/firstvoices/backend/search/utils.py
@@ -271,10 +271,15 @@ def get_export_search_response(search_query, page_size):
         # Set page_size to 10,000 (ES limit)
         effective_page_size = min(page_size, 10000)
 
+        # track how many entries have been gathered
+        total_page_size_count = page_size
+
         while True:
             # Apply search_after if we have a previous result
             if search_after_point is not None:
                 search_query = search_query.extra(search_after=search_after_point)
+
+            effective_page_size = min(effective_page_size, 10000)
 
             search_query = search_query.extra(size=effective_page_size)
 
@@ -295,7 +300,9 @@ def get_export_search_response(search_query, page_size):
             if len(all_hits) == page_size:
                 break
 
-            effective_page_size = page_size - len(hits)
+            # decrement from total page size
+            effective_page_size = total_page_size_count - len(hits)
+            total_page_size_count -= len(hits)
 
         return {
             "hits": {

--- a/firstvoices/backend/search/utils.py
+++ b/firstvoices/backend/search/utils.py
@@ -268,13 +268,18 @@ def get_export_search_response(search_query, page_size):
         all_hits = []
         search_after_point = None
 
+        # Set page_size to 10,000 (ES limit)
+        effective_page_size = min(page_size, 10000)
+
         while True:
             # Apply search_after if we have a previous result
             if search_after_point is not None:
                 search_query = search_query.extra(search_after=search_after_point)
 
+            search_query = search_query.extra(size=effective_page_size)
+
             response = search_query.execute()
-            hits = response.get("hits", {}).get("hits", [])
+            hits = response["hits"]["hits"]
 
             # If no more hits, break the loop
             if not hits:
@@ -284,10 +289,13 @@ def get_export_search_response(search_query, page_size):
 
             # Set the search_after point for the next iteration
             last_hit = hits[-1]
-            search_after_point = last_hit.get("sort", [])
+            search_after_point = last_hit["sort"]
 
-            if len(hits) < page_size:
+            # If we got fewer results than page_size, we've reached the end
+            if len(all_hits) == page_size:
                 break
+
+            effective_page_size = page_size - len(hits)
 
         return {
             "hits": {

--- a/firstvoices/backend/search/utils.py
+++ b/firstvoices/backend/search/utils.py
@@ -262,5 +262,42 @@ def get_search_response(search_query):
         raise ElasticSearchConnectionError()
 
 
+def get_export_search_response(search_query, page_size):
+    # Modified get_serach_response using search_after for over 10000 results in dictionary exports
+    try:
+        all_hits = []
+        search_after_point = None
+
+        while True:
+            # Apply search_after if we have a previous result
+            if search_after_point is not None:
+                search_query = search_query.extra(search_after=search_after_point)
+
+            response = search_query.execute()
+            hits = response.get("hits", {}).get("hits", [])
+
+            # If no more hits, break the loop
+            if not hits:
+                break
+
+            all_hits.extend(hits)
+
+            # Set the search_after point for the next iteration
+            last_hit = hits[-1]
+            search_after_point = last_hit.get("sort", [])
+
+            if len(hits) < page_size:
+                break
+
+        return {
+            "hits": {
+                "hits": all_hits,
+                "total": {"value": len(all_hits), "relation": "eq"},
+            }
+        }
+    except ConnectionError:
+        raise ElasticSearchConnectionError()
+
+
 def queryset_as_map(queryset):
     return {str(x.id): x for x in queryset}

--- a/firstvoices/backend/tasks/constants.py
+++ b/firstvoices/backend/tasks/constants.py
@@ -1,2 +1,4 @@
 ASYNC_TASK_START_TEMPLATE = "Task started. Additional info: %s."
 ASYNC_TASK_END_TEMPLATE = "Task ended."
+
+MAXIMUM_ENTRIES_PER_EXPORT_JOB = 50000

--- a/firstvoices/backend/tasks/export_job_tasks.py
+++ b/firstvoices/backend/tasks/export_job_tasks.py
@@ -16,7 +16,11 @@ from backend.search.queries.query_builder import (
     get_base_entries_sort_query,
     get_base_paginate_query,
 )
-from backend.search.utils import get_ids_by_type, get_search_response, queryset_as_map
+from backend.search.utils import (
+    get_export_search_response,
+    get_ids_by_type,
+    queryset_as_map,
+)
 from backend.serializers.export_serializers import DictionaryEntryExportSerializer
 from backend.tasks.constants import ASYNC_TASK_END_TEMPLATE, ASYNC_TASK_START_TEMPLATE
 from backend.utils.export_utils import convert_queryset_to_csv_content
@@ -140,7 +144,9 @@ def get_search_results(search_params, pagination_params):
         search_query, **search_params
     )  # sort_query
 
-    response = get_search_response(search_query)
+    response = get_export_search_response(
+        search_query, pagination_params.get("page_size")
+    )
     search_results = response["hits"]["hits"]
 
     data = hydrate(search_results, search_params["user"])

--- a/firstvoices/backend/tests/test_apis/test_export_job_api.py
+++ b/firstvoices/backend/tests/test_apis/test_export_job_api.py
@@ -4,6 +4,7 @@ import pytest
 
 from backend.models.constants import AppRole, Role, Visibility
 from backend.models.jobs import ExportJob, JobStatus
+from backend.tasks.constants import MAXIMUM_ENTRIES_PER_EXPORT_JOB
 from backend.tests import factories
 from backend.tests.test_apis.base.base_async_api_test import (
     AsyncWorkflowTestMixin,
@@ -192,7 +193,8 @@ class TestExportJobAPI(
         )
 
         post_response = self.client.post(
-            self.get_list_endpoint(site_slug=site.slug) + "?page=1&pageSize=7501",
+            self.get_list_endpoint(site_slug=site.slug)
+            + f"?page=1&pageSize={MAXIMUM_ENTRIES_PER_EXPORT_JOB + 1}",
             format="json",
         )
 
@@ -200,8 +202,8 @@ class TestExportJobAPI(
         response_data = json.loads(post_response.content)
         assert (
             response_data[0]
-            == "pageSize: The maximum number of items per page is 7500. "
-            "Please contact staff if you require more than 7500 items."
+            == f"pageSize: The maximum number of items per page is {MAXIMUM_ENTRIES_PER_EXPORT_JOB}. "
+            f"Please contact staff if you require more than {MAXIMUM_ENTRIES_PER_EXPORT_JOB} items."
         )
 
     @pytest.mark.django_db

--- a/firstvoices/backend/views/export_job_views.py
+++ b/firstvoices/backend/views/export_job_views.py
@@ -131,6 +131,7 @@ class ExportJobViewSet(
         "related_dictionary_entries": "related_entry_id",
     }
     started_statuses = [JobStatus.ACCEPTED, JobStatus.STARTED]
+    MAXIMUM_ENTRIES_PER_EXPORT = 50000
 
     def get_queryset(self):
         site = self.get_validated_site()
@@ -143,7 +144,9 @@ class ExportJobViewSet(
         search_params = get_site_entries_search_params(
             self.request, site, self.default_search_types, self.allowed_search_types
         )
-        pagination_params = get_pagination_params(self.request, self.paginator, 7500)
+        pagination_params = get_pagination_params(
+            self.request, self.paginator, self.MAXIMUM_ENTRIES_PER_EXPORT
+        )
 
         export_params = {**search_params, **pagination_params}
 

--- a/firstvoices/backend/views/export_job_views.py
+++ b/firstvoices/backend/views/export_job_views.py
@@ -14,6 +14,7 @@ from backend.search.constants import TYPE_PHRASE, TYPE_WORD
 from backend.search.utils import get_pagination_params, get_site_entries_search_params
 from backend.serializers.export_job_serializers import ExportJobSerializer
 from backend.serializers.export_serializers import DictionaryEntryExportSerializer
+from backend.tasks.constants import MAXIMUM_ENTRIES_PER_EXPORT_JOB
 from backend.tasks.export_job_tasks import generate_export_csv
 from backend.views import doc_strings
 from backend.views.api_doc_variables import id_parameter, site_slug_parameter
@@ -131,7 +132,6 @@ class ExportJobViewSet(
         "related_dictionary_entries": "related_entry_id",
     }
     started_statuses = [JobStatus.ACCEPTED, JobStatus.STARTED]
-    MAXIMUM_ENTRIES_PER_EXPORT = 50000
 
     def get_queryset(self):
         site = self.get_validated_site()
@@ -145,7 +145,7 @@ class ExportJobViewSet(
             self.request, site, self.default_search_types, self.allowed_search_types
         )
         pagination_params = get_pagination_params(
-            self.request, self.paginator, self.MAXIMUM_ENTRIES_PER_EXPORT
+            self.request, self.paginator, MAXIMUM_ENTRIES_PER_EXPORT_JOB
         )
 
         export_params = {**search_params, **pagination_params}


### PR DESCRIPTION
### Description of Changes
- Converts just the export job search retrieval to use `search_after` allowing for more than 10000 entries to be added to the export csv
- Updates new maximum export value to 50000 as we should have some limit on the number of entries, value can be adjusted via a constant

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~
- [x] ~~Signal and Task inventories have been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
