### PR TITLE
FW-6075: Return 401 for unauthenticated users instead of 403

### DIFF
--- a/firstvoices/backend/tests/test_apis/base/base_media_test.py
+++ b/firstvoices/backend/tests/test_apis/base/base_media_test.py
@@ -729,7 +729,10 @@ class BaseMediaApiTest(
             content_type=self.content_type,
         )
 
-        assert response.status_code == 403
+        expected_status = (
+            401 if get_site_with_user == get_site_with_anonymous_user else 403
+        )
+        assert response.status_code == expected_status
 
     @pytest.mark.django_db
     @pytest.mark.parametrize("role", [Role.ASSISTANT, Role.EDITOR, Role.LANGUAGE_ADMIN])
@@ -774,7 +777,10 @@ class BaseMediaApiTest(
             data=self.format_upload_data(data),
             content_type=self.content_type,
         )
-        assert response.status_code == 403
+        expected_status = (
+            401 if get_site_with_user == get_site_with_anonymous_user else 403
+        )
+        assert response.status_code == expected_status
 
     def get_media_instance_that_has_usages(self, site, visibility=Visibility.PUBLIC):
         """Create a media instance and add that instance to 5 separate entries

--- a/firstvoices/backend/tests/test_apis/base/base_uncontrolled_site_api.py
+++ b/firstvoices/backend/tests/test_apis/base/base_uncontrolled_site_api.py
@@ -91,6 +91,17 @@ class SiteContentListApiTestMixin(SiteContentListEndpointMixin):
 
         assert response.status_code == 403
 
+    @pytest.mark.parametrize(
+        "visibility",
+        [Visibility.MEMBERS, Visibility.TEAM],
+    )
+    @pytest.mark.django_db
+    def test_list_401_when_site_not_visible_for_guest(self, visibility):
+        site = factories.SiteFactory.create(visibility=visibility)
+        response = self.client.get(self.get_list_endpoint(site_slug=site.slug))
+
+        assert response.status_code == 401
+
     @pytest.mark.django_db
     def test_list_empty(self):
         site = self.create_site_with_non_member(Visibility.PUBLIC)
@@ -257,6 +268,20 @@ class SiteContentDetailApiTestMixin(SiteContentDetailEndpointMixin):
         assert response.status_code == 403
 
     @pytest.mark.django_db
+    def test_detail_401_site_not_visible_for_guest(self):
+        site = factories.SiteFactory.create(visibility=Visibility.MEMBERS)
+
+        instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
+
+        response = self.client.get(
+            self.get_detail_endpoint(
+                key=self.get_lookup_key(instance), site_slug=site.slug
+            )
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.django_db
     def test_detail_minimal(self):
         site, _ = factories.get_site_with_app_admin(self.client, Visibility.PUBLIC)
         instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
@@ -322,7 +347,7 @@ class SiteContentDetailPermissionTestMixin:
             )
         )
 
-        assert response.status_code == 403
+        assert response.status_code == 401
 
     @pytest.mark.parametrize("role", [Role.ASSISTANT, Role.EDITOR, Role.LANGUAGE_ADMIN])
     @pytest.mark.django_db
@@ -384,6 +409,18 @@ class SiteContentCreateApiTestMixin:
         )
 
         assert response.status_code == 403
+
+    @pytest.mark.django_db
+    def test_create_private_site_401_unauthenticated(self):
+        site = factories.SiteFactory.create(visibility=Visibility.MEMBERS)
+
+        response = self.client.post(
+            self.get_list_endpoint(site_slug=site.slug),
+            data=self.format_upload_data(self.get_valid_data(site)),
+            content_type=self.content_type,
+        )
+
+        assert response.status_code == 401
 
     @pytest.mark.django_db
     def test_create_site_missing_404(self):
@@ -532,6 +569,21 @@ class SiteContentUpdateApiTestMixin:
         assert response.status_code == 403
 
     @pytest.mark.django_db
+    def test_update_401_unauthenticated(self):
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+        instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
+
+        response = self.client.put(
+            self.get_detail_endpoint(
+                key=self.get_lookup_key(instance), site_slug=site.slug
+            ),
+            data=self.format_upload_data(self.get_valid_data(site)),
+            content_type=self.content_type,
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.django_db
     def test_update_site_missing_404(self):
         site, _ = factories.get_site_with_app_admin(self.client, Visibility.PUBLIC)
         instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
@@ -678,6 +730,19 @@ class SiteContentDestroyApiTestMixin:
         assert response.status_code == 403
 
     @pytest.mark.django_db
+    def test_destroy_denied_401_unauthenticated(self):
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+        instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
+
+        response = self.client.delete(
+            self.get_detail_endpoint(
+                key=self.get_lookup_key(instance), site_slug=site.slug
+            )
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.django_db
     def test_destroy_missing_404(self):
         site, _ = factories.get_site_with_app_admin(self.client, Visibility.PUBLIC)
 
@@ -763,6 +828,21 @@ class SiteContentPatchApiTestMixin:
         )
 
         assert response.status_code == 403
+
+    @pytest.mark.django_db
+    def test_patch_401_unauthenticated(self):
+        site = factories.SiteFactory.create(visibility=Visibility.PUBLIC)
+        instance = self.create_minimal_instance(site=site, visibility=Visibility.PUBLIC)
+
+        response = self.client.patch(
+            self.get_detail_endpoint(
+                key=self.get_lookup_key(instance), site_slug=site.slug
+            ),
+            data=self.format_upload_data(self.get_valid_patch_data(site)),
+            content_type=self.content_type,
+        )
+
+        assert response.status_code == 401
 
     @pytest.mark.django_db
     def test_patch_site_missing_404(self):

--- a/firstvoices/backend/tests/test_apis/test_sites_api.py
+++ b/firstvoices/backend/tests/test_apis/test_sites_api.py
@@ -581,6 +581,16 @@ class TestSitesEndpoints(MediaTestMixin, ReadOnlyNonSiteApiTest):
         assert response.status_code == 403
 
     @pytest.mark.django_db
+    def test_detail_401_unauthenticated(self):
+        site, _user = factories.get_site_with_anonymous_user(
+            visibility=Visibility.MEMBERS
+        )
+
+        response = self.client.get(f"{self.get_detail_endpoint(site.slug)}")
+
+        assert response.status_code == 401
+
+    @pytest.mark.django_db
     def test_detail_404(self):
         user = factories.get_non_member_user()
         self.client.force_authenticate(user=user)
@@ -907,6 +917,20 @@ class TestSitesEndpoints(MediaTestMixin, ReadOnlyNonSiteApiTest):
         assert response.status_code == 403
 
     @pytest.mark.django_db
+    def test_detail_patch_401_unauthenticated(self):
+        site, _user = factories.get_site_with_anonymous_user(
+            visibility=Visibility.PUBLIC
+        )
+
+        response = self.client.patch(
+            f"{self.get_detail_endpoint(site.slug)}",
+            data=json.dumps(self.get_valid_patch_data(site)),
+            content_type=self.content_type,
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.django_db
     def test_patch_site_missing_404(self):
         user = factories.get_app_admin(AppRole.SUPERADMIN)
         self.client.force_authenticate(user=user)
@@ -984,6 +1008,15 @@ class TestSitesEndpoints(MediaTestMixin, ReadOnlyNonSiteApiTest):
         assert response.status_code == 403
 
     @pytest.mark.django_db
+    def test_hidden_site_detail_401_unauthenticated(self):
+        instance, _user = factories.get_site_with_anonymous_user()
+        instance.is_hidden = True
+        instance.save()
+
+        response = self.client.get(f"{self.get_detail_endpoint(instance.slug)}")
+        assert response.status_code == 401
+
+    @pytest.mark.django_db
     def test_hidden_site_detail_403_members(self):
         user = factories.get_non_member_user()
         instance = factories.SiteFactory.create(
@@ -994,6 +1027,15 @@ class TestSitesEndpoints(MediaTestMixin, ReadOnlyNonSiteApiTest):
 
         response = self.client.get(f"{self.get_detail_endpoint(instance.slug)}")
         assert response.status_code == 403
+
+    @pytest.mark.django_db
+    def test_hidden_site_detail_401_members_unauthenticated(self):
+        instance, _user = factories.get_site_with_anonymous_user()
+        instance.is_hidden = True
+        instance.save()
+
+        response = self.client.get(f"{self.get_detail_endpoint(instance.slug)}")
+        assert response.status_code == 401
 
     @pytest.mark.django_db
     @pytest.mark.parametrize("app_role", [AppRole.SUPERADMIN, AppRole.STAFF])

--- a/firstvoices/backend/tests/test_apis/test_storypage_api.py
+++ b/firstvoices/backend/tests/test_apis/test_storypage_api.py
@@ -24,7 +24,7 @@ class TestStoryPageEndpoint(RelatedMediaTestMixin, BaseControlledSiteContentApiT
     model = StoryPage
     model_factory = factories.StoryPageFactory
 
-    def get_list_endpoint(self, site_slug, story_id):
+    def get_list_endpoint(self, site_slug, story_id="123-fake-id"):
         # nested url needs both site and story
         url = reverse(
             self.API_LIST_VIEW, current_app=self.APP_NAME, args=[site_slug, story_id]

--- a/firstvoices/backend/views/base_views.py
+++ b/firstvoices/backend/views/base_views.py
@@ -1,6 +1,10 @@
 from django.core.exceptions import ImproperlyConfigured
 from django.http import Http404
-from rest_framework.exceptions import PermissionDenied, ValidationError
+from rest_framework.exceptions import (
+    NotAuthenticated,
+    PermissionDenied,
+    ValidationError,
+)
 from rest_framework.response import Response
 
 from backend.models import Alphabet, Character, CharacterVariant, IgnoredCharacter, Site
@@ -51,6 +55,11 @@ class FVPermissionViewSetMixin(ThrottlingMixin):
         "update": "change",
     }
 
+    def _deny_for_user_state(self):
+        if self.request.user.is_anonymous:
+            raise NotAuthenticated
+        raise PermissionDenied
+
     def initial(self, *args, **kwargs):
         """Ensures user has permission to perform the requested action."""
         super().initial(*args, **kwargs)
@@ -96,7 +105,7 @@ class FVPermissionViewSetMixin(ThrottlingMixin):
         # Finally, check permission
         perm = self.get_queryset().model.get_perm(perm_type)
         if not self.request.user.has_perm(perm, obj):
-            raise PermissionDenied
+            self._deny_for_user_state()
 
     def get_object_for_create_permission(self):
         """Subclasses can override to return an object to be used for checking create permissions"""

--- a/firstvoices/backend/views/base_views.py
+++ b/firstvoices/backend/views/base_views.py
@@ -13,6 +13,12 @@ from backend.permissions import utils
 from backend.views.utils import BurstRateThrottle, SustainedRateThrottle
 
 
+def raise_permission_denied_for_user(user):
+    if user.is_anonymous:
+        raise NotAuthenticated
+    raise PermissionDenied
+
+
 class ThrottlingMixin:
     """
     A mixin to provide request usage throttling for viewsets.
