### PR TITLE
FW-7036 Ensure batch updates only require id and title

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         run: pip install --upgrade pyOpenSSL
       - name: Fix apt mirrors
         run: |
-          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/apt-mirrors.txt
       - name: Install ffmpeg
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
       - name: Run Pytest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
             sudo apt-get update
           fi
 
-          # Supply Chain Defense: Pin the exact ffmpeg package version
+          # Pin the exact ffmpeg package version
             sudo apt-get install -y --no-install-recommends ffmpeg=7:4.4.2-0ubuntu0.22.04.1 # Update the package version whenever runner is updated
       - name: Run Pytest
         working-directory: ./firstvoices

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,9 @@ jobs:
           if [ -f requirements.debug.txt ]; then pip install -r requirements.debug.txt; fi
       - name: Upgrade pyOpenSSL
         run: pip install --upgrade pyOpenSSL
+      - name: Fix apt mirrors
+        run: |
+          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
       - name: Install ffmpeg
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
       - name: Run Pytest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,11 +45,6 @@ jobs:
         run: pip install --upgrade pyOpenSSL
       - name: Install ffmpeg safely with retries and version lock
         run: |
-          # Temp
-          apt-cache policy ffmpeg
-
-          apt-cache madison ffmpeg
-
           # Network retry
           echo "Acquire::Retries \"5\";" | sudo tee /etc/apt/apt.conf.d/80-retries
 
@@ -62,7 +57,7 @@ jobs:
           fi
 
           # Supply Chain Defense: Pin the exact ffmpeg package version
-            sudo apt-get install -y --no-install-recommends ffmpeg=7:6.1.1-1ubuntu2 # Update the package version whenever runner is updated
+            sudo apt-get install -y --no-install-recommends ffmpeg=7:4.4.2-0ubuntu0.22.04.1 # Update the package version whenever runner is updated
       - name: Run Pytest
         working-directory: ./firstvoices
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,11 +43,21 @@ jobs:
           if [ -f requirements.debug.txt ]; then pip install -r requirements.debug.txt; fi
       - name: Upgrade pyOpenSSL
         run: pip install --upgrade pyOpenSSL
-      - name: Fix apt mirrors
+      - name: Install ffmpeg safely with retries and version lock
         run: |
-          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/apt-mirrors.txt
-      - name: Install ffmpeg
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+          # Network retry
+          echo "Acquire::Retries \"5\";" | sudo tee /etc/apt/apt.conf.d/80-retries
+
+          # Mirror fallback
+          if ! sudo apt-get update; then
+            echo "Azure mirror failed, switching to official Ubuntu HTTPS mirror..."
+            sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/apt-mirrors.txt
+            sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+            sudo apt-get update
+          fi
+
+          # Supply Chain Defense: Pin the exact ffmpeg package version
+            sudo apt-get install -y --no-install-recommends ffmpeg=7:6.1.1-1ubuntu2. # Update the package version whenever runner is updated
       - name: Run Pytest
         working-directory: ./firstvoices
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,11 @@ jobs:
         run: pip install --upgrade pyOpenSSL
       - name: Install ffmpeg safely with retries and version lock
         run: |
+          # Temp
+          apt-cache policy ffmpeg
+
+          apt-cache madison ffmpeg
+
           # Network retry
           echo "Acquire::Retries \"5\";" | sudo tee /etc/apt/apt.conf.d/80-retries
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
           fi
 
           # Supply Chain Defense: Pin the exact ffmpeg package version
-            sudo apt-get install -y --no-install-recommends ffmpeg=7:6.1.1-1ubuntu2. # Update the package version whenever runner is updated
+            sudo apt-get install -y --no-install-recommends ffmpeg=7:6.1.1-1ubuntu2 # Update the package version whenever runner is updated
       - name: Run Pytest
         working-directory: ./firstvoices
         env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -57,7 +57,7 @@ jobs:
           fi
 
           # Supply Chain Defense: Pin the exact ffmpeg package version
