### PR TITLE
Fw 5083, 5062 investigate and fix validation errors that return a 500 internal server error rather than 400 bad request

### DIFF
--- a/firstvoices/backend/serializers/category_serializers.py
+++ b/firstvoices/backend/serializers/category_serializers.py
@@ -49,6 +49,10 @@ class ParentCategoryFlatListSerializer(ChildCategoryListSerializer):
 class CategoryDetailSerializer(
     WritableSiteContentSerializer,
 ):
+    title = serializers.CharField(
+        max_length=CATEGORY_POS_MAX_TITLE_LENGTH,
+        validators=[UniqueForSite(queryset=Category.objects.all())],
+    )
     description = serializers.CharField(
         required=False, allow_blank=True, allow_null=True, default=""
     )

--- a/firstvoices/backend/serializers/story_serializers.py
+++ b/firstvoices/backend/serializers/story_serializers.py
@@ -77,6 +77,20 @@ class StoryPageDetailSerializer(
             )
         )
 
+    def validate_ordering(self, value):
+        """validate that the page ordering number is unique within the parent story"""
+        story = get_story_from_context(self)
+        if story:
+            queryset = StoryPage.objects.filter(story=story, ordering=value)
+            if self.instance:
+                queryset = queryset.exclude(pk=self.instance.pk)
+
+            if queryset.exists():
+                raise serializers.ValidationError(
+                    "A page with this ordering number already exists in this story."
+                )
+        return value
+
     def validate(self, attrs):
         """use the visibility from the parent story for all permission checks"""
         story = get_story_from_context(self)

--- a/firstvoices/backend/tests/test_serializers.py
+++ b/firstvoices/backend/tests/test_serializers.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 from backend.models import Category
 from backend.serializers import validators
 from backend.serializers.category_serializers import CategoryDetailSerializer
+from backend.serializers.story_serializers import StoryPageDetailSerializer
 from backend.tests import factories
 
 
@@ -168,5 +169,70 @@ class TestCategoryDetailSerializerValidation:
         }
         context = {"site": site_b}
         serializer = CategoryDetailSerializer(data=cross_site_payload, context=context)
+
+        assert serializer.is_valid()
+
+
+class MockRequest:
+    def __init__(self, user, data=None):
+        self.user = user
+        self.data = data or {}
+
+
+class TestStoryPageDetailSerializerValidation:
+    @pytest.mark.django_db
+    def test_duplicate_page_ordering_on_same_story_fails(self):
+        """
+        Verify StoryPageDetailSerializer blocks duplicate page order numbers on the same story.
+        """
+        story = factories.StoryFactory.create()
+        factories.StoryPageFactory.create(ordering=0, story=story, site=story.site)
+
+        duplicate_page_payload = {
+            "text": "This is page two, but using order '0'!",
+            "ordering": 0,
+        }
+
+        mock_user = factories.UserFactory.create()
+        request = MockRequest(user=mock_user, data=duplicate_page_payload)
+
+        context = {
+            "site": story.site,
+            "story": story,
+            "request": request,
+        }
+        serializer = StoryPageDetailSerializer(
+            data=duplicate_page_payload, context=context
+        )
+
+        assert not serializer.is_valid()
+        assert "ordering" in serializer.errors
+        assert serializer.errors["ordering"] == [
+            "A page with this ordering number already exists in this story."
+        ]
+
+    @pytest.mark.django_db
+    def test_same_page_ordering_on_different_stories_succeeds(self):
+        """
+        Verify that separate stories are allowed to have pages with identical order integers.
+        """
+        story_a = factories.StoryFactory.create()
+        factories.StoryPageFactory.create(ordering=0, story=story_a, site=story_a.site)
+
+        story_b = factories.StoryFactory.create(site=story_a.site)
+        valid_page_payload = {
+            "text": "Page one of our second story book",
+            "ordering": 0,
+        }
+
+        mock_user = factories.UserFactory.create()
+        request = MockRequest(user=mock_user, data=valid_page_payload)
+
+        context = {
+            "site": story_b.site,
+            "story": story_b,
+            "request": request,
+        }
+        serializer = StoryPageDetailSerializer(data=valid_page_payload, context=context)
 
         assert serializer.is_valid()