@@ -54,11 +60,6 @@ class FVPermissionViewSetMixin(ThrottlingMixin):
         "retrieve": "view",
         "update": "change",
     }
-
-    def _deny_for_user_state(self):
-        if self.request.user.is_anonymous:
-            raise NotAuthenticated
-        raise PermissionDenied
 
     def initial(self, *args, **kwargs):
         """Ensures user has permission to perform the requested action."""
@@ -105,7 +106,7 @@ class FVPermissionViewSetMixin(ThrottlingMixin):
         # Finally, check permission
         perm = self.get_queryset().model.get_perm(perm_type)
         if not self.request.user.has_perm(perm, obj):
-            self._deny_for_user_state()
+            raise_permission_denied_for_user(self.request.user)
 
     def get_object_for_create_permission(self):
         """Subclasses can override to return an object to be used for checking create permissions"""
@@ -178,7 +179,7 @@ class SiteContentViewSetMixin:
             self._cached_site = site
             return site
         else:
-            raise PermissionDenied
+            raise_permission_denied_for_user(self.request.user)
 
     def get_object_for_create_permission(self):
         """Check create permissions based on the relevant site"""

--- a/firstvoices/firstvoices/settings.py
+++ b/firstvoices/firstvoices/settings.py
@@ -98,10 +98,11 @@ REST_FRAMEWORK = {
         "djangorestframework_camel_case.render.CamelCaseJSONRenderer",
     ),
     "DEFAULT_AUTHENTICATION_CLASSES": [
-        # the first 2 are for admin app compatibility
+        # JWT must be first so DRF can return 401 for anonymous API requests.
+        # Session and basic auth remain available for admin compatibility.
+        "jwt_auth.authentication.JwtAuthentication",
         "rest_framework.authentication.SessionAuthentication",
         "rest_framework.authentication.BasicAuthentication",
-        "jwt_auth.authentication.JwtAuthentication",
     ],
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.AllowAny",),