-            sudo apt-get install -y --no-install-recommends ffmpeg=7:6.1.1-1ubuntu2 # Update the package version whenever runner is updated
+            sudo apt-get install -y --no-install-recommends ffmpeg=7:4.4.2-0ubuntu0.22.04.1 # Update the package version whenever runner is updated
       - name: Start docker-compose
         run: |
           docker compose -f docker-compose.yml up -d

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,7 +45,7 @@ jobs:
           if [ -f requirements.debug.txt ]; then pip install -r requirements.debug.txt; fi
       - name: Fix apt mirrors
         run: |
-          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/apt-mirrors.txt
       - name: Install ffmpeg
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
       - name: Start docker-compose

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,6 +43,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.debug.txt ]; then pip install -r requirements.debug.txt; fi
+      - name: Fix apt mirrors
+        run: |
+          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
       - name: Install ffmpeg
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
       - name: Start docker-compose

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -56,7 +56,7 @@ jobs:
             sudo apt-get update
           fi
 
-          # Supply Chain Defense: Pin the exact ffmpeg package version
+          # Pin the exact ffmpeg package version
             sudo apt-get install -y --no-install-recommends ffmpeg=7:4.4.2-0ubuntu0.22.04.1 # Update the package version whenever runner is updated
       - name: Start docker-compose
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,11 +43,21 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.debug.txt ]; then pip install -r requirements.debug.txt; fi
-      - name: Fix apt mirrors
+      - name: Install ffmpeg safely with retries and version lock
         run: |
-          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/apt-mirrors.txt
-      - name: Install ffmpeg
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+          # Network retry
+          echo "Acquire::Retries \"5\";" | sudo tee /etc/apt/apt.conf.d/80-retries
+
+          # Mirror fallback
+          if ! sudo apt-get update; then
+            echo "Azure mirror failed, switching to official Ubuntu HTTPS mirror..."
+            sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/apt-mirrors.txt
+            sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+            sudo apt-get update
+          fi
+
+          # Supply Chain Defense: Pin the exact ffmpeg package version
+            sudo apt-get install -y --no-install-recommends ffmpeg=7:6.1.1-1ubuntu2. # Update the package version whenever runner is updated
       - name: Start docker-compose
         run: |
           docker compose -f docker-compose.yml up -d

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -57,7 +57,7 @@ jobs:
           fi
 
           # Supply Chain Defense: Pin the exact ffmpeg package version
-            sudo apt-get install -y --no-install-recommends ffmpeg=7:6.1.1-1ubuntu2. # Update the package version whenever runner is updated
+            sudo apt-get install -y --no-install-recommends ffmpeg=7:6.1.1-1ubuntu2 # Update the package version whenever runner is updated
       - name: Start docker-compose
         run: |
           docker compose -f docker-compose.yml up -d

--- a/firstvoices/backend/resources/dictionary.py
+++ b/firstvoices/backend/resources/dictionary.py
@@ -131,12 +131,13 @@ class DictionaryEntryResource(
             if not row.get("id"):
                 raise ImportError(f"Missing 'id' for update in row: {row}.")
 
-            # Skip missing types
+            # Skip invalid types
             if "type" in row and (
-                row.get("type") is None or str(row.get("type")).strip() == ""
+                str(row["type"]).strip().lower() not in TypeOfDictionaryEntry.values
+                and row["type"]
             ):
                 raise ImportError(
-                    f"Missing 'type' for update in row with id {row.get('id')}."
+                    f"Invalid 'type' for update in row with id {row.get('id')}."
                 )
 
             # Enforce visibility restrictions

--- a/firstvoices/backend/tasks/utils.py
+++ b/firstvoices/backend/tasks/utils.py
@@ -30,6 +30,8 @@ def verify_no_other_import_jobs_running(current_job):
     ).exclude(id=current_job.id)
 
     if len(existing_incomplete_jobs):
