### PR TITLE
FW-7039 fix thumbnail race condition

### DIFF
--- a/firstvoices/backend/models/media.py
+++ b/firstvoices/backend/models/media.py
@@ -364,6 +364,14 @@ class ThumbnailMixin(models.Model):
 
     def save(self, generate_thumbnails=True, **kwargs):
         is_modifying_original = self._state.adding or self._is_updating_original()
+
+        if is_modifying_original and not self._state.adding:
+            # Prevent stale ids in python from being set as the ids on newly generated thumbnails
+            # _delete_related_media() deletes the thumbnails and SET_NULL removes the db foreign key
+            self.thumbnail_id = None
+            self.small_id = None
+            self.medium_id = None
+
         super().save(**kwargs)
 
         if generate_thumbnails and is_modifying_original:

--- a/firstvoices/backend/models/media.py
+++ b/firstvoices/backend/models/media.py
@@ -8,7 +8,7 @@ import rules
 from django.conf import settings
 from django.core.files.images import get_image_dimensions
 from django.core.files.uploadedfile import InMemoryUploadedFile
-from django.db import models
+from django.db import models, transaction
 from django.utils.translation import gettext as _
 from django_better_admin_arrayfield.models.fields import ArrayField
 from embed_video.fields import EmbedVideoField
@@ -376,8 +376,10 @@ class ThumbnailMixin(models.Model):
         raise NotImplementedError
 
     def _request_thumbnail_generation(self):
-        generate_media_thumbnails.apply_async(
-            (self._meta.model_name, self.id), link_error=link_error_handler.s()
+        transaction.on_commit(
+            lambda: generate_media_thumbnails.apply_async(
+                (self._meta.model_name, self.id), link_error=link_error_handler.s()
+            )
         )
 
     def _delete_related_media(self, instance):

--- a/firstvoices/backend/models/media.py
+++ b/firstvoices/backend/models/media.py
@@ -368,9 +368,9 @@ class ThumbnailMixin(models.Model):
         if is_modifying_original and not self._state.adding:
             # Prevent stale ids in python from being set as the ids on newly generated thumbnails
             # _delete_related_media() deletes the thumbnails and SET_NULL removes the db foreign key
-            self.thumbnail_id = None
-            self.small_id = None
-            self.medium_id = None
+            self.thumbnail = None
+            self.small = None
+            self.medium = None
 
         super().save(**kwargs)
 

--- a/firstvoices/backend/tests/test_models/test_media_models.py
+++ b/firstvoices/backend/tests/test_models/test_media_models.py
@@ -29,6 +29,7 @@ from backend.tests.test_apis.base.base_media_test import (
     VIMEO_VIDEO_LINK,
     YOUTUBE_VIDEO_LINK,
 )
+from backend.tests.utils import TransactionOnCommitMixin
 
 logger = logging.getLogger(__name__)
 
@@ -256,7 +257,7 @@ class TestThumbnailDimensions:
         ) < 0.1
 
 
-class ThumbnailTestMixin:
+class ThumbnailTestMixin(TransactionOnCommitMixin):
     image_sizes = None
     size_names = ["thumbnail", "small", "medium"]
     media_model = None
@@ -290,7 +291,10 @@ class ThumbnailTestMixin:
     @pytest.mark.django_db
     @pytest.mark.disable_thumbnail_mocks
     def test_related_file_removed_on_delete(self):