--- a/firstvoices/firstvoices/settings_test.py
+++ b/firstvoices/firstvoices/settings_test.py
@@ -7,16 +7,6 @@ from .settings import *  # noqa
 # https://docs.djangoproject.com/en/dev/ref/settings/#test-runner
 TEST_RUNNER = "django.test.runner.DiscoverRunner"
 
-REST_FRAMEWORK.update(  # noqa F405
-    {
-        "DEFAULT_AUTHENTICATION_CLASSES": [
-            # remove jwt auth for the test runner
-            "rest_framework.authentication.SessionAuthentication",
-            "rest_framework.authentication.BasicAuthentication",
-        ],
-    }
-)
-
 # Disable AWS file storage during tests
 STORAGES = {
     "default": {

--- a/firstvoices/jwt_auth/authentication.py
+++ b/firstvoices/jwt_auth/authentication.py
@@ -4,7 +4,6 @@ import jwt
 import requests
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import AnonymousUser
 from django.db import IntegrityError
 from drf_spectacular.extensions import OpenApiAuthenticationExtension
 from drf_spectacular.plumbing import build_bearer_security_scheme_object
@@ -159,7 +158,7 @@ class JwtAuthentication(authentication.BaseAuthentication):
         auth_header = request.META.get("HTTP_AUTHORIZATION", None)
 
         if not auth_header:
-            return AnonymousUser(), None
+            return None
 
         bearer_token = extract_bearer_token(auth_header)
         signing_key = get_signing_key(bearer_token)
@@ -167,6 +166,9 @@ class JwtAuthentication(authentication.BaseAuthentication):
         user = get_or_create_user_for_token(user_token, auth_header)
 
         return user, None
+
+    def authenticate_header(self, request):
+        return 'Bearer realm="api"'
 
 
 class JWTScheme(OpenApiAuthenticationExtension):

--- a/firstvoices/jwt_auth/tests.py
+++ b/firstvoices/jwt_auth/tests.py
@@ -326,9 +326,7 @@ class TestAuthenticate:
         mock_request = MagicMock()
         type(mock_request).META = {}
         auth = JwtAuthentication()
-        user, _ = auth.authenticate(mock_request)
-        assert user.is_anonymous
-        assert not user.is_authenticated
+        assert auth.authenticate(mock_request) is None
 
     @pytest.mark.parametrize(
         "token", ["Bearer ", "NotBearer 12345", "12345", "Bearer 12345 and then some"]


### PR DESCRIPTION
### Description of Changes
- Updated authentication order, and added an authenticate_header method to return 401 when unauthenticated.

### Checklist
- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable
- ~Admin Panel has been updated if models have been added or modified~
- ~Migrations have been updated and committed if applicable~
- ~Insomnia workspace has been updated if applicable~
- ~Signal and Task inventories have been updated if applicable~

### Reviewers Should Do The Following:
- [x] Review the code changes here
- ~Pull the branch and test locally~

### Additional Notes
N/A
