### PR TITLE
FW-7035: Added media field to import-job serializer

### DIFF
--- a/firstvoices/backend/serializers/import_job_serializers.py
+++ b/firstvoices/backend/serializers/import_job_serializers.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+from pathlib import Path
 
 import chardet
 import tablib
@@ -157,3 +158,35 @@ class ImportJobSerializer(CreateSiteContentSerializerMixin, BaseJobSerializer):
                     ]
                 }
             )
+
+
+class ImportJobDetailSerializer(ImportJobSerializer):
+    media = serializers.SerializerMethodField()
+
+    def get_media(self, instance):
+        audio_and_docs = instance.file_set.all()
+        images = instance.imagefile_set.all()
+        videos = instance.videofile_set.all()
+
+        all_files = list(audio_and_docs) + list(images) + list(videos)
+
+        media_items = []
+
+        for file in all_files:
+            file_content = file.content
+            filename = Path(file_content.name).name
+
+            media_items.append(
+                {
+                    "id": file.id,
+                    "mimetype": file.mimetype,
+                    "size": file.size,
+                    "filename": filename,
+                }
+            )
+
+        return media_items
+
+    class Meta:
+        model = ImportJob
+        fields = ImportJobSerializer.Meta.fields + ("media",)

--- a/firstvoices/backend/serializers/import_job_serializers.py
+++ b/firstvoices/backend/serializers/import_job_serializers.py
@@ -185,6 +185,7 @@ class ImportJobDetailSerializer(ImportJobSerializer):
                 }
             )
 
+        media_items = sorted(media_items, key=lambda item: item["filename"])
         return media_items
 
     class Meta:

--- a/firstvoices/backend/serializers/update_job_serializers.py
+++ b/firstvoices/backend/serializers/update_job_serializers.py
@@ -1,6 +1,9 @@
 from rest_framework import serializers
 
-from backend.serializers.import_job_serializers import ImportJobSerializer
+from backend.serializers.import_job_serializers import (
+    ImportJobDetailSerializer,
+    ImportJobSerializer,
+)
 
 
 class UpdateJobSerializer(ImportJobSerializer):
@@ -14,3 +17,7 @@ class UpdateJobSerializer(ImportJobSerializer):
         field_kwargs["view_name"] = "api:updatejob-detail"
 
         return field_class, field_kwargs
+
+
+class UpdateJobDetailSerializer(UpdateJobSerializer, ImportJobDetailSerializer):
+    pass

--- a/firstvoices/backend/tests/test_apis/test_import_job_api.py
+++ b/firstvoices/backend/tests/test_apis/test_import_job_api.py
@@ -468,3 +468,46 @@ class TestImportEndpoints(
 
         assert str(import_job.id) in returned_job_ids
         assert str(update_job.id) not in returned_job_ids
+
+    def test_detail_includes_media_field(self):
+        site, user = factories.get_site_with_app_admin(
+            self.client, Visibility.PUBLIC, AppRole.SUPERADMIN
+        )
+        self.client.force_authenticate(user=user)
+
+        import_job = factories.ImportJobFactory.create(site=site)
+
+        # Add media files to the job
+        image = factories.ImageFileFactory(import_job=import_job)
+        video = factories.VideoFileFactory(import_job=import_job)
+        audio = factories.FileFactory(import_job=import_job, mimetype="audio/mpeg")
+        document = factories.FileFactory(
+            import_job=import_job, mimetype="application/pdf"
+        )
+
+        response = self.client.get(
+            self.get_detail_endpoint(
+                key=self.get_lookup_key(import_job), site_slug=site.slug
+            )
+        )
+
+        assert response.status_code == 200
+        response_data = json.loads(response.content)
+
+        assert "media" in response_data
+        media = response_data["media"]
+
+        assert len(media) == 4
+
+        returned_ids = [item["id"] for item in media]
+        assert str(image.id) in returned_ids
+        assert str(video.id) in returned_ids
+        assert str(audio.id) in returned_ids
+        assert str(document.id) in returned_ids
+
+        # Validate structure of media items
+        for item in media:
+            assert "id" in item
+            assert "mimetype" in item
+            assert "size" in item
+            assert "filename" in item

--- a/firstvoices/backend/tests/test_apis/test_import_job_api.py
+++ b/firstvoices/backend/tests/test_apis/test_import_job_api.py
@@ -53,6 +53,13 @@ class TestImportEndpoints(
             "failedRowsCsv": instance.failed_rows_csv,
         }
 
+    def get_expected_detail_response(self, instance, site):
+        expected_response = self.get_expected_response(instance, site)
+        return {
+            **expected_response,
+            "media": [],  # Empty since it's a method field tested separately
+        }
+
     def get_valid_data(self, site=None):
         return {
             "title": "Test Title",
@@ -475,7 +482,7 @@ class TestImportEndpoints(
         )
         self.client.force_authenticate(user=user)
 
-        import_job = factories.ImportJobFactory.create(site=site)
+        import_job = self.create_minimal_instance(site)
 
         # Add media files to the job
         image = factories.ImageFileFactory(import_job=import_job)

--- a/firstvoices/backend/views/import_job_views.py
+++ b/firstvoices/backend/views/import_job_views.py
@@ -9,7 +9,10 @@ from rest_framework.viewsets import ModelViewSet
 
 from backend.models import ImportJobMode
 from backend.models.import_jobs import ImportJob, JobStatus
-from backend.serializers.import_job_serializers import ImportJobSerializer
+from backend.serializers.import_job_serializers import (
+    ImportJobDetailSerializer,
+    ImportJobSerializer,
+)
 from backend.tasks.import_job_tasks import confirm_import_job, validate_import_job
 from backend.tasks.utils import verify_no_other_import_jobs_running
 from backend.views import doc_strings
@@ -152,6 +155,11 @@ class ImportJobViewSet(
         ).order_by(
             "-created"
         )  # permissions are applied by the base view
+
+    def get_serializer_class(self):
+        if self.action == "retrieve":
+            return ImportJobDetailSerializer
+        return ImportJobSerializer
 
     @action(detail=True, methods=["post"])
     def validate(self, request, site_slug=None, pk=None):

--- a/firstvoices/backend/views/update_job_views.py
+++ b/firstvoices/backend/views/update_job_views.py
@@ -8,7 +8,10 @@ from rest_framework.response import Response
 
 from backend.models.import_jobs import ImportJob, ImportJobMode, JobStatus
 from backend.serializers.import_job_serializers import ImportJobSerializer
-from backend.serializers.update_job_serializers import UpdateJobSerializer
+from backend.serializers.update_job_serializers import (
+    UpdateJobDetailSerializer,
+    UpdateJobSerializer,
+)
 from backend.tasks.update_job_tasks import confirm_update_job, validate_update_job
 from backend.tasks.utils import verify_no_other_import_jobs_running
 from backend.views import doc_strings
@@ -130,6 +133,11 @@ class UpdateJobViewSet(ImportJobViewSet):
 
     def perform_create(self, serializer):
         serializer.save(mode=ImportJobMode.UPDATE)
+
+    def get_serializer_class(self):
+        if self.action == "retrieve":
+            return UpdateJobDetailSerializer
+        return UpdateJobSerializer
 
     @action(detail=True, methods=["post"])
     def validate(self, request, site_slug=None, pk=None):


### PR DESCRIPTION
### Description of Changes
- Added `ImportJobDetailSerializer` with an additional media field which returns list of media objects.
- Added `ImportJobDetailSerializer` with the same functionality.

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Insomnia workspace has been updated if applicable~
- ~Signal and Task inventories have been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