-        media_instance = self.create_media_model()
+        with self.capture_on_commit_callbacks(execute=True):
+            media_instance = self.create_media_model()
+
+        media_instance.refresh_from_db()
         related_id = media_instance.original.id
         related_image_ids = [
             media_instance.thumbnail.id,
@@ -311,13 +315,17 @@ class ThumbnailTestMixin:
     @pytest.mark.django_db
     @pytest.mark.disable_thumbnail_mocks
     def test_related_file_removed_on_update(self):
-        media_instance = self.create_media_model()
+        with self.capture_on_commit_callbacks(execute=True):
+            media_instance = self.create_media_model()
+
+        media_instance.refresh_from_db()
         related_id = media_instance.original.id
         related_image_ids = [
             media_instance.thumbnail.id,
             media_instance.small.id,
             media_instance.medium.id,
         ]
+
         assert self.file_model.objects.filter(pk=related_id).count() == 1
         for related_id in related_image_ids:
             assert ImageFile.objects.filter(pk=related_id).count() == 1
@@ -332,8 +340,10 @@ class ThumbnailTestMixin:
     @pytest.mark.django_db
     @pytest.mark.disable_thumbnail_mocks
     def test_thumbnail_paths_correct(self):
-        site, media_instance = self.create_site_and_instance()
+        with self.capture_on_commit_callbacks(execute=True):
+            site, media_instance = self.create_site_and_instance()
 
+        media_instance.refresh_from_db()
         for size_name in self.image_sizes:
             generated_image = getattr(media_instance, size_name)
             assert generated_image.content.file
@@ -399,7 +409,10 @@ class TestImageModel(ThumbnailTestMixin):
         original_file_exif = PILImage.open(original_file.content).getexif()
         assert original_file_exif.get(0x0112) == 6
 
-        image_instance = self.create_media_model(site=site, original=original_file)
+        with self.capture_on_commit_callbacks(execute=True):
+            image_instance = self.create_media_model(site=site, original=original_file)
+
+        image_instance.refresh_from_db()
         original_id = image_instance.original.id
         thumbnail_image_ids = [
             image_instance.thumbnail.id,

--- a/firstvoices/backend/tests/test_search_indexing/test_media_indexing.py
+++ b/firstvoices/backend/tests/test_search_indexing/test_media_indexing.py
@@ -93,7 +93,8 @@ class TestAudioDocumentManager(BaseMediaDocumentManagerTest):
 
         doc = self.manager.create_index_document(instance)
 
-        assert doc.speakers == [str(speaker1.id), str(speaker2.id)]
+        assert str(speaker1.id) in doc.speakers
+        assert str(speaker2.id) in doc.speakers
 
 
 class TestDocumentDocumentManager(BaseMediaDocumentManagerTest):

--- a/firstvoices/backend/tests/test_tasks/test_build_mtd.py
+++ b/firstvoices/backend/tests/test_tasks/test_build_mtd.py
@@ -13,10 +13,11 @@ from backend.tasks.mtd_export_tasks import (
 )
 from backend.tests import factories
 from backend.tests.test_tasks.base_task_test import IgnoreTaskResultsMixin
+from backend.tests.utils import TransactionOnCommitMixin
 from firstvoices.celery import link_error_handler
 
 
-class TestMTDIndexAndScoreTask(IgnoreTaskResultsMixin):
+class TestMTDIndexAndScoreTask(IgnoreTaskResultsMixin, TransactionOnCommitMixin):
     sample_entry_title = "title_one word"
     TASK = build_index_and_calculate_scores
 
@@ -102,46 +103,49 @@ class TestMTDIndexAndScoreTask(IgnoreTaskResultsMixin):
     @pytest.mark.disable_thumbnail_mocks
     def test_build_and_score(self, site, caplog):
         # Add some entries
-        speaker = factories.PersonFactory.create(site=site)
-        audio = factories.AudioFactory.create(site=site)
-        factories.AudioSpeakerFactory.create(audio=audio, speaker=speaker)
-        image = factories.ImageFactory.create(site=site)
-        video = factories.VideoFactory.create(site=site)
-        parent_category = factories.CategoryFactory.create(site=site)
-        child_category = factories.CategoryFactory.create(
-            site=site, parent=parent_category
-        )
-        entry_one = factories.DictionaryEntryFactory.create(
-            site=site,
-            visibility=Visibility.PUBLIC,
-            type=TypeOfDictionaryEntry.WORD,
-            title=self.sample_entry_title,
-            related_audio=[audio],
-            related_images=[image],
-            related_videos=[video],
-        )
-        factories.DictionaryEntryCategoryFactory.create(
-            category=parent_category, dictionary_entry=entry_one
-        )
-        factories.DictionaryEntryCategoryFactory.create(
-            category=child_category, dictionary_entry=entry_one
-        )
 
-        # entry_two
-        factories.DictionaryEntryFactory.create(
-            site=site,
-            visibility=Visibility.PUBLIC,
-            type=TypeOfDictionaryEntry.PHRASE,
-            title="title_two",
-        )
-        entry_three = factories.DictionaryEntryFactory.create(
-            site=site,
-            visibility=Visibility.PUBLIC,
-            type=TypeOfDictionaryEntry.PHRASE,
-            title="the word 'third' appears as the third word in this sentence",
-        )
+        with self.capture_on_commit_callbacks(execute=True):
+            speaker = factories.PersonFactory.create(site=site)
+            audio = factories.AudioFactory.create(site=site)
+            factories.AudioSpeakerFactory.create(audio=audio, speaker=speaker)
+            image = factories.ImageFactory.create(site=site)
+            video = factories.VideoFactory.create(site=site)
+            parent_category = factories.CategoryFactory.create(site=site)
+            child_category = factories.CategoryFactory.create(
+                site=site, parent=parent_category
+            )
+            entry_one = factories.DictionaryEntryFactory.create(
+                site=site,
+                visibility=Visibility.PUBLIC,
+                type=TypeOfDictionaryEntry.WORD,
+                title=self.sample_entry_title,
+                related_audio=[audio],
+                related_images=[image],
+                related_videos=[video],
+            )
+            factories.DictionaryEntryCategoryFactory.create(
+                category=parent_category, dictionary_entry=entry_one
+            )
+            factories.DictionaryEntryCategoryFactory.create(
+                category=child_category, dictionary_entry=entry_one
+            )
+
+            # entry_two
+            factories.DictionaryEntryFactory.create(
+                site=site,
+                visibility=Visibility.PUBLIC,
+                type=TypeOfDictionaryEntry.PHRASE,
+                title="title_two",
+            )
+            entry_three = factories.DictionaryEntryFactory.create(
+                site=site,
+                visibility=Visibility.PUBLIC,
+                type=TypeOfDictionaryEntry.PHRASE,
+                title="the word 'third' appears as the third word in this sentence",
+            )
         # Build and index
         job = MTDExportJob.objects.get(id=build_index_and_calculate_scores(site.slug))
+        job.refresh_from_db()
         result = job.export_result
         assert len(result["data"]) == 3
         assert result["data"][1]["word"] == self.sample_entry_title

--- a/firstvoices/backend/tests/test_tasks/test_media_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_media_tasks.py
@@ -15,9 +15,10 @@ from backend.tests.factories import (
     get_image_content,
 )
 from backend.tests.test_tasks.base_task_test import IgnoreTaskResultsMixin
+from backend.tests.utils import TransactionOnCommitMixin
 
 
-class TestThumbnailGeneration(IgnoreTaskResultsMixin):
+class TestThumbnailGeneration(IgnoreTaskResultsMixin, TransactionOnCommitMixin):
     TASK = generate_media_thumbnails
 
     def get_valid_task_args(self):
@@ -31,7 +32,8 @@ class TestThumbnailGeneration(IgnoreTaskResultsMixin):
     )
     def test_thumbnail_generation_started(self, model_factory, model, caplog):
         site = SiteFactory()
-        media_item = model_factory.create(site=site)
+        with self.capture_on_commit_callbacks(execute=True):
+            media_item = model_factory.create(site=site)
 
         assert (
             f"Task started. Additional info: "
@@ -69,11 +71,12 @@ class TestThumbnailGeneration(IgnoreTaskResultsMixin):
     @pytest.mark.parametrize("file_type", SUPPORTED_FILETYPES["image"])
     def test_thumbnail_generation_adds_white_background(self, file_type):
         site = SiteFactory()
-        image_file = ImageFileFactory.create(
-            content=get_image_content(file_type=file_type),
-            site=site,
-        )
-        image = ImageFactory.create(original=image_file, site=site)
+        with self.capture_on_commit_callbacks(execute=True):
+            image_file = ImageFileFactory.create(
+                content=get_image_content(file_type=file_type),
+                site=site,
+            )
+            image = ImageFactory.create(original=image_file, site=site)
 
         image.generate_resized_images()
         image.refresh_from_db()
@@ -89,7 +92,7 @@ class TestThumbnailGeneration(IgnoreTaskResultsMixin):
 
     @pytest.mark.django_db
     @pytest.mark.disable_thumbnail_mocks
-    def test_thumbail_generation_error(self, caplog):
+    def test_thumbnail_generation_error(self, caplog):
         site = SiteFactory()
         image = ImageFactory.create(site=site)
 
@@ -97,7 +100,7 @@ class TestThumbnailGeneration(IgnoreTaskResultsMixin):
             "PIL.Image.open",
             side_effect=Exception("test exception"),
         ):
-            image._request_thumbnail_generation()
+            generate_media_thumbnails("Image", image.id)
 
         assert "Error creating thumbnail for " in caplog.text
         assert "test exception" in caplog.text
@@ -116,9 +119,10 @@ class TestThumbnailGeneration(IgnoreTaskResultsMixin):
     @pytest.mark.disable_thumbnail_mocks
     def test_generate_resized_images_original_image_does_not_exist(self, caplog):
         site = SiteFactory()
-        image = ImageFactory.create(site=site)
-        image.original.delete()
-        image._request_thumbnail_generation()
+        with self.capture_on_commit_callbacks(execute=True):
+            image = ImageFactory.create(site=site)
+            image.original.delete()
+            image._request_thumbnail_generation()
 
         assert f"Thumbnail generation failed for image model {image.id}" in caplog.text
         assert "Error: Original image file not found" in caplog.text
@@ -128,9 +132,10 @@ class TestThumbnailGeneration(IgnoreTaskResultsMixin):
     @pytest.mark.disable_thumbnail_mocks
     def test_generate_resized_images_original_video_does_not_exist(self, caplog):
         site = SiteFactory()
-        video = VideoFactory.create(site=site)
-        video.original.delete()
-        video._request_thumbnail_generation()
+        with self.capture_on_commit_callbacks(execute=True):
+            video = VideoFactory.create(site=site)
+            video.original.delete()
+            video._request_thumbnail_generation()
 
         assert f"Thumbnail generation failed for video model {video.id}" in caplog.text
         assert "Error: Original video file not found" in caplog.text


### PR DESCRIPTION
### Description of Changes
- Adds transaction.on_commit to generate_media_thumbnails, as the call to create thumbnails was occasionally occurring before the Image instance had been fully created, preventing thumbnails from being properly generated
- Updates tests to handle new use of transaction.on_commit
- Fixes an issue where stale ids of deleted thumbnails could be attempted to be used as the ids for newly generated thumbnails

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~
- [x] ~~Signal and Task inventories have been updated if applicable~~

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [ ] ~~Pull the branch and test locally~~

### Additional Notes
N/A
