### PR TITLE
FW-5325 N+1 queries fix

### DIFF
--- a/firstvoices/backend/views/base_views.py
+++ b/firstvoices/backend/views/base_views.py
@@ -138,6 +138,8 @@ class SiteContentViewSetMixin:
     Provides common methods for handling site content, usually for data models that use the ``BaseSiteContentModel``.
     """
 
+    _cached_site = None
+
     def get_site_slug(self):
         return self.kwargs["site_slug"]
 
@@ -150,6 +152,9 @@ class SiteContentViewSetMixin:
         return context
 
     def get_validated_site(self):
+        if self._cached_site is not None:
+            return self._cached_site
+
         site_slug = self.get_site_slug()
         sites = Site.objects.filter(slug=site_slug)
 
@@ -161,6 +166,7 @@ class SiteContentViewSetMixin:
         # Check permissions on the site first
         perm = Site.get_perm("view")
         if self.request.user.has_perm(perm, site):
+            self._cached_site = site
             return site
         else:
             raise PermissionDenied

--- a/firstvoices/backend/views/sites_views.py
+++ b/firstvoices/backend/views/sites_views.py
@@ -66,9 +66,15 @@ class SiteViewSet(FVPermissionViewSetMixin, ModelViewSet):
     Summary information about language sites.
     """
 
+    _cached_site = None
     http_method_names = ["get", "put", "patch"]
     lookup_field = "slug"
     serializer_class = SiteDetailWriteSerializer
+
+    def get_object(self):
+        if self._cached_site is None:
+            self._cached_site = super().get_object()
+        return self._cached_site
 
     def get_detail_queryset(self):
         sites = (


### PR DESCRIPTION
### Description of Changes
- Added site caching in `get_validated_site` as it was being called multiple times during the /search view and thus internally calling the mentioned method multiple times, which was making essentially duplicate SQL queries.
- Added site caching in `SiteViewSet`
- Targets N+1 query at: `/api/1.0/sites/{slug}/` and `/api/1.0/sites/{site_slug}/search/`.

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Insomnia workspace has been updated if applicable~
- ~Signal and Task inventories have been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