+        current_job.status = ImportJobStatus.FAILED
+        current_job.save()
         raise ValidationError(
             "There is at least 1 job on this site that is already running or queued to run soon. "
             "Please wait for it to finish before starting a new one."

--- a/firstvoices/backend/tests/factories/resources/update_job/invalid_dictionary_entry_updates.csv
+++ b/firstvoices/backend/tests/factories/resources/update_job/invalid_dictionary_entry_updates.csv
@@ -1,7 +1,6 @@
 ﻿id,title,type,visibility,category,include_in_games,include_on_kids_site,part_of_speech,Ignorable_comments_column
 ba93662a-e1bc-4c0b-8fa1-12b0bc108be1,Control,phrase,Team,Animals,FALSE,TRUE,Suffix,Valid entry for control
 768c920c-38a9-4aea-821a-e1c0739c00d4,Invalid type,xyz,Public,Animals,TRUE,FALSE,Adjective,invalid type
-67525f1e-2a55-40b6-b39c-cb708819f47c,Blank type,,Public,Animals,FALSE,TRUE,Adjective,blank type
 adcc9c74-3ab2-4a31-8063-5ba5007be507,Invalid vis,phrase,notAValidVis,Animals,FALSE,TRUE,Suffix,invalid visibility
 6398bfb3-7d4a-48ce-9286-0408ea183043,Invalid bool,phrase,Team,Animals,notBoolValue,TRUE,Adjective,invalid boolean value
 bc525519-77ef-4318-94a6-cd9fc85f8646,Invalid part,xyz,Public,Animals,TRUE,FALSE,invalid_part,invalid_part_of_speech

--- a/firstvoices/backend/tests/factories/resources/update_job/minimal.csv
+++ b/firstvoices/backend/tests/factories/resources/update_job/minimal.csv
@@ -1,3 +1,3 @@
-ID,TITLE,TYPE
-ba93662a-e1bc-4c0b-8fa1-12b0bc108be1,abc,word
-768c920c-38a9-4aea-821a-e1c0739c00d4,xyz,phrase
+ID,TITLE
+ba93662a-e1bc-4c0b-8fa1-12b0bc108be1,abc
+768c920c-38a9-4aea-821a-e1c0739c00d4,xyz

--- a/firstvoices/backend/tests/factories/resources/update_job/test_create_with_nulls.csv
+++ b/firstvoices/backend/tests/factories/resources/update_job/test_create_with_nulls.csv
@@ -1,3 +1,0 @@
-ID,TITLE,TYPE
-ba93662a-e1bc-4c0b-8fa1-12b0bc108be1,abc,word
-768c920c-38a9-4aea-821a-e1c0739c00d4,xyz,phrase

--- a/firstvoices/backend/tests/test_apis/test_import_job_api.py
+++ b/firstvoices/backend/tests/test_apis/test_import_job_api.py
@@ -82,6 +82,13 @@ class TestImportEndpoints(
             **data,
         }
 
+    @staticmethod
+    def assert_equivalent_filenames(expected_file_name, actual_file_name):
+        stem, ext = expected_file_name.rsplit(".", 1)
+        assert re.search(
+            rf"{re.escape(stem)}(_\w+)?\.{re.escape(ext)}", actual_file_name
+        )
+
     def assert_created_instance(self, pk, data):
         instance = ImportJob.objects.get(pk=pk)
         return self.assert_updated_instance(data, instance)
@@ -99,18 +106,12 @@ class TestImportEndpoints(
         assert expected_data["title"] == actual_instance.title
         expected_file_name = expected_data["data"].file.name.split("/")[-1]
         actual_file_name = actual_instance.data.content.file.name.split("/")[-1]
-        stem, ext = expected_file_name.rsplit(".", 1)
-        assert re.search(
-            rf"{re.escape(stem)}(_\w+)?\.{re.escape(ext)}", actual_file_name
-        )
+        self.assert_equivalent_filenames(expected_file_name, actual_file_name)
 
     def assert_update_response(self, expected_data, actual_response):
         expected_file_name = expected_data["data"].file.name.split("/")[-1]
         actual_file_name = actual_response["data"]["path"].split("/")[-1]
-        stem, ext = expected_file_name.rsplit(".", 1)
-        assert re.search(
-            rf"{re.escape(stem)}(_\w+)?\.{re.escape(ext)}", actual_file_name
-        )
+        self.assert_equivalent_filenames(expected_file_name, actual_file_name)
 
     def test_invalid_dimensions(self):
         site, _ = factories.get_site_with_app_admin(self.client, Visibility.PUBLIC)

--- a/firstvoices/backend/tests/test_apis/test_import_job_api.py
+++ b/firstvoices/backend/tests/test_apis/test_import_job_api.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 import pytest
 
@@ -98,12 +99,18 @@ class TestImportEndpoints(
         assert expected_data["title"] == actual_instance.title
         expected_file_name = expected_data["data"].file.name.split("/")[-1]
         actual_file_name = actual_instance.data.content.file.name.split("/")[-1]
-        assert expected_file_name == actual_file_name
+        stem, ext = expected_file_name.rsplit(".", 1)
+        assert re.search(
+            rf"{re.escape(stem)}(_\w+)?\.{re.escape(ext)}", actual_file_name
+        )
 
     def assert_update_response(self, expected_data, actual_response):
         expected_file_name = expected_data["data"].file.name.split("/")[-1]
         actual_file_name = actual_response["data"]["path"].split("/")[-1]
-        assert expected_file_name == actual_file_name
+        stem, ext = expected_file_name.rsplit(".", 1)
+        assert re.search(
+            rf"{re.escape(stem)}(_\w+)?\.{re.escape(ext)}", actual_file_name
+        )
 
     def test_invalid_dimensions(self):
         site, _ = factories.get_site_with_app_admin(self.client, Visibility.PUBLIC)

--- a/firstvoices/backend/tests/test_apis/test_update_job_api.py
+++ b/firstvoices/backend/tests/test_apis/test_update_job_api.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 import pytest
 
@@ -57,9 +58,7 @@ class TestUpdateEndpoints(TestImportEndpoints):
     def get_valid_data_with_nulls(self, site=None):
         return {
             "title": "Update Job",
-            "data": get_sample_file(
-                "update_job/test_create_with_nulls.csv", "text/csv"
-            ),
+            "data": get_sample_file("update_job/minimal.csv", "text/csv"),
             "mode": "update",
         }
 
@@ -86,12 +85,18 @@ class TestUpdateEndpoints(TestImportEndpoints):
         assert expected_data["title"] == actual_instance.title
         expected_file_name = expected_data["data"].file.name.split("/")[-1]
         actual_file_name = actual_instance.data.content.file.name.split("/")[-1]
-        assert expected_file_name == actual_file_name
+        stem, ext = expected_file_name.rsplit(".", 1)
+        assert re.search(
+            rf"{re.escape(stem)}(_\w+)?\.{re.escape(ext)}", actual_file_name
+        )
 
     def assert_update_response(self, expected_data, actual_response):
         expected_file_name = expected_data["data"].file.name.split("/")[-1]
         actual_file_name = actual_response["data"]["path"].split("/")[-1]
-        assert expected_file_name == actual_file_name
+        stem, ext = expected_file_name.rsplit(".", 1)
+        assert re.search(
+            rf"{re.escape(stem)}(_\w+)?\.{re.escape(ext)}", actual_file_name
+        )
 
     @pytest.mark.skip(
         reason="Update job API does not have eligible optional charfields."

--- a/firstvoices/backend/tests/test_apis/test_update_job_api.py
+++ b/firstvoices/backend/tests/test_apis/test_update_job_api.py
@@ -1,5 +1,4 @@
 import json
-import re
 
 import pytest
 
@@ -85,18 +84,12 @@ class TestUpdateEndpoints(TestImportEndpoints):
         assert expected_data["title"] == actual_instance.title
         expected_file_name = expected_data["data"].file.name.split("/")[-1]
         actual_file_name = actual_instance.data.content.file.name.split("/")[-1]
-        stem, ext = expected_file_name.rsplit(".", 1)
-        assert re.search(
-            rf"{re.escape(stem)}(_\w+)?\.{re.escape(ext)}", actual_file_name
-        )
+        self.assert_equivalent_filenames(expected_file_name, actual_file_name)
 
     def assert_update_response(self, expected_data, actual_response):
         expected_file_name = expected_data["data"].file.name.split("/")[-1]
         actual_file_name = actual_response["data"]["path"].split("/")[-1]
-        stem, ext = expected_file_name.rsplit(".", 1)
-        assert re.search(
-            rf"{re.escape(stem)}(_\w+)?\.{re.escape(ext)}", actual_file_name
-        )
+        self.assert_equivalent_filenames(expected_file_name, actual_file_name)
 
     @pytest.mark.skip(
         reason="Update job API does not have eligible optional charfields."

--- a/firstvoices/backend/tests/test_tasks/test_update_job_tasks.py
+++ b/firstvoices/backend/tests/test_tasks/test_update_job_tasks.py
@@ -220,8 +220,8 @@ class TestBulkUpdateDryRun(BatchRelatedMediaMixin):
 
         assert update_job.validation_status == JobStatus.COMPLETE
         assert update_job.validation_report.updated_rows == 1
-        assert update_job.validation_report.error_rows == 9
-        assert error_rows_numbers == [2, 3, 4, 5, 6, 7, 8, 9, 10]
+        assert update_job.validation_report.error_rows == 8
+        assert error_rows_numbers == [2, 3, 4, 5, 6, 7, 8, 9]
 
     def test_dry_run_failed(self, caplog):
         self.create_dictionary_entries(TEST_ENTRY_IDS)
@@ -265,9 +265,9 @@ class TestBulkUpdateDryRun(BatchRelatedMediaMixin):
             format="csv",
         )
 
-        assert update_job.validation_report.error_rows == 9
-        assert error_rows_numbers == [2, 3, 4, 5, 6, 7, 8, 9, 10]
-        assert len(failed_rows_csv_table) == 9
+        assert update_job.validation_report.error_rows == 8
+        assert error_rows_numbers == [2, 3, 4, 5, 6, 7, 8, 9]
+        assert len(failed_rows_csv_table) == 8
 
         for i in range(0, len(error_rows_numbers)):
             input_index = (
@@ -565,11 +565,9 @@ class TestBulkUpdate(IgnoreTaskResultsMixin, BatchRelatedMediaMixin):
 
         entry1 = DictionaryEntry.objects.get(id=TEST_ENTRY_IDS[0])
         assert entry1.title == "abc"
-        assert entry1.type == "word"
 
         entry2 = DictionaryEntry.objects.get(id=TEST_ENTRY_IDS[1])
         assert entry2.title == "xyz"
-        assert entry2.type == "phrase"
 
     def test_all_columns_update(self):
         self.create_dictionary_entries(TEST_ENTRY_IDS)
@@ -819,12 +817,12 @@ class TestBulkUpdate(IgnoreTaskResultsMixin, BatchRelatedMediaMixin):
 
         entry1 = DictionaryEntry.objects.get(id=TEST_ENTRY_IDS[0])
         assert entry1.title == "abc"
-        assert entry1.type == "word"
+        assert entry1.type == "word"  # unchanged
         assert entry1.visibility == Visibility.PUBLIC  # unchanged
 
         entry2 = DictionaryEntry.objects.get(id=TEST_ENTRY_IDS[1])
         assert entry2.title == "xyz"
-        assert entry2.type == "phrase"
+        assert entry2.type == "word"  # unchanged
         assert entry2.visibility == Visibility.MEMBERS  # unchanged
 
     def test_update_only_one_column(self):


### PR DESCRIPTION
### Description of Changes
- Ensures update jobs can be run with only the "id" and "title" columns required
- Bonus: fixes flaky update job tests based on duplicate filenames
- Bonus: Adds a FAILED jobstatus to the verify_no_other_import_jobs_running() function
- Fixes ffmpeg install sources

### Checklist
- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [x] ~~Admin Panel has been updated if models have been added or modified~~
- [x] ~~Migrations have been updated and committed if applicable~~
- [x] ~~Insomnia workspace has been updated if applicable~~
- [x] ~~Signal and Task inventories have been updated if applicable~~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- [ ] Pull the branch and test locally

### Additional Notes
N/A
