### PR TITLE
FW-7037 add page + pagesize limits to export and search

### DIFF
--- a/firstvoices/backend/search/constants.py
+++ b/firstvoices/backend/search/constants.py
@@ -70,6 +70,9 @@ UNKNOWN_CHARACTER_FLAG = "⚑"
 
 LENGTH_FILTER_MAX = DEFAULT_TITLE_LENGTH
 
+# Set maximum entries per search to 10000 to conform to the ES limit.
+MAXIMUM_ENTRIES_PER_SEARCH = 10000
+
 
 class SearchIndexEntryTypes(TextChoices):
     DICTIONARY_ENTRY = "dictionary_entry", _("dictionary_entry")

--- a/firstvoices/backend/search/utils.py
+++ b/firstvoices/backend/search/utils.py
@@ -198,6 +198,12 @@ def get_pagination_params(request, paginator, page_size_limit=-1):
             f"Please contact staff if you require more than {page_size_limit} items."
         )
 
+    if page_size * page > page_size_limit:
+        raise ValidationError(
+            f"The maximum number of results retrieved by this action is {page_size_limit}. "
+            f"Please contact staff if you require more than {page_size_limit} results."
+        )
+
     start = (page - 1) * page_size
 
     return {
@@ -262,8 +268,16 @@ def get_search_response(search_query):
         raise ElasticSearchConnectionError()
 
 
-def get_export_search_response(search_query, page_size):
+def get_export_search_response(search_query, pagination_params):
     # Modified get_search_response using search_after for over 10000 results in dictionary exports
+    # To prevent initial queries over 10000 always start from page 1, and skip until desired entries
+
+    page_size = pagination_params.get("page_size")
+    page = pagination_params.get("page")
+    skip_until = page * page_size if page > 1 else -1
+
+    search_query = search_query.extra(from_=0)
+
     try:
         all_hits = []
         search_after_point = None
@@ -290,7 +304,13 @@ def get_export_search_response(search_query, page_size):
             if not hits:
                 break
 
-            all_hits.extend(hits)
+            if skip_until > 0 and len(hits) < skip_until:
+                skip_until -= len(hits)
+            else:
+                all_hits.extend(hits)
+                # decrement from total page size
+                effective_page_size = total_page_size_count - len(hits)
+                total_page_size_count -= len(hits)
 
             # Set the search_after point for the next iteration
             last_hit = hits[-1]
@@ -299,10 +319,6 @@ def get_export_search_response(search_query, page_size):
             # If we got fewer results than page_size, we've reached the end
             if len(all_hits) == page_size:
                 break
-
-            # decrement from total page size
-            effective_page_size = total_page_size_count - len(hits)
-            total_page_size_count -= len(hits)
 
         return {
             "hits": {

--- a/firstvoices/backend/search/utils.py
+++ b/firstvoices/backend/search/utils.py
@@ -271,7 +271,6 @@ def get_search_response(search_query):
 def get_export_search_response(search_query, pagination_params):
     # Modified get_search_response using search_after for over 10000 results in dictionary exports
     page_size = pagination_params.get("page_size")
-
     skip_remaining = pagination_params.get("start")
     collect_remaining = page_size
 
@@ -279,43 +278,49 @@ def get_export_search_response(search_query, pagination_params):
         all_hits = []
         search_after_point = None
 
-        while True:
-            # Apply search_after if we have a previous result
-            if search_after_point is not None:
-                search_query = search_query.extra(search_after=search_after_point)
+        # Run query with point_in_time and tiebreakers
+        with search_query.point_in_time(keep_alive="5m") as search_query:
+            # Always start from 0 and skip to desired page using search_after
+            search_query = search_query.extra(**{"from": 0})
+            search_query = search_query.sort(*search_query._sort, "_shard_doc")
 
-            if skip_remaining > 0:
-                request_size = min(skip_remaining, 10000)
-            else:
-                request_size = min(collect_remaining, 10000)
+            while True:
+                # Apply search_after if we have a previous result
+                if search_after_point is not None:
+                    search_query = search_query.extra(search_after=search_after_point)
 
-            search_query = search_query.extra(size=request_size)
-            response = search_query.execute()
-            hits = response["hits"]["hits"]
+                if skip_remaining > 0:
+                    request_size = min(skip_remaining, 10000)
+                else:
+                    request_size = min(collect_remaining, 10000)
 
-            # If no more hits, break the loop
-            if not hits:
-                break
+                search_query = search_query.extra(size=request_size)
+                response = search_query.execute()
+                hits = response["hits"]["hits"]
 
-            if skip_remaining >= len(hits):
-                # Continue to skip
-                skip_remaining -= len(hits)
-            elif skip_remaining > 0:
-                # Skip some and collect the rest
-                hits = hits[skip_remaining:]
-                skip_remaining = 0
-                all_hits.extend(hits)
-                collect_remaining -= len(hits)
-            else:
-                # Collect hits
-                all_hits.extend(hits)
-                collect_remaining -= len(hits)
+                # If no more hits, break the loop
+                if not hits:
+                    break
 
-            last_hit = hits[-1]
-            search_after_point = last_hit["sort"]
+                if skip_remaining >= len(hits):
+                    # Continue to skip
+                    skip_remaining -= len(hits)
+                elif skip_remaining > 0:
+                    # Skip some and collect the rest
+                    hits = hits[skip_remaining:]
+                    skip_remaining = 0
+                    all_hits.extend(hits)
+                    collect_remaining -= len(hits)
+                else:
+                    # Collect hits
+                    all_hits.extend(hits)
+                    collect_remaining -= len(hits)
 
-            if collect_remaining <= 0:
-                break
+                last_hit = hits[-1]
+                search_after_point = last_hit["sort"]
+
+                if collect_remaining <= 0:
+                    break
 
         return {
             "hits": {

--- a/firstvoices/backend/search/utils.py
+++ b/firstvoices/backend/search/utils.py
@@ -270,33 +270,26 @@ def get_search_response(search_query):
 
 def get_export_search_response(search_query, pagination_params):
     # Modified get_search_response using search_after for over 10000 results in dictionary exports
-    # To prevent initial queries over 10000 always start from page 1, and skip until desired entries
-
     page_size = pagination_params.get("page_size")
-    page = pagination_params.get("page")
-    skip_until = page * page_size if page > 1 else -1
 
-    search_query = search_query.extra(from_=0)
+    skip_remaining = pagination_params.get("start")
+    collect_remaining = page_size
 
     try:
         all_hits = []
         search_after_point = None
-
-        # Set page_size to 10,000 (ES limit)
-        effective_page_size = min(page_size, 10000)
-
-        # track how many entries have been gathered
-        total_page_size_count = page_size
 
         while True:
             # Apply search_after if we have a previous result
             if search_after_point is not None:
                 search_query = search_query.extra(search_after=search_after_point)
 
-            effective_page_size = min(effective_page_size, 10000)
+            if skip_remaining > 0:
+                request_size = min(skip_remaining, 10000)
+            else:
+                request_size = min(collect_remaining, 10000)
 
-            search_query = search_query.extra(size=effective_page_size)
-
+            search_query = search_query.extra(size=request_size)
             response = search_query.execute()
             hits = response["hits"]["hits"]
 
@@ -304,26 +297,30 @@ def get_export_search_response(search_query, pagination_params):
             if not hits:
                 break
 
-            if skip_until > 0 and len(hits) < skip_until:
-                skip_until -= len(hits)
-            else:
+            if skip_remaining >= len(hits):
+                # Continue to skip
+                skip_remaining -= len(hits)
+            elif skip_remaining > 0:
+                # Skip some and collect the rest
+                hits = hits[skip_remaining:]
+                skip_remaining = 0
                 all_hits.extend(hits)
-                # decrement from total page size
-                effective_page_size = total_page_size_count - len(hits)
-                total_page_size_count -= len(hits)
+                collect_remaining -= len(hits)
+            else:
+                # Collect hits
+                all_hits.extend(hits)
+                collect_remaining -= len(hits)
 
-            # Set the search_after point for the next iteration
             last_hit = hits[-1]
             search_after_point = last_hit["sort"]
 
-            # If we got fewer results than page_size, we've reached the end
-            if len(all_hits) == page_size:
+            if collect_remaining <= 0:
                 break
 
         return {
             "hits": {
-                "hits": all_hits,
-                "total": {"value": len(all_hits), "relation": "eq"},
+                "hits": all_hits[:page_size],
+                "total": {"value": min(len(all_hits), page_size), "relation": "eq"},
             }
         }
     except ConnectionError:

--- a/firstvoices/backend/tasks/constants.py
+++ b/firstvoices/backend/tasks/constants.py
@@ -2,6 +2,3 @@ ASYNC_TASK_START_TEMPLATE = "Task started. Additional info: %s."
 ASYNC_TASK_END_TEMPLATE = "Task ended."
 
 MAXIMUM_ENTRIES_PER_EXPORT_JOB = 50000
-
-# Set maximum entries per search to 10000 to conform to the ES limit.
-MAXIMUM_ENTRIES_PER_SEARCH = 10000

--- a/firstvoices/backend/tasks/constants.py
+++ b/firstvoices/backend/tasks/constants.py
@@ -2,3 +2,6 @@ ASYNC_TASK_START_TEMPLATE = "Task started. Additional info: %s."
 ASYNC_TASK_END_TEMPLATE = "Task ended."
 
 MAXIMUM_ENTRIES_PER_EXPORT_JOB = 50000
+
+# Set maximum entries per search to 10000 to conform to the ES limit.
+MAXIMUM_ENTRIES_PER_SEARCH = 10000

--- a/firstvoices/backend/tasks/export_job_tasks.py
+++ b/firstvoices/backend/tasks/export_job_tasks.py
@@ -144,9 +144,7 @@ def get_search_results(search_params, pagination_params):
         search_query, **search_params
     )  # sort_query
 
-    response = get_export_search_response(
-        search_query, pagination_params.get("page_size")
-    )
+    response = get_export_search_response(search_query, pagination_params)
     search_results = response["hits"]["hits"]
 
     data = hydrate(search_results, search_params["user"])

--- a/firstvoices/backend/tests/test_apis/test_export_job_api.py
+++ b/firstvoices/backend/tests/test_apis/test_export_job_api.py
@@ -207,6 +207,26 @@ class TestExportJobAPI(
         )
 
     @pytest.mark.django_db
+    def test_export_job_page_and_page_size_maximum(self):
+        site, _ = factories.get_site_with_authenticated_member(
+            self.client, Visibility.PUBLIC, Role.LANGUAGE_ADMIN
+        )
+
+        post_response = self.client.post(
+            self.get_list_endpoint(site_slug=site.slug)
+            + f"?page=5&pageSize={MAXIMUM_ENTRIES_PER_EXPORT_JOB}",
+            format="json",
+        )
+
+        assert post_response.status_code == 400
+        response_data = json.loads(post_response.content)
+        assert (
+            response_data[0]
+            == f"The maximum number of results retrieved by this action is {MAXIMUM_ENTRIES_PER_EXPORT_JOB}. "
+            f"Please contact staff if you require more than {MAXIMUM_ENTRIES_PER_EXPORT_JOB} results."
+        )
+
+    @pytest.mark.django_db
     @pytest.mark.parametrize("role", [Role.ASSISTANT, Role.EDITOR, Role.LANGUAGE_ADMIN])
     def test_only_creating_user_can_view_export_job(self, role):
         site, user1 = factories.get_site_with_authenticated_member(

--- a/firstvoices/backend/tests/test_apis/test_search_apis/test_search_api.py
+++ b/firstvoices/backend/tests/test_apis/test_search_apis/test_search_api.py
@@ -6,6 +6,7 @@ from elasticsearch.exceptions import ConnectionError
 
 from backend.models.constants import AppRole, Visibility
 from backend.models.dictionary import TypeOfDictionaryEntry
+from backend.search.constants import MAXIMUM_ENTRIES_PER_SEARCH
 from backend.tests import factories
 from backend.tests.test_apis.base.base_media_test import (
     VIMEO_VIDEO_LINK,
@@ -416,3 +417,15 @@ class TestSearchAPI(
 
         assert len(response_data["results"]) == 0
         assert response_data["count"] == 0
+
+    def test_search_page_and_page_size_maximum(self):
+        response = self.client.get(
+            self.get_list_endpoint() + f"?page=2&pageSize={MAXIMUM_ENTRIES_PER_SEARCH}"
+        )
+        response_data = json.loads(response.content)
+        assert response.status_code == 400
+        assert (
+            response_data[0]
+            == f"The maximum number of results retrieved by this action is {MAXIMUM_ENTRIES_PER_SEARCH}. "
+            f"Please contact staff if you require more than {MAXIMUM_ENTRIES_PER_SEARCH} results."
+        )

--- a/firstvoices/backend/views/base_search_views.py
+++ b/firstvoices/backend/views/base_search_views.py
@@ -13,6 +13,7 @@ from backend.search.utils import (
     get_search_response,
     queryset_as_map,
 )
+from backend.tasks.constants import MAXIMUM_ENTRIES_PER_SEARCH
 
 
 class HydrateSerializeSearchResultsMixin:
@@ -174,7 +175,9 @@ class BaseSearchViewSet(viewsets.GenericViewSet, HydrateSerializeSearchResultsMi
         """
         Returns pagination parameters.
         """
-        return get_pagination_params(self.request, self.paginator)
+        return get_pagination_params(
+            self.request, self.paginator, page_size_limit=MAXIMUM_ENTRIES_PER_SEARCH
+        )
 
     def paginate_search_response(self, request, serialized_data, result_count):
         page = self.paginator.apply_search_pagination(

--- a/firstvoices/backend/views/base_search_views.py
+++ b/firstvoices/backend/views/base_search_views.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 
 from backend import models
 from backend.pagination import SearchPageNumberPagination
+from backend.search.constants import MAXIMUM_ENTRIES_PER_SEARCH
 from backend.search.queries.query_builder import get_base_paginate_query
 from backend.search.utils import (
     get_base_search_params,
@@ -13,7 +14,6 @@ from backend.search.utils import (
     get_search_response,
     queryset_as_map,
 )
-from backend.tasks.constants import MAXIMUM_ENTRIES_PER_SEARCH
 
 
 class HydrateSerializeSearchResultsMixin:


### PR DESCRIPTION
### Description of Changes
- Ensures users cannot bypass the results limits in search or export jobs via combining the `page` and `pageSize` params
- Updates `get_export_search_response` to be able to take `page` and `pageSize` combinations up to the set limit of 50000 entries

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~
- [x] ~~Signal and Task inventories have been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [x] Pull the branch and test locally

### Additional Notes
N/A