--- a/firstvoices/backend/tests/test_serializers.py
+++ b/firstvoices/backend/tests/test_serializers.py
@@ -132,28 +132,6 @@ class TestHasNoParentValidator:
 
 class TestCategoryDetailSerializerValidation:
     @pytest.mark.django_db
-    def test_duplicate_category_title_on_same_site_fails(self):
-        """
-        Verify CategoryDetailSerializer safely catches duplicate titles on the same site,
-        turning what used to be a database 500 integrity error into a clean 400 validation error.
-        """
-        unique_title = "UniqueTestCategoryXYZ"
-        site = factories.SiteFactory.create()
-        factories.CategoryFactory.create(title=unique_title, site=site)
-
-        duplicate_payload = {
-            "title": unique_title,
-            "description": "A different description, but a duplicated name!",
-        }
-        context = {"site": site}
-        serializer = CategoryDetailSerializer(data=duplicate_payload, context=context)
-
-        assert not serializer.is_valid()
-        assert serializer.errors == {
-            "title": ["This field must be unique within the site."]
-        }
-
-    @pytest.mark.django_db
     def test_same_category_title_on_different_sites_succeeds(self):
         """
         Verify that having an identical category title across different sites is perfectly

--- a/firstvoices/backend/tests/test_serializers.py
+++ b/firstvoices/backend/tests/test_serializers.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 
 from backend.models import Category
 from backend.serializers import validators
+from backend.serializers.category_serializers import CategoryDetailSerializer
 from backend.tests import factories
 
 
@@ -126,3 +127,46 @@ class TestHasNoParentValidator:
         serializer = HasNoParentSerializer(data=data, context=context)
         assert not serializer.is_valid()
         assert serializer.errors == {"parent": ["Must not have a parent."]}
+
+
+class TestCategoryDetailSerializerValidation:
+    @pytest.mark.django_db
+    def test_duplicate_category_title_on_same_site_fails(self):
+        """
+        Verify CategoryDetailSerializer safely catches duplicate titles on the same site,
+        turning what used to be a database 500 integrity error into a clean 400 validation error.
+        """
+        unique_title = "UniqueTestCategoryXYZ"
+        site = factories.SiteFactory.create()
+        factories.CategoryFactory.create(title=unique_title, site=site)
+
+        duplicate_payload = {
+            "title": unique_title,
+            "description": "A different description, but a duplicated name!",
+        }
+        context = {"site": site}
+        serializer = CategoryDetailSerializer(data=duplicate_payload, context=context)
+
+        assert not serializer.is_valid()
+        assert serializer.errors == {
+            "title": ["This field must be unique within the site."]
+        }
+
+    @pytest.mark.django_db
+    def test_same_category_title_on_different_sites_succeeds(self):
+        """
+        Verify that having an identical category title across different sites is perfectly
+        legal and passes our site-scoped validation check successfully.
+        """
+        unique_title = "UniqueTestCategoryXYZ"
+        site_a = factories.SiteFactory.create()
+        factories.CategoryFactory.create(title=unique_title, site=site_a)
+
+        site_b = factories.SiteFactory.create()
+        cross_site_payload = {
+            "title": unique_title,
+        }
+        context = {"site": site_b}
+        serializer = CategoryDetailSerializer(data=cross_site_payload, context=context)
+
+        assert serializer.is_valid()


### PR DESCRIPTION
### Description of Changes
Please briefly explain the changes here.

Made updates on story_serializers, category_serializers to validate duplicate stories and category titles. 
Also made updates on unit tests. 

Not sure if I need to keep the unit tests as I have ran or need to remove them afterwards. 

### Checklist
- [ ] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- [ ] Admin Panel has been updated if models have been added or modified
- [ ] Migrations have been updated and committed if applicable
- [ ] Insomnia workspace has been updated if applicable
- [ ] Signal and Task inventories have been updated if applicable

### Reviewers Should Do The Following:
- [ ] Review the code changes here
- [x] Pull the branch and test locally

### Additional Notes
N/A
