### PR TITLE
FW-5325: N+1 query fix in search APIs

### DIFF
--- a/firstvoices/backend/serializers/base_serializers.py
+++ b/firstvoices/backend/serializers/base_serializers.py
@@ -10,7 +10,6 @@ from rest_framework_nested.relations import NestedHyperlinkedIdentityField
 from backend.serializers.utils.context_utils import get_site_from_context
 
 from ..models import Membership, Site
-from ..models.app import AppMembership
 from ..models.constants import AppRole, Role, Visibility
 from . import fields
 from .fields import WritableVisibilityField
@@ -74,14 +73,9 @@ class HideEmailFieldsMixin:
         except Membership.DoesNotExist:
             membership = None
 
-        try:
-            app_role = AppMembership.objects.get(
-                user=user,
-            )
-        except AppMembership.DoesNotExist:
-            app_role = None
+        app_role = user.app_role_cached
+        is_not_staff = app_role < AppRole.STAFF
 
-        is_not_staff = app_role.role < AppRole.STAFF if app_role else True
         #  Hide email fields if the user is not staff and not an assistant or higher in site membership
         if is_not_staff and (not membership or membership.role < Role.ASSISTANT):
             self._remove_email_fields(data)

--- a/firstvoices/backend/serializers/base_serializers.py
+++ b/firstvoices/backend/serializers/base_serializers.py
@@ -68,10 +68,7 @@ class HideEmailFieldsMixin:
 
         site = instance.site
 
-        try:
-            membership = Membership.objects.get(user=user, site=site)
-        except Membership.DoesNotExist:
-            membership = None
+        membership = user.get_site_membership_cached(site)
 
         app_role = user.app_role_cached
         is_not_staff = app_role < AppRole.STAFF

--- a/firstvoices/backend/serializers/search_result_serializers.py
+++ b/firstvoices/backend/serializers/search_result_serializers.py
@@ -40,19 +40,32 @@ class SearchResultPrefetchMixin:
             Prefetch(
                 "related_audio",
                 queryset=Audio.objects.visible(user)
-                .select_related("original")
+                .select_related(
+                    "original",
+                    "created_by",
+                    "last_modified_by",
+                    "system_last_modified_by",
+                )
                 .prefetch_related("speakers"),
             ),
             Prefetch(
                 "related_images",
                 queryset=Image.objects.visible(user).select_related(
-                    "original", "small"
+                    "original",
+                    "small",
+                    "created_by",
+                    "last_modified_by",
+                    "system_last_modified_by",
                 ),
             ),
             Prefetch(
                 "related_videos",
                 queryset=Video.objects.visible(user).select_related(
-                    "original", "small"
+                    "original",
+                    "small",
+                    "created_by",
+                    "last_modified_by",
+                    "system_last_modified_by",
                 ),
             ),
         )

--- a/firstvoices/jwt_auth/models.py
+++ b/firstvoices/jwt_auth/models.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import AbstractUser
 from django.db import models
+from django.utils.functional import cached_property
 
 from .managers import UserManager
 
@@ -43,6 +44,11 @@ class User(AbstractUser):
     @property
     def natural_key(self):
         return (self.email,)
+
+    @cached_property
+    def app_role_cached(self):
+        membership = getattr(self, "app_role", None)
+        return membership.role if membership else -1
 
     class Meta:
         db_table = "user"

--- a/firstvoices/jwt_auth/models.py
+++ b/firstvoices/jwt_auth/models.py
@@ -34,6 +34,10 @@ class User(AbstractUser):
 
     password = models.CharField(null=True, blank=False, max_length=128)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._site_membership_cache = {}
+
     @property
     def username(self):
         return self.id
@@ -49,6 +53,19 @@ class User(AbstractUser):
     def app_role_cached(self):
         membership = getattr(self, "app_role", None)
         return membership.role if membership else -1
+
+    def get_site_membership_cached(self, site):
+        if site is None:
+            return None
+        key = str(site.pk)
+        if key not in self._site_membership_cache:
+            # Importing here to avoid circular imports issue
+            from backend.models import Membership
+
+            self._site_membership_cache[key] = Membership.objects.filter(
+                user=self, site=site
+            ).first()
+        return self._site_membership_cache[key]
 
     class Meta:
         db_table = "user"


### PR DESCRIPTION
### Description of Changes
- Added cached property for app membership to user model.
- Added cached field for site memberships to user model.
- Updated `select_related` to add user related fields to make queryset eager in search API. 

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Insomnia workspace has been updated if applicable~
- ~Signal and Task inventories have been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
